### PR TITLE
fix: extract correct completion tokens in streaming and prevent overwriting with total tokens

### DIFF
--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -388,10 +388,22 @@ func (p *Proxy) handleTransformedStreaming(
 			logger:          p.logger,
 			onChunk: func(chunk []byte) {
 				chunkCount++
-				// Store each chunk, keeping only the last one
-				// This allows us to extract usage info that typically appears in final chunks
-				lastChunk = make([]byte, len(chunk))
-				copy(lastChunk, chunk)
+
+				if logCtx != nil {
+					if usage := extractTokenUsageFromStreamingChunk(string(chunk)); usage != nil {
+						if logCtx.TokenUsage == nil {
+							logCtx.TokenUsage = &converter.TokenUsage{}
+						}
+						*logCtx.TokenUsage = *usage
+					}
+				}
+
+				// Store each chunk, keeping only the last one that contains actual data and isn't [DONE]
+				trimmed := strings.TrimSpace(string(chunk))
+				if trimmed != "" && trimmed != "data: [DONE]" && trimmed != "[DONE]" {
+					lastChunk = make([]byte, len(chunk))
+					copy(lastChunk, chunk)
+				}
 			},
 		})
 		if err != nil {
@@ -462,18 +474,25 @@ func (p *Proxy) handleStreamingWithTokens(w http.ResponseWriter, resp *http.Resp
 
 	onChunk := func(chunk []byte) {
 		chunkCount++
+
+		if logCtx != nil {
+			if usage := extractTokenUsageFromStreamingChunk(string(chunk)); usage != nil {
+				if logCtx.TokenUsage == nil {
+					logCtx.TokenUsage = &converter.TokenUsage{}
+				}
+				*logCtx.TokenUsage = *usage
+			}
+		}
+
 		tokens := extractTokensFromStreamingChunk(string(chunk))
 		if tokens > 0 {
 			totalTokens += tokens
 		}
 		completionChars += extractCompletionDeltaChars(chunk)
 
-		// Don't let a bare [DONE] sentinel overwrite a lastChunk that carries usage
-		// data — when drain reads usage and [DONE] as separate buffer reads, the
-		// [DONE] chunk would otherwise obscure the usage, and ExtractUsage would
-		// return nil, falling back to the less-precise total_tokens value.
-		chunkStr := strings.TrimSpace(string(chunk))
-		if chunkStr != "data: [DONE]" {
+		// Don't let a bare [DONE] sentinel or empty chunks overwrite a lastChunk that carries usage data.
+		trimmed := strings.TrimSpace(string(chunk))
+		if trimmed != "" && trimmed != "data: [DONE]" && trimmed != "[DONE]" {
 			lastChunk = make([]byte, len(chunk))
 			copy(lastChunk, chunk)
 		}
@@ -536,8 +555,8 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 		logCtx.TokenUsage = &converter.TokenUsage{}
 	}
 
-	logCtx.TokenUsage.PromptTokens = logCtx.PromptTokensEstimate
-	logCtx.TokenUsage.CompletionTokens = totalTokens
+	fallbackPrompt := logCtx.PromptTokensEstimate
+	fallbackCompletion := totalTokens
 
 	if len(lastChunk) > 0 {
 		extractor := getStreamUsageExtractor(providerName)
@@ -549,11 +568,21 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 				logCtx.TokenUsage.CompletionTokens = usageInfo.CompletionTokens
 			}
 
-			logCtx.TokenUsage.CachedInputTokens = usageInfo.CachedTokens
-			logCtx.TokenUsage.AudioInputTokens = usageInfo.AudioInputTokens
-			logCtx.TokenUsage.AudioOutputTokens = usageInfo.AudioOutputTokens
-			logCtx.TokenUsage.ImageTokens = usageInfo.ImageTokens
-			logCtx.TokenUsage.ReasoningTokens = usageInfo.ReasoningTokens
+			if usageInfo.CachedTokens > 0 {
+				logCtx.TokenUsage.CachedInputTokens = usageInfo.CachedTokens
+			}
+			if usageInfo.AudioInputTokens > 0 {
+				logCtx.TokenUsage.AudioInputTokens = usageInfo.AudioInputTokens
+			}
+			if usageInfo.AudioOutputTokens > 0 {
+				logCtx.TokenUsage.AudioOutputTokens = usageInfo.AudioOutputTokens
+			}
+			if usageInfo.ImageTokens > 0 {
+				logCtx.TokenUsage.ImageTokens = usageInfo.ImageTokens
+			}
+			if usageInfo.ReasoningTokens > 0 {
+				logCtx.TokenUsage.ReasoningTokens = usageInfo.ReasoningTokens
+			}
 
 			if usageInfo.CacheCreationTokens > 0 {
 				logCtx.TokenUsage.CacheCreationTokens = usageInfo.CacheCreationTokens
@@ -570,6 +599,13 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 				"reasoning_tokens", usageInfo.ReasoningTokens,
 			)
 		}
+	}
+
+	if logCtx.TokenUsage.PromptTokens == 0 {
+		logCtx.TokenUsage.PromptTokens = fallbackPrompt
+	}
+	if logCtx.TokenUsage.CompletionTokens == 0 {
+		logCtx.TokenUsage.CompletionTokens = fallbackCompletion
 	}
 
 	logCtx.HTTPStatus = statusCode
@@ -939,6 +975,17 @@ func (p *Proxy) handlePassthroughResponsesStreaming(
 			if json.Unmarshal([]byte(jsonData), &event) == nil && event.Type == "response.completed" {
 				if event.Response.Usage != nil {
 					totalTokens = event.Response.Usage.TotalTokens
+					if logCtx != nil {
+						if logCtx.TokenUsage == nil {
+							logCtx.TokenUsage = &converter.TokenUsage{}
+						}
+						logCtx.TokenUsage.PromptTokens = event.Response.Usage.InputTokens
+						logCtx.TokenUsage.CompletionTokens = event.Response.Usage.OutputTokens
+						logCtx.TokenUsage.CachedInputTokens = event.Response.Usage.InputTokensDetails.CachedTokens
+						logCtx.TokenUsage.AudioInputTokens = event.Response.Usage.InputTokensDetails.AudioTokens
+						logCtx.TokenUsage.AudioOutputTokens = event.Response.Usage.OutputTokensDetails.AudioTokens
+						logCtx.TokenUsage.ReasoningTokens = event.Response.Usage.OutputTokensDetails.ReasoningTokens
+					}
 				}
 				completedData = []byte(jsonData) // plain JSON; extractResponsesAPIUsage handles it
 				if onComplete != nil {

--- a/internal/proxy/stream_test.go
+++ b/internal/proxy/stream_test.go
@@ -862,6 +862,130 @@ func TestHandleStreamingWithTokens_HybridApproach(t *testing.T) {
 		"CompletionTokens should be > 0 from streaming count or extracted usage")
 }
 
+// TestHandleStreamingWithTokens_WithDoneAndUsage verifies that the presence of data: [DONE]
+// as the last chunk does not prevent extracting the correct usage from the previous chunk,
+// and that CompletionTokens is not overwritten with TotalTokens.
+func TestHandleStreamingWithTokens_WithDoneAndUsage(t *testing.T) {
+	upstreamServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		chunks := []string{
+			"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n",
+			"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":5,\"total_tokens\":105}}\n\n",
+			"data: [DONE]\n\n",
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		for _, chunk := range chunks {
+			_, _ = fmt.Fprint(w, chunk)
+			flusher.Flush()
+			time.Sleep(1 * time.Millisecond)
+		}
+	}))
+	defer upstreamServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeProxy, upstreamServer.URL, "upstream-key-1").
+		WithRequestTimeout(5 * time.Second).
+		Build()
+
+	resp, err := http.Get(upstreamServer.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	w := httptest.NewRecorder()
+
+	logCtx := &RequestLogContext{
+		RequestID:            "test-request-done-123",
+		PromptTokensEstimate: 95,
+		TokenUsage:           &converter.TokenUsage{},
+		Credential: &config.CredentialConfig{
+			Name: "test",
+			Type: config.ProviderTypeOpenAI,
+		},
+		Request: httptest.NewRequest("POST", "/v1/chat/completions", nil),
+	}
+
+	err = prx.handleStreamingWithTokens(w, resp, "test", "gpt-4o-mini", logCtx)
+	require.NoError(t, err)
+
+	assert.True(t, logCtx.Logged, "logCtx should be marked as logged")
+	assert.NotNil(t, logCtx.TokenUsage, "TokenUsage should not be nil")
+
+	// Verify that the actual prompt tokens and completion tokens were extracted and NOT overwritten
+	assert.Equal(t, 100, logCtx.TokenUsage.PromptTokens, "PromptTokens should be 100 (extracted from usage)")
+	assert.Equal(t, 5, logCtx.TokenUsage.CompletionTokens, "CompletionTokens should be 5 (extracted from usage, not total_tokens = 105)")
+
+	// Verify that tokens were consumed in the rate limiter (total_tokens = 105)
+	assert.Equal(t, 105, prx.rateLimiter.GetCurrentTPM("test"), "Rate limiter should have recorded 105 tokens")
+}
+
+// TestHandleStreamingWithTokens_CombinedUsageAndDone verifies that when the usage data
+// and the data: [DONE] sentinel arrive in the same TCP/buffer read chunk, the usage is still
+// extracted correctly and lastChunk is updated.
+func TestHandleStreamingWithTokens_CombinedUsageAndDone(t *testing.T) {
+	upstreamServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		chunks := []string{
+			"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n",
+			"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":5,\"total_tokens\":105}}\n\ndata: [DONE]\n\n",
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		for _, chunk := range chunks {
+			_, _ = fmt.Fprint(w, chunk)
+			flusher.Flush()
+			time.Sleep(1 * time.Millisecond)
+		}
+	}))
+	defer upstreamServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeProxy, upstreamServer.URL, "upstream-key-1").
+		WithRequestTimeout(5 * time.Second).
+		Build()
+
+	resp, err := http.Get(upstreamServer.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	w := httptest.NewRecorder()
+
+	logCtx := &RequestLogContext{
+		RequestID:            "test-request-combined-123",
+		PromptTokensEstimate: 95,
+		TokenUsage:           &converter.TokenUsage{},
+		Credential: &config.CredentialConfig{
+			Name: "test",
+			Type: config.ProviderTypeOpenAI,
+		},
+		Request: httptest.NewRequest("POST", "/v1/chat/completions", nil),
+	}
+
+	err = prx.handleStreamingWithTokens(w, resp, "test", "gpt-4o-mini", logCtx)
+	require.NoError(t, err)
+
+	assert.True(t, logCtx.Logged, "logCtx should be marked as logged")
+	assert.NotNil(t, logCtx.TokenUsage, "TokenUsage should not be nil")
+
+	// Verify that the actual prompt tokens and completion tokens were extracted and NOT overwritten
+	assert.Equal(t, 100, logCtx.TokenUsage.PromptTokens, "PromptTokens should be 100 (extracted from usage)")
+	assert.Equal(t, 5, logCtx.TokenUsage.CompletionTokens, "CompletionTokens should be 5 (extracted from usage, not total_tokens = 105)")
+}
+
 // TestTokenCapturingWriter_CumulativeTokens verifies that tokenCapturingWriter does NOT
 // accumulate total_tokens across chunks. Vertex/Gemini include a cumulative total_tokens in
 // every streaming chunk; naively adding them up multiplies the real count by N (the number of


### PR DESCRIPTION
Fixes billing discrepancy on streaming responses (specifically stateful `/v1/responses` via OpenRouter) where completion tokens were being incorrectly overwritten with the total cumulative tokens (including prompt and full history) when the stream ended with a `[DONE]` chunk.

This PR:
1. Populates `logCtx.TokenUsage` directly from parsed Responses API usage.
2. Extracts usage stats dynamically from stream chunks.
3. Skips `[DONE]` and empty lines when capturing `lastChunk`.
4. Avoids overwriting pre-extracted values with fallback estimates in `finalizeStreamingLog`.