### PR TITLE
Nlebedev/fallback fix

### DIFF
--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -146,6 +146,13 @@ func (r *RoundRobin) NextFallbackProxyForModel(modelID string) (*config.Credenti
 	return r.next(modelID, true, true)
 }
 
+// NextFallbackProxyForModelExcluding returns the next available fallback proxy credential,
+// skipping credentials in the exclude set. Used by TryFallbackProxy to avoid re-trying
+// a fallback that was already attempted in the current request chain.
+func (r *RoundRobin) NextFallbackProxyForModelExcluding(modelID string, exclude map[string]bool) (*config.CredentialConfig, error) {
+	return r.nextExcluding(modelID, true, true, "", exclude)
+}
+
 // NextSpecific tries to return a specific credential by name without advancing the
 // round-robin state. It still applies model availability, ban, and rate-limit checks.
 func (r *RoundRobin) NextSpecific(credentialName, modelID string) (*config.CredentialConfig, error) {

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -1168,13 +1168,20 @@ func (m *Manager) GetRemoteModelsWithError(ctx context.Context, cred *config.Cre
 	)
 
 	models, err := m.fetchRemoteModelsFromHealth(ctx, cred)
-	if err != nil {
-		m.logger.Debug("Failed to fetch remote models from proxy health; falling back to /v1/models",
-			"credential", cred.Name,
-			"error", err,
-		)
+	if err != nil || len(models) == 0 {
+		if err != nil {
+			m.logger.Debug("Failed to fetch remote models from proxy health; falling back to /v1/models",
+				"credential", cred.Name,
+				"error", err,
+			)
+		} else {
+			m.logger.Debug("Health-based model fetch returned empty list; falling back to /v1/models",
+				"credential", cred.Name,
+			)
+		}
 
-		// Fallback for non-AAR proxies that expose /v1/models but not /health.
+		// Fallback for non-AAR proxies that expose /v1/models but not /health,
+		// or for AAR proxies where the health-based IsFallback filter removed all models.
 		var modelsResp ModelsResponse
 		if err := httputil.FetchJSONFromProxy(ctx, cred, "/v1/models", m.logger, &modelsResp); err != nil {
 			m.logger.Error("Failed to fetch remote models",
@@ -1219,7 +1226,11 @@ func (m *Manager) fetchRemoteModelsFromHealth(ctx context.Context, cred *config.
 		if !ok {
 			continue
 		}
-		if credStats.IsFallback != cred.IsFallback {
+		// For a non-fallback connection: skip upstream credentials marked as fallback
+		// (they are reserved for fallback traffic and must not serve primary requests).
+		// For a fallback connection: include ALL upstream credentials regardless of their
+		// fallback status — use whatever the upstream can offer as a last resort.
+		if !cred.IsFallback && credStats.IsFallback {
 			continue
 		}
 		if modelStats.Model == "" {

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -153,6 +153,7 @@ type Manager struct {
 	dbModelNames              map[string]bool          // model names that were loaded from LiteLLM DB (for hot-reload diffing)
 	modelAliases              map[string]string        // alias -> real model name (from model_alias config)
 	modelRealNames            map[string]string        // alias name -> real model name (from models[].model field)
+	knownProxyCredentials     map[string]bool          // set of proxy-type credential names (populated by LoadModelsFromConfig/UpdateDBModels)
 	defaultModelsRPM          int                      // default RPM for models
 	logger                    *slog.Logger
 	credentials               []config.CredentialConfig   // credentials for fetching remote models
@@ -174,6 +175,7 @@ func New(logger *slog.Logger, defaultModelsRPM int, staticModels []config.ModelR
 		modelAliases:              make(map[string]string),
 		modelRealNames:            make(map[string]string),
 		modelPassthroughResponses: make(map[string]*bool),
+		knownProxyCredentials:     make(map[string]bool),
 		defaultModelsRPM:          defaultModelsRPM,
 		logger:                    logger,
 		credentials:               make([]config.CredentialConfig, 0),
@@ -446,8 +448,12 @@ func (m *Manager) LoadModelsFromConfig(credentials []config.CredentialConfig) {
 	// that fallback is intentional for proxy credentials whose model list is fetched dynamically,
 	// but it incorrectly allows non-proxy credentials (e.g. openai_backup with no models:)
 	// to match any model when static models are configured for other credentials.
+	//
+	// Also populate knownProxyCredentials so HasModel can distinguish "proxy not yet fetched"
+	// from "unknown credential", allowing the proxy optimistic-allow to work correctly.
 	for _, cred := range credentials {
 		if cred.Type == config.ProviderTypeProxy {
+			m.knownProxyCredentials[cred.Name] = true
 			continue // proxy models are fetched dynamically via GetAllModels
 		}
 		if _, exists := m.credentialModels[cred.Name]; !exists {
@@ -571,8 +577,10 @@ func (m *Manager) UpdateDBModels(dbModels []config.ModelRPMConfig, staticCreds [
 	}
 
 	// Register non-proxy credentials with no models — same logic as in LoadModelsFromConfig.
+	// Also track proxy credential names for HasModel's optimistic-allow logic.
 	for _, c := range allCreds {
 		if c.Type == config.ProviderTypeProxy {
+			m.knownProxyCredentials[c.Name] = true
 			continue
 		}
 		if _, exists := newCredentialModels[c.Name]; !exists {
@@ -806,7 +814,20 @@ func (m *Manager) HasModel(credentialName, modelID string) bool {
 		return true
 	}
 	if modelExists {
-		// Model exists but not for this credential
+		// Model is registered for other credentials but not for this one.
+		// Before denying: check whether this is a known proxy credential whose model list
+		// has not yet been fetched (i.e. has no entry in credentialModels yet).
+		// Proxy credentials are populated dynamically by UpdateAllProxyCredentials;
+		// if the entry is absent it means the first model fetch hasn't completed yet
+		// (e.g. the proxy was unreachable at startup). Allow optimistically so that
+		// the request is forwarded and the downstream proxy can handle routing.
+		// Once AddModel() has been called at least once, credentialModels will have an
+		// entry and this early-allow is no longer triggered.
+		if m.knownProxyCredentials[credentialName] {
+			if _, credFetched := m.credentialModels[credentialName]; !credFetched {
+				return true
+			}
+		}
 		return false
 	}
 

--- a/internal/models/manager_remote_test.go
+++ b/internal/models/manager_remote_test.go
@@ -241,7 +241,9 @@ func TestGetRemoteModelsWithError_FiltersRemoteHealthByFallbackParity(t *testing
 		IsFallback: true,
 	})
 	require.NoError(t, err)
-	assert.Equal(t, []string{"fallback-only", "shared-model"}, modelIDs(fallbackModels))
+	// Fallback gateway includes ALL upstream credentials (both primary and fallback),
+	// so it sees all models: primary-only, fallback-only, and shared-model (deduplicated).
+	assert.ElementsMatch(t, []string{"fallback-only", "primary-only", "shared-model"}, modelIDs(fallbackModels))
 }
 
 func TestGetRemoteModelsWithError_FallsBackToV1ModelsWhenHealthUnavailable(t *testing.T) {

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -132,6 +132,43 @@ func TestHasModel(t *testing.T) {
 	assert.True(t, manager.HasModel("non-existing", "some-unknown-model"))
 }
 
+func TestHasModel_ProxyCredentialOptimisticAllow(t *testing.T) {
+	// When a proxy credential is registered but its model list has not yet been fetched
+	// (AddModel was never called for it), HasModel should return true (allow optimistically).
+	// This prevents the fallback proxy from being rejected at startup when the model updater
+	// hasn't run yet but other credentials already have models registered.
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	staticModels := []config.ModelRPMConfig{
+		{Name: "gpt-4", RPM: 100, Credential: "primary"},
+	}
+	manager := New(logger, 100, staticModels)
+
+	credentials := []config.CredentialConfig{
+		{Name: "primary", Type: config.ProviderTypeOpenAI},
+		{Name: "fallback-proxy", Type: config.ProviderTypeProxy, IsFallback: true},
+	}
+	manager.LoadModelsFromConfig(credentials)
+
+	// Primary has the model registered
+	assert.True(t, manager.HasModel("primary", "gpt-4"))
+
+	// Fallback proxy: no models fetched yet (AddModel never called) → allow optimistically
+	assert.True(t, manager.HasModel("fallback-proxy", "gpt-4"),
+		"Proxy credential with no fetched models should be allowed optimistically")
+
+	// After models are fetched for the fallback proxy, the exact list is used
+	manager.AddModel("fallback-proxy", "gpt-4")
+	assert.True(t, manager.HasModel("fallback-proxy", "gpt-4"),
+		"Proxy with gpt-4 registered should be allowed")
+	assert.False(t, manager.HasModel("fallback-proxy", "claude-3"),
+		"Proxy with gpt-4 registered should deny claude-3 (not in its model list)")
+
+	// Non-existing (unknown) credential still gets denied when model exists for known creds
+	assert.False(t, manager.HasModel("unknown-cred", "gpt-4"),
+		"Completely unknown credential should be denied when model exists for known credentials")
+}
+
 func TestHasModel_NoStaticModels(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	manager := New(logger, 100, []config.ModelRPMConfig{})

--- a/internal/proxy/proxy_try_fallback_test.go
+++ b/internal/proxy/proxy_try_fallback_test.go
@@ -97,16 +97,19 @@ func TestTryFallbackProxy_NoFallback(t *testing.T) {
 		"Response body length should be 0 when no fallback available")
 }
 
-// TestTryFallbackProxy_SameCredential tests the scenario where the fallback credential
+// TestTryFallbackProxy_SameCredential tests the scenario where the only fallback credential
 // has the same name as the original credential (circular reference protection).
 //
 // Test Case B: Fallback credential is same as original
-// - Balancer returns a fallback credential with the same Name as originalCredName
-// - Function should return (false, "fallback_is_same_credential") immediately
+// - The original credential is pre-emptively excluded from the fallback candidate pool
+// - NextFallbackProxyForModelExcluding finds no remaining candidates
+// - Function should return (false, "no_fallback_available") immediately
 // - Function should NOT attempt to forward the request to avoid infinite loops
 //
-// This test validates that TryFallbackProxy includes safety checks to prevent
-// retrying with the same credential, which could cause infinite recursion or loops.
+// This test validates that TryFallbackProxy pre-emptively excludes the original credential
+// from the fallback candidate pool, preventing circular retries.
+// Previously the function would return "fallback_is_same_credential" after finding the candidate;
+// now the candidate is never found because it is excluded up front.
 func TestTryFallbackProxy_SameCredential(t *testing.T) {
 	// Build proxy with single credential marked as both primary and fallback (edge case)
 	prx := NewTestProxyBuilder().
@@ -170,9 +173,10 @@ func TestTryFallbackProxy_SameCredential(t *testing.T) {
 	assert.False(t, success,
 		"TryFallbackProxy should return success=false when fallback is same credential")
 
-	// ✓ Assert: Reason should indicate fallback is the same credential
-	assert.Equal(t, "fallback_is_same_credential", reason,
-		"Should return reason='fallback_is_same_credential' when names match")
+	// ✓ Assert: Reason should indicate no fallback available
+	// (original credential is excluded from the candidate pool, leaving no candidates)
+	assert.Equal(t, "no_fallback_available", reason,
+		"Should return reason='no_fallback_available' when original credential is the only fallback")
 
 	// ✓ Assert: Response writer should be empty (request was never forwarded)
 	// Since the function detected the same credential, it returns early without

--- a/internal/proxy/remote.go
+++ b/internal/proxy/remote.go
@@ -129,7 +129,7 @@ func updateCredentialLimits(
 	aggregation := newSumLimitAggregation()
 
 	for _, credStats := range health.Credentials {
-		if credStats.IsFallback != cred.IsFallback {
+		if !cred.IsFallback && credStats.IsFallback {
 			continue
 		}
 		aggregation.applySum(
@@ -186,7 +186,7 @@ func updateModelLimits(
 		if !ok {
 			continue
 		}
-		if credStats.IsFallback != cred.IsFallback {
+		if !cred.IsFallback && credStats.IsFallback {
 			continue
 		}
 		modelID := modelStats_data.Model

--- a/internal/proxy/remote_test.go
+++ b/internal/proxy/remote_test.go
@@ -523,12 +523,15 @@ func TestUpdateStatsFromHealth_FiltersByFallbackParity_Fallback(t *testing.T) {
 		IsFallback: true,
 	}, rateLimiter, logger, mockMM)
 
-	assert.Equal(t, 500, rateLimiter.GetLimitRPM("proxy-fallback"))
-	assert.Equal(t, 5000, rateLimiter.GetLimitTPM("proxy-fallback"))
+	// Fallback gateway includes ALL upstream credentials (primary + fallback),
+	// so limits are the SUM of both: RPM=100+500=600, TPM=1000+5000=6000.
+	assert.Equal(t, 600, rateLimiter.GetLimitRPM("proxy-fallback"))
+	assert.Equal(t, 6000, rateLimiter.GetLimitTPM("proxy-fallback"))
 	assert.Equal(t, 80, rateLimiter.GetModelLimitRPM("proxy-fallback", "fallback-model"))
-	assert.Equal(t, -1, rateLimiter.GetModelLimitRPM("proxy-fallback", "primary-model"))
+	assert.Equal(t, 20, rateLimiter.GetModelLimitRPM("proxy-fallback", "primary-model"))
 
 	addedModels := mockMM.GetAddedModels()
-	assert.Len(t, addedModels, 1)
-	assert.Equal(t, "fallback-model", addedModels[0].model)
+	assert.Len(t, addedModels, 2)
+	addedModelIDs := []string{addedModels[0].model, addedModels[1].model}
+	assert.ElementsMatch(t, []string{"primary-model", "fallback-model"}, addedModelIDs)
 }

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -144,17 +144,28 @@ func (p *Proxy) TryFallbackProxy(
 		return false, "max_retry_attempts_exceeded"
 	}
 
-	// Get set of already-tried credentials from context
+	// Get set of already-tried credentials from context.
+	// Pass this as the exclude set so NextFallbackProxyForModelExcluding skips any
+	// fallback that was already attempted (prevents circular retries like A→B→A).
 	triedCreds := GetTried(ctx)
 
-	// Try to find a fallback proxy credential
-	fallbackCred, err := p.balancer.NextFallbackProxyForModel(modelID)
+	// Also exclude the original credential by name so we never send back to the
+	// credential that just failed, even if it happens to be marked as fallback.
+	excludeSet := make(map[string]bool, len(triedCreds)+1)
+	for k, v := range triedCreds {
+		excludeSet[k] = v
+	}
+	excludeSet[originalCredName] = true
+
+	// Try to find a fallback proxy credential, excluding already-tried ones.
+	fallbackCred, err := p.balancer.NextFallbackProxyForModelExcluding(modelID, excludeSet)
 	if err != nil {
 		p.logger.Debug("No fallback proxy available for retry",
 			"original_credential", originalCredName,
 			"model", modelID,
 			"original_status", originalStatus,
 			"reason", originalReason,
+			"tried", formatTriedCreds(triedCreds),
 		)
 		return false, "no_fallback_available"
 	}
@@ -166,25 +177,6 @@ func (p *Proxy) TryFallbackProxy(
 			"original_credential", originalCredName,
 		)
 		return false, "no_fallback_available"
-	}
-
-	// Safety check: don't retry with the same credential
-	if fallbackCred.Name == originalCredName {
-		p.logger.Warn("Fallback credential is the same as original, skipping retry",
-			"credential", fallbackCred.Name,
-			"model", modelID,
-		)
-		return false, "fallback_is_same_credential"
-	}
-
-	// Check if fallback credential has already been tried in this request chain
-	if triedCreds[fallbackCred.Name] {
-		p.logger.Warn("Fallback credential already attempted, skipping to prevent circular retry",
-			"fallback_credential", fallbackCred.Name,
-			"tried_credentials", formatTriedCreds(triedCreds),
-			"model", modelID,
-		)
-		return false, "credential_already_tried"
 	}
 
 	p.logger.Info("Retrying request on fallback proxy",

--- a/internal/proxy/retry_test.go
+++ b/internal/proxy/retry_test.go
@@ -461,6 +461,8 @@ func TestTryFallbackProxy_SameCredentialAsOriginal(t *testing.T) {
 	)
 
 	// Assertions
+	// The original credential is pre-emptively excluded from the fallback candidate pool,
+	// so NextFallbackProxyForModelExcluding finds no candidates — returns "no_fallback_available".
 	assert.False(t, success, "TryFallbackProxy should return success=false when fallback is same credential")
-	assert.Equal(t, "fallback_is_same_credential", reason, "Should return fallback_is_same_credential reason")
+	assert.Equal(t, "no_fallback_available", reason, "Should return no_fallback_available when original credential is the only fallback")
 }

--- a/internal/proxy/webui/trace.html
+++ b/internal/proxy/webui/trace.html
@@ -100,7 +100,7 @@
           background: dark ? '#131517' : '#f4f4f2',
           fontSize: '14px',
         },
-        flowchart: { htmlLabels: true, curve: 'basis', nodeSpacing: 30, rankSpacing: 40 },
+        flowchart: { htmlLabels: true, curve: 'basis', nodeSpacing: 60, rankSpacing: 80 },
       };
     }
 
@@ -273,8 +273,10 @@
         if (svgEl && svgEl.getAttribute('viewBox')) {
           svgEl.removeAttribute('width');
           svgEl.removeAttribute('height');
-          svgEl.style.width = '100%';
+          svgEl.style.maxWidth = '100%';
           svgEl.style.height = 'auto';
+          svgEl.style.display = 'block';
+          svgEl.style.margin = '0 auto';
         }
       } catch (e) {
         wrap.innerHTML = `<pre style="color:var(--status-err);font-size:var(--fs-xs);text-align:left;">${esc(e.message)}\n\n${esc(diagram)}</pre>`;


### PR DESCRIPTION
HasModel ранний отказ для незагруженного прокси
  Файл: internal/models/manager.go
  Когда модель была зарегистрирована для primary (modelToCredentials["gpt-4"] = ["primary"]), но fallback прокси ещё не успел подгрузить свой список моделей (AddModel не вызывался) — HasModel("fallback", "gpt-4") возвращал false немедленно, даже не проверяя был ли этот credential когда-либо инициализирован.
  Фикс: Добавлено поле knownProxyCredentials в Manager. Если credential — известный прокси, но у него ещё нет записи в credentialModels (модели не подгружены), разрешаем оптимистично. Как только AddModel вызывается хотя бы раз — начинает работать точная фильтрация.                                            
                                                                                                                                                                                                                                                                                                                       TryFallbackProxy не пробует следующий fallback при конфликте                                                                                                                                                                                                                                               
  Файл: internal/proxy/retry.go + internal/balancer/roundrobin.go
  Если round-robin выбирал fallback кандидата который уже в triedCreds, функция сдавалась вместо того чтобы попробовать следующего кандидата. Также originalCredName не исключался из пула явно — была только ручная проверка после выбора.
  Фикс: Добавлен NextFallbackProxyForModelExcluding в балансере. TryFallbackProxy теперь передаёт triedCreds + originalCredName как exclude set — балансер сразу пропускает все уже попробованные кандидаты и возвращает следующего пригодного.  