### PR TITLE
feat: Add model label to RequestsTotal prometheus metric

### DIFF
--- a/examples/grafana.json
+++ b/examples/grafana.json
@@ -504,6 +504,67 @@
         },
         "overrides": []
       },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "id": 205,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (model) (rate(auto_ai_router_requests_total{instance=~\"$instance\",credential=~\"$credential\",model=~\"$model\"}[5m]))",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "RPS by Model",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
       "gridPos": { "h": 8, "w": 12, "x": 12, "y": 14 },
       "id": 204,
       "options": {
@@ -533,7 +594,7 @@
 
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 22 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 30 },
       "id": 300,
       "panels": [],
       "title": "Credentials",
@@ -574,7 +635,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 23 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
       "id": 301,
       "options": {
         "legend": {
@@ -635,7 +696,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 23 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
       "id": 302,
       "options": {
         "legend": {
@@ -696,7 +757,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 31 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 39 },
       "id": 303,
       "options": {
         "legend": {
@@ -782,7 +843,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 31 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 39 },
       "id": 304,
       "options": {
         "cellHeight": "sm",
@@ -870,7 +931,7 @@
 
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 39 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 47 },
       "id": 400,
       "panels": [],
       "title": "Models",
@@ -911,7 +972,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 40 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
       "id": 401,
       "options": {
         "legend": {
@@ -972,7 +1033,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 40 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
       "id": 402,
       "options": {
         "legend": {
@@ -1033,7 +1094,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 48 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 56 },
       "id": 403,
       "options": {
         "legend": {
@@ -1094,7 +1155,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 48 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 56 },
       "id": 404,
       "options": {
         "legend": {
@@ -1123,7 +1184,7 @@
 
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 56 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 64 },
       "id": 500,
       "panels": [],
       "title": "Bans & Selection",
@@ -1164,7 +1225,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 57 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 65 },
       "id": 501,
       "options": {
         "legend": {
@@ -1233,7 +1294,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 57 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 65 },
       "id": 502,
       "options": {
         "legend": {
@@ -1293,7 +1354,7 @@
           }
         ]
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 65 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 73 },
       "id": 503,
       "options": {
         "cellHeight": "sm",
@@ -1344,7 +1405,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 65 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 73 },
       "id": 504,
       "options": {
         "cellHeight": "sm",
@@ -1381,7 +1442,7 @@
 
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 73 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 81 },
       "id": 600,
       "panels": [],
       "title": "Latency",
@@ -1423,7 +1484,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 74 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 82 },
       "id": 601,
       "options": {
         "legend": {
@@ -1493,7 +1554,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 74 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 82 },
       "id": 602,
       "options": {
         "legend": {
@@ -1551,7 +1612,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 82 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 90 },
       "id": 603,
       "options": {
         "legend": {
@@ -1611,7 +1672,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 82 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 90 },
       "id": 604,
       "options": {
         "legend": {
@@ -1638,7 +1699,7 @@
 
     {
       "collapsed": true,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 90 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 98 },
       "id": 700,
       "panels": [
         {
@@ -1676,7 +1737,7 @@
             },
             "overrides": []
           },
-          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 91 },
+          "gridPos": { "h": 8, "w": 8, "x": 0, "y": 99 },
           "id": 701,
           "options": {
             "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -1728,7 +1789,7 @@
             },
             "overrides": []
           },
-          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 91 },
+          "gridPos": { "h": 8, "w": 8, "x": 8, "y": 99 },
           "id": 702,
           "options": {
             "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -1792,7 +1853,7 @@
             },
             "overrides": []
           },
-          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 91 },
+          "gridPos": { "h": 8, "w": 8, "x": 16, "y": 99 },
           "id": 703,
           "options": {
             "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
@@ -1815,7 +1876,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 91 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 99 },
       "id": 800,
       "panels": [],
       "title": "Token Usage",
@@ -1853,7 +1914,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 92 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 100 },
       "id": 801,
       "options": {
         "legend": {
@@ -1911,7 +1972,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 92 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 100 },
       "id": 802,
       "options": {
         "legend": {
@@ -1969,7 +2030,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 100 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 108 },
       "id": 803,
       "options": {
         "legend": {
@@ -2027,7 +2088,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 100 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 108 },
       "id": 804,
       "options": {
         "legend": {
@@ -2085,7 +2146,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 108 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 116 },
       "id": 805,
       "options": {
         "legend": {
@@ -2143,7 +2204,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 108 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 116 },
       "id": 806,
       "options": {
         "legend": {
@@ -2178,7 +2239,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 116 },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 124 },
       "id": 807,
       "options": {
         "colorMode": "value",
@@ -2210,7 +2271,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 116 },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 124 },
       "id": 808,
       "options": {
         "colorMode": "value",
@@ -2242,7 +2303,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 116 },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 124 },
       "id": 809,
       "options": {
         "colorMode": "value",
@@ -2274,7 +2335,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 116 },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 124 },
       "id": 810,
       "options": {
         "colorMode": "value",
@@ -2315,7 +2376,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 120 },
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 128 },
       "id": 811,
       "options": {
         "cellHeight": "sm",

--- a/internal/monitoring/metrics.go
+++ b/internal/monitoring/metrics.go
@@ -14,7 +14,7 @@ var (
 			Name: "auto_ai_router_requests_total",
 			Help: "Total number of requests",
 		},
-		[]string{"credential", "endpoint", "status"},
+		[]string{"credential", "model", "endpoint", "status"},
 	)
 
 	RequestDuration = promauto.NewHistogramVec(
@@ -177,13 +177,13 @@ func (m *Metrics) updateModelMetric(gauge *prometheus.GaugeVec, credential, mode
 	gauge.WithLabelValues(credential, model).Set(float64(value))
 }
 
-func (m *Metrics) RecordRequest(credential, endpoint string, statusCode int, duration time.Duration) {
+func (m *Metrics) RecordRequest(credential, endpoint, model string, statusCode int, duration time.Duration) {
 	if !m.isEnabled() {
 		return
 	}
 
 	status := strconv.Itoa(statusCode)
-	RequestsTotal.WithLabelValues(credential, endpoint, status).Inc()
+	RequestsTotal.WithLabelValues(credential, model, endpoint, status).Inc()
 	RequestDuration.WithLabelValues(credential, endpoint).Observe(duration.Seconds())
 
 	if statusCode != 200 {

--- a/internal/monitoring/metrics_test.go
+++ b/internal/monitoring/metrics_test.go
@@ -65,7 +65,7 @@ func TestRecordRequest_DifferentStatusCodes(t *testing.T) {
 	// Record requests with different status codes
 	statusCodes := []int{200, 201, 400, 401, 403, 429, 500, 502, 503}
 	for _, code := range statusCodes {
-		m.RecordRequest("cred1", "/v1/test", code, 50*time.Millisecond)
+		m.RecordRequest("cred1", "/v1/test", "test-model", code, 50*time.Millisecond)
 	}
 
 	// Verify metrics were collected

--- a/internal/monitoring/metrics_test.go
+++ b/internal/monitoring/metrics_test.go
@@ -28,14 +28,14 @@ func TestRecordRequest_Enabled(t *testing.T) {
 	m := New(true)
 
 	// Record a successful request
-	m.RecordRequest("cred1", "/v1/chat/completions", 200, 100*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 200, 100*time.Millisecond)
 
 	// Verify RequestsTotal metric
 	count := testutil.CollectAndCount(RequestsTotal)
 	assert.Greater(t, count, 0)
 
 	// Record an error request
-	m.RecordRequest("cred1", "/v1/chat/completions", 500, 150*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 500, 150*time.Millisecond)
 
 	// Verify CredentialErrorsTotal metric was incremented
 	count = testutil.CollectAndCount(CredentialErrorsTotal)
@@ -48,8 +48,8 @@ func TestRecordRequest_Disabled(t *testing.T) {
 	m := New(false)
 
 	// Record requests when disabled
-	m.RecordRequest("cred1", "/v1/chat/completions", 200, 100*time.Millisecond)
-	m.RecordRequest("cred1", "/v1/chat/completions", 500, 150*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 200, 100*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 500, 150*time.Millisecond)
 
 	// Metrics should not be recorded when disabled
 	// (They actually will be because metrics are global, but the method should return early)
@@ -79,9 +79,9 @@ func TestRecordRequest_MultipleCredentials(t *testing.T) {
 	m := New(true)
 
 	// Record requests for different credentials
-	m.RecordRequest("cred1", "/v1/chat/completions", 200, 100*time.Millisecond)
-	m.RecordRequest("cred2", "/v1/chat/completions", 200, 150*time.Millisecond)
-	m.RecordRequest("cred3", "/v1/embeddings", 200, 80*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 200, 100*time.Millisecond)
+	m.RecordRequest("cred2", "/v1/chat/completions", "test-model", 200, 150*time.Millisecond)
+	m.RecordRequest("cred3", "/v1/embeddings", "test-model", 200, 80*time.Millisecond)
 
 	// Verify metrics were collected
 	count := testutil.CollectAndCount(RequestsTotal)
@@ -145,12 +145,12 @@ func TestMetrics_Integration(t *testing.T) {
 	m := New(true)
 
 	// Simulate a series of requests
-	m.RecordRequest("cred1", "/v1/chat/completions", 200, 100*time.Millisecond)
-	m.RecordRequest("cred1", "/v1/chat/completions", 200, 120*time.Millisecond)
-	m.RecordRequest("cred1", "/v1/chat/completions", 500, 150*time.Millisecond) // Error
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 200, 100*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 200, 120*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 500, 150*time.Millisecond) // Error
 
-	m.RecordRequest("cred2", "/v1/embeddings", 200, 80*time.Millisecond)
-	m.RecordRequest("cred2", "/v1/embeddings", 429, 90*time.Millisecond) // Rate limit error
+	m.RecordRequest("cred2", "/v1/embeddings", "test-model", 200, 80*time.Millisecond)
+	m.RecordRequest("cred2", "/v1/embeddings", "test-model", 429, 90*time.Millisecond) // Rate limit error
 
 	// Update RPM metrics
 	m.UpdateCredentialRPM("cred1", 3)
@@ -189,13 +189,13 @@ func TestRecordRequest_ErrorIncrementsCounter(t *testing.T) {
 	m := New(true)
 
 	// Record successful request (200)
-	m.RecordRequest("cred1", "/v1/test", 200, 50*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/test", "test-model", 200, 50*time.Millisecond)
 
 	// Get initial error count (should be 0)
 	initialErrors := testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1"))
 
 	// Record error request
-	m.RecordRequest("cred1", "/v1/test", 500, 50*time.Millisecond)
+	m.RecordRequest("cred1", "/v1/test", "test-model", 500, 50*time.Millisecond)
 
 	// Error count should increase
 	finalErrors := testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1"))
@@ -231,7 +231,7 @@ func TestMultipleEndpoints(t *testing.T) {
 	}
 
 	for _, endpoint := range endpoints {
-		m.RecordRequest("cred1", endpoint, 200, 100*time.Millisecond)
+		m.RecordRequest("cred1", endpoint, "test-model", 200, 100*time.Millisecond)
 	}
 
 	// All endpoints should be tracked separately

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -288,12 +288,12 @@ func (p *Proxy) executeProxyRequest(
 			)
 		}
 		p.balancer.RecordResponse(cred.Name, modelID, statusCode)
-		p.metrics.RecordRequest(cred.Name, r.URL.Path, statusCode, time.Since(start))
+		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, statusCode, time.Since(start))
 		return nil, err
 	}
 	// Record response
 	p.balancer.RecordResponse(cred.Name, modelID, resp.StatusCode)
-	p.metrics.RecordRequest(cred.Name, r.URL.Path, resp.StatusCode, time.Since(start))
+	p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
 
 	p.logger.Debug("Proxy request forwarded",
 		"credential", cred.Name,
@@ -853,7 +853,7 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 				shouldRetry = true
 				retryReason = RetryReasonAuthErr
 				p.balancer.RecordResponse(cred.Name, modelID, http.StatusInternalServerError)
-				p.metrics.RecordRequest(cred.Name, r.URL.Path, http.StatusInternalServerError, time.Since(start))
+				p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, http.StatusInternalServerError, time.Since(start))
 				continue
 			}
 		}
@@ -930,7 +930,7 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 					"credential", cred.Name, "error", doErr, "url", targetURL)
 			}
 			p.balancer.RecordResponse(cred.Name, modelID, statusCode)
-			p.metrics.RecordRequest(cred.Name, r.URL.Path, statusCode, time.Since(start))
+			p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, statusCode, time.Since(start))
 			shouldRetry = true
 			retryReason = RetryReasonNetErr
 			transportErr = doErr
@@ -948,7 +948,7 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 
 		p.balancer.RecordResponse(cred.Name, modelID, resp.StatusCode)
-		p.metrics.RecordRequest(cred.Name, r.URL.Path, resp.StatusCode, time.Since(start))
+		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
 
 		// Debug: log response headers
 		maskedRespHeaders := security.MaskSensitiveHeaders(resp.Header)


### PR DESCRIPTION
### What does this PR do?
This PR adds the missing `model` label to the `auto_ai_router_requests_total` Prometheus metric. 
### Why is this necessary?
Previously, the `RequestsTotal` metric only recorded `credential`, `endpoint`, and `status`. Because of this, it was impossible to track the number of total and successful requests on a per-model basis (e.g., distinguishing requests between `claude-opus` and `claude-sonnet`) in Grafana or custom billing dashboards. 
### Changes:
- **`internal/monitoring/metrics.go`**: Added `"model"` to `RequestsTotal` labels and updated the `RecordRequest` function signature to accept a `model` string.
- **`internal/proxy/proxy.go`**: Updated all `p.metrics.RecordRequest` calls to pass the `modelID` extracted during the proxy flow.
- **`internal/monitoring/metrics_test.go`**: Updated all tests to match the new `RecordRequest` signature.