### PR TITLE
Add comet api provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@
 [![GitHub Pages](https://img.shields.io/badge/docs-GitHub%20Pages-blue)](https://mixaill76.github.io/auto_ai_router/)
 [![license](https://img.shields.io/github/license/MiXaiLL76/auto_ai_router.svg)](https://github.com/MiXaiLL76/auto_ai_router/blob/main/LICENSE)
 
-High-performance proxy router for LLM APIs with automatic load balancing, rate limiting, and fail2ban protection. Routes requests to OpenAI, Vertex AI, Gemini AI Studio, Anthropic, and other Auto AI Router instances.
+High-performance proxy router for LLM APIs with automatic load balancing, rate limiting, and fail2ban protection. Routes requests to OpenAI, Vertex AI, Gemini AI Studio, Anthropic, Comet API, and other Auto AI Router instances.
 
 ## Key Features
 
-- **Multi-provider support** — OpenAI, Vertex AI, Gemini, Anthropic, Proxy chains
+- **Multi-provider support** — OpenAI, Vertex AI, Gemini, Anthropic, Comet API, Proxy chains
 - **Round-robin load balancing** — across multiple credentials per model
 - **Rate limiting** — per-credential and per-model RPM/TPM controls
 - **Fail2ban** — automatic provider banning on repeated errors

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -68,6 +68,23 @@ credentials:
     rpm: 60
     tpm: -1
 
+  # Comet API using the Anthropic-compatible Messages API
+  - name: "comet_anthropic"
+    type: "cometapi"
+    api_key: "os.environ/COMET_API_KEY"
+    base_url: "https://api.cometapi.com/v1"
+    rpm: 60
+    tpm: -1
+
+  # CheapGPT / AIProductiv using the Anthropic-compatible Messages API
+  - name: "cheapgpt_anthropic"
+    type: "anthropic"
+    api_key: "os.environ/CHEAPGPT_API_KEY"
+    auth_type: "bearer"
+    base_url: "https://api.aiproductiv.ru/v1"
+    rpm: 60
+    tpm: -1
+
   # Proxy credential (forwards requests to another auto_ai_router instance)
   - name: "proxy_fallback"
     type: "proxy"
@@ -88,6 +105,118 @@ models:
     credential: vertex_ai
     rpm: 100
     tpm: 50000
+
+  # Comet API Claude aliases for public model names.
+  - name: "anthropic/claude-haiku-4.5"
+    model: "claude-haiku-4-5-20251001"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-haiku-4.5"
+    model: "claude-haiku-4-5-20251001"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-haiku-4-5-20251001"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-opus-4.1"
+    model: "claude-opus-4-1-20250805"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-opus-4.1"
+    model: "claude-opus-4-1-20250805"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-opus-4-1-20250805"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-opus-4.5"
+    model: "claude-opus-4-5-20251101"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-opus-4.5"
+    model: "claude-opus-4-5-20251101"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-opus-4-5-20251101"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-opus-4.6"
+    model: "claude-opus-4-6"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-opus-4-6"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-opus-4.7"
+    model: "claude-opus-4-7"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-opus-4-7"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-sonnet-4"
+    model: "claude-sonnet-4-20250514"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-sonnet-4"
+    model: "claude-sonnet-4-20250514"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-sonnet-4.5"
+    model: "claude-sonnet-4-5-20250929"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-sonnet-4.5"
+    model: "claude-sonnet-4-5-20250929"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-sonnet-4-5-20250929"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-sonnet-4-5"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "anthropic/claude-sonnet-4.6"
+    model: "claude-sonnet-4-6"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+  - name: "claude-sonnet-4-6"
+    credential: comet_anthropic
+    rpm: 60
+    tpm: -1
+
+  - name: "cheapgpt/claude-sonnet-4.5"
+    model: "claude-sonnet-4-5"
+    credential: cheapgpt_anthropic
+    rpm: 60
+    tpm: -1
 
 # Optional: Redis/Valkey backend for distributed rate limiting and response storage.
 # When enabled, all replicas share a single counter namespace — RPM/TPM limits are

--- a/docs/advanced/responses.md
+++ b/docs/advanced/responses.md
@@ -1,6 +1,6 @@
 # Responses API
 
-Auto AI Router implements the [OpenAI Responses API](../refs/openai_responses_api.md) and routes requests natively to Anthropic, Vertex AI, and AWS Bedrock — without converting through Chat Completions format as an intermediary.
+Auto AI Router implements the [OpenAI Responses API](../refs/openai_responses_api.md) and routes requests natively to Anthropic, Comet API, Vertex AI, and AWS Bedrock — without converting through Chat Completions format as an intermediary.
 
 ## Endpoints
 
@@ -275,7 +275,7 @@ The router uses two modes for Responses API requests:
 | **Native**      | Responses API request → provider-specific format directly. Preserves all provider features |
 | **Passthrough** | Responses API request → Chat Completions → provider, then Chat Completions → Responses API |
 
-Native mode is used automatically for **Anthropic**, **Vertex AI**, and **AWS Bedrock**. Passthrough is used for OpenAI and other providers that already speak Responses API natively.
+Native mode is used automatically for **Anthropic**, **Comet API**, **Vertex AI**, and **AWS Bedrock**. Passthrough is used for OpenAI and other providers that already speak Responses API natively.
 
 The mode can be overridden via model configuration:
 
@@ -287,19 +287,19 @@ models:
 
 ## Provider Support
 
-| Feature                  | Anthropic | Vertex AI | Bedrock | OpenAI |
-| ------------------------ | --------- | --------- | ------- | ------ |
-| Non-streaming            | ✅        | ✅        | ✅      | ✅     |
-| Streaming (SSE)          | ✅        | ✅        | ✅      | ✅     |
-| WebSocket                | ✅        | ✅        | ✅      | ✅     |
-| `store` / response store | ✅        | ✅        | ✅      | ✅     |
-| `previous_response_id`   | ✅        | ✅        | ✅      | ✅     |
-| `tools` (function)       | ✅        | ✅        | ✅      | ✅     |
-| `reasoning`              | ✅        | ✅        | ✅      | ✅     |
-| `presence_penalty`       | ❌        | ✅        | ❌      | ✅     |
-| `frequency_penalty`      | ❌        | ✅        | ❌      | ✅     |
-| `top_logprobs`           | ❌        | ✅        | ❌      | ✅     |
-| `compact` endpoint       | ✅        | ✅        | ✅      | ✅     |
+| Feature                  | Anthropic | Comet API | Vertex AI | Bedrock | OpenAI |
+| ------------------------ | --------- | --------- | --------- | ------- | ------ |
+| Non-streaming            | ✅        | ✅        | ✅        | ✅      | ✅     |
+| Streaming (SSE)          | ✅        | ✅        | ✅        | ✅      | ✅     |
+| WebSocket                | ✅        | ✅        | ✅        | ✅      | ✅     |
+| `store` / response store | ✅        | ✅        | ✅        | ✅      | ✅     |
+| `previous_response_id`   | ✅        | ✅        | ✅        | ✅      | ✅     |
+| `tools` (function)       | ✅        | ✅        | ✅        | ✅      | ✅     |
+| `reasoning`              | ✅        | ✅        | ✅        | ✅      | ✅     |
+| `presence_penalty`       | ❌        | ❌        | ✅        | ❌      | ✅     |
+| `frequency_penalty`      | ❌        | ❌        | ✅        | ❌      | ✅     |
+| `top_logprobs`           | ❌        | ❌        | ✅        | ❌      | ✅     |
+| `compact` endpoint       | ✅        | ✅        | ✅        | ✅      | ✅     |
 
 ## Retry and Fallback
 

--- a/docs/advanced/session_sticky.md
+++ b/docs/advanced/session_sticky.md
@@ -196,7 +196,7 @@ Negative values are rejected at startup.
 
 ### Automatic Anthropic Prompt Caching
 
-When routing to an **Anthropic** or **Bedrock** credential with an active session, the proxy automatically injects `cache_control: {type: "ephemeral"}` markers into the request body. This converts automatic same-credential affinity into explicit provider-level prompt caching, reducing token costs by up to 90% on long conversations.
+When routing to an **Anthropic**, **Comet API**, or **Bedrock** credential with an active session, the proxy automatically injects `cache_control: {type: "ephemeral"}` markers into the request body. This converts automatic same-credential affinity into explicit provider-level prompt caching, reducing token costs by up to 90% on long conversations.
 
 **Enabled by default.** To disable:
 
@@ -232,7 +232,7 @@ If the incoming request **already contains** any `cache_control` field anywhere 
 Auto-injection fires when **all** of the following are true:
 
 - `session_sticky_auto_cache_control: true` (default)
-- Credential type is `anthropic` or `bedrock`
+- Credential type is `anthropic`, `cometapi`, or `bedrock`
 - A session is active: request has a session ID **or** `previous_response_id` resolved to a known credential
 
 ### Full Example

--- a/docs/getting-started/api.md
+++ b/docs/getting-started/api.md
@@ -48,7 +48,7 @@ print(response.choices[0].message.content)
 
 ## Responses API
 
-The router supports the [OpenAI Responses API](../advanced/responses.md) with native provider integration for Anthropic, Vertex AI, and AWS Bedrock.
+The router supports the [OpenAI Responses API](../advanced/responses.md) with native provider integration for Anthropic, Comet API, Vertex AI, and AWS Bedrock.
 
 ```bash
 curl -X POST http://localhost:8080/v1/responses \

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -153,13 +153,13 @@ Each credential defines a connection to an LLM provider. See [Providers](../prov
 
 Common fields for all credentials:
 
-| Field         | Type   | Description                                                          |
-| ------------- | ------ | -------------------------------------------------------------------- |
-| `name`        | string | Unique credential identifier                                         |
-| `type`        | string | Provider type: `openai`, `anthropic`, `vertex-ai`, `gemini`, `proxy` |
-| `rpm`         | int    | Requests per minute limit (-1 = unlimited)                           |
-| `tpm`         | int    | Tokens per minute limit (-1 = unlimited)                             |
-| `is_fallback` | bool   | Use as fallback when primary credentials are exhausted               |
+| Field         | Type   | Description                                                                                 |
+| ------------- | ------ | ------------------------------------------------------------------------------------------- |
+| `name`        | string | Unique credential identifier                                                                |
+| `type`        | string | Provider type: `openai`, `anthropic`, `cometapi`, `vertex-ai`, `gemini`, `bedrock`, `proxy` |
+| `rpm`         | int    | Requests per minute limit (-1 = unlimited)                                                  |
+| `tpm`         | int    | Tokens per minute limit (-1 = unlimited)                                                    |
+| `is_fallback` | bool   | Use as fallback when primary credentials are exhausted                                      |
 
 ## Models
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ graph LR
 
 ## Features
 
-- **Multi-provider routing** — OpenAI, Vertex AI, Gemini AI Studio, Anthropic
+- **Multi-provider routing** — OpenAI, Vertex AI, Gemini AI Studio, Anthropic, Comet API
 - **Proxy chains** — forward to other Auto AI Router instances as fallback
 - **Round-robin balancing** — distribute load across multiple credentials
 - **Two-level rate limiting** — per-credential RPM/TPM + per-model limits

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -12,12 +12,61 @@ credentials:
     tpm: 100000
 ```
 
+### Anthropic-Compatible Providers
+
+For Comet API, prefer the dedicated [`cometapi`](cometapi.md) provider type.
+Other Anthropic-compatible providers can still use `type: "anthropic"` with
+an optional `auth_type` override:
+
+```yaml
+credentials:
+  - name: "compatible_anthropic"
+    type: "anthropic"
+    api_key: "os.environ/COMPATIBLE_API_KEY"
+    auth_type: "bearer"  # optional; default is X-Api-Key
+    base_url: "https://api.example.com/v1"
+    rpm: 60
+    tpm: -1
+
+models:
+  - name: "provider/claude-sonnet-4.5"
+    model: "claude-sonnet-4-5-20250929"
+    credential: compatible_anthropic
+    rpm: 60
+    tpm: -1
+```
+
+### CheapGPT / AIProductiv
+
+CheapGPT can be configured as another Anthropic-compatible provider:
+
+```yaml
+credentials:
+  - name: "cheapgpt_anthropic"
+    type: "anthropic"
+    api_key: "os.environ/CHEAPGPT_API_KEY"
+    auth_type: "bearer"
+    base_url: "https://api.aiproductiv.ru/v1"
+    rpm: 60
+    tpm: -1
+
+models:
+  - name: "cheapgpt/claude-sonnet-4.5"
+    model: "claude-sonnet-4-5"
+    credential: cheapgpt_anthropic
+    rpm: 60
+    tpm: -1
+```
+
 ## Required Fields
 
 | Field      | Description                                        |
 | ---------- | -------------------------------------------------- |
 | `api_key`  | Anthropic API key (supports `os.environ/VAR_NAME`) |
 | `base_url` | API base URL (`https://api.anthropic.com`)         |
+
+By default, Anthropic credentials send `X-Api-Key`. Set `auth_type: "bearer"` for
+Anthropic-compatible providers that expect `Authorization: Bearer <token>`.
 
 ## Responses API
 

--- a/docs/providers/cometapi.md
+++ b/docs/providers/cometapi.md
@@ -1,0 +1,112 @@
+# Comet API
+
+Comet API is supported as an Anthropic-compatible provider via the dedicated
+`cometapi` credential type. Requests are converted from OpenAI Chat Completions
+or Responses API format to Anthropic Messages API and sent to `/v1/messages`.
+
+## Configuration
+
+```yaml
+credentials:
+  - name: "comet_anthropic"
+    type: "cometapi"
+    api_key: "os.environ/COMET_API_KEY"
+    base_url: "https://api.cometapi.com/v1"
+    rpm: 60
+    tpm: -1
+```
+
+## Claude Model Aliases
+
+Use public `name` values for clients, and map them to Comet model IDs with
+`model` where the provider names differ:
+
+```yaml
+models:
+  - name: "anthropic/claude-haiku-4.5"
+    model: "claude-haiku-4-5-20251001"
+    credential: comet_anthropic
+  - name: "claude-haiku-4.5"
+    model: "claude-haiku-4-5-20251001"
+    credential: comet_anthropic
+  - name: "claude-haiku-4-5-20251001"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-opus-4.1"
+    model: "claude-opus-4-1-20250805"
+    credential: comet_anthropic
+  - name: "claude-opus-4.1"
+    model: "claude-opus-4-1-20250805"
+    credential: comet_anthropic
+  - name: "claude-opus-4-1-20250805"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-opus-4.5"
+    model: "claude-opus-4-5-20251101"
+    credential: comet_anthropic
+  - name: "claude-opus-4.5"
+    model: "claude-opus-4-5-20251101"
+    credential: comet_anthropic
+  - name: "claude-opus-4-5-20251101"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-opus-4.6"
+    model: "claude-opus-4-6"
+    credential: comet_anthropic
+  - name: "claude-opus-4-6"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-opus-4.7"
+    model: "claude-opus-4-7"
+    credential: comet_anthropic
+  - name: "claude-opus-4-7"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-sonnet-4"
+    model: "claude-sonnet-4-20250514"
+    credential: comet_anthropic
+  - name: "claude-sonnet-4"
+    model: "claude-sonnet-4-20250514"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-sonnet-4.5"
+    model: "claude-sonnet-4-5-20250929"
+    credential: comet_anthropic
+  - name: "claude-sonnet-4.5"
+    model: "claude-sonnet-4-5-20250929"
+    credential: comet_anthropic
+  - name: "claude-sonnet-4-5-20250929"
+    credential: comet_anthropic
+
+  - name: "anthropic/claude-sonnet-4.6"
+    model: "claude-sonnet-4-6"
+    credential: comet_anthropic
+  - name: "claude-sonnet-4-6"
+    credential: comet_anthropic
+```
+
+## Prompt Caching
+
+`cometapi` uses the Anthropic Messages cache-control format:
+
+```json
+{"cache_control": {"type": "ephemeral"}}
+```
+
+When session-sticky routing is active, the router can automatically inject cache
+markers for stable conversation history. Cache accounting is preserved in OpenAI
+responses:
+
+| Comet/Anthropic usage field   | OpenAI-compatible response field              |
+| ----------------------------- | --------------------------------------------- |
+| `cache_read_input_tokens`     | `prompt_tokens_details.cached_tokens`         |
+| `cache_creation_input_tokens` | `prompt_tokens_details.cache_creation_tokens` |
+
+For `claude-sonnet-4.5`, prefer the dated Comet model
+`claude-sonnet-4-5-20250929` for more stable prompt-cache behavior.
+
+## Error Masking
+
+Comet upstream error bodies are masked before being returned to clients or logged.
+The HTTP status is preserved, but the response body is replaced with a neutral
+OpenAI-compatible error object.

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -8,6 +8,7 @@ Auto AI Router supports multiple LLM providers. Each provider type has its own a
 | ----------------------------- | ----------- | ------------------------------------------------------------------ | ------------------------ |
 | [OpenAI](openai.md)           | `openai`    | `api_key`, `base_url`                                              | API Key                  |
 | [Anthropic](anthropic.md)     | `anthropic` | `api_key`, `base_url`                                              | API Key                  |
+| [Comet API](cometapi.md)      | `cometapi`  | `api_key`, `base_url`                                              | API Key                  |
 | [AWS Bedrock](bedrock.md)     | `bedrock`   | `api_key`, `base_url`                                              | Bearer Token             |
 | [Vertex AI](vertex.md)        | `vertex-ai` | `project_id`, `location`, `credentials_file` or `credentials_json` | OAuth2 / Service Account |
 | [Gemini AI Studio](gemini.md) | `gemini`    | `api_key`, `base_url`                                              | API Key                  |
@@ -17,9 +18,10 @@ Auto AI Router supports multiple LLM providers. Each provider type has its own a
 
 All credential types share these fields:
 
-| Field         | Type   | Description                                     |
-| ------------- | ------ | ----------------------------------------------- |
-| `name`        | string | Unique identifier for this credential           |
-| `rpm`         | int    | Requests per minute limit (-1 = unlimited)      |
-| `tpm`         | int    | Tokens per minute limit (-1 = unlimited)        |
-| `is_fallback` | bool   | Use only when primary credentials are exhausted |
+| Field         | Type   | Description                                      |
+| ------------- | ------ | ------------------------------------------------ |
+| `name`        | string | Unique identifier for this credential            |
+| `rpm`         | int    | Requests per minute limit (-1 = unlimited)       |
+| `tpm`         | int    | Tokens per minute limit (-1 = unlimited)         |
+| `auth_type`   | string | Optional auth override (`bearer` or `x-api-key`) |
+| `is_fallback` | bool   | Use only when primary credentials are exhausted  |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ const (
 	ProviderTypeVertexAI  ProviderType = "vertex-ai"
 	ProviderTypeGemini    ProviderType = "gemini"
 	ProviderTypeAnthropic ProviderType = "anthropic"
+	ProviderTypeCometAPI  ProviderType = "cometapi"
 	ProviderTypeBedrock   ProviderType = "bedrock"
 	ProviderTypeProxy     ProviderType = "proxy"
 )
@@ -38,10 +39,19 @@ func (p ProviderType) LogValue() slog.Value {
 // IsValid checks if the provider type is valid
 func (p ProviderType) IsValid() bool {
 	switch p {
-	case ProviderTypeOpenAI, ProviderTypeVertexAI, ProviderTypeGemini, ProviderTypeAnthropic, ProviderTypeBedrock, ProviderTypeProxy:
+	case ProviderTypeOpenAI, ProviderTypeVertexAI, ProviderTypeGemini, ProviderTypeAnthropic, ProviderTypeCometAPI, ProviderTypeBedrock, ProviderTypeProxy:
 		return true
 	}
 	return false
+}
+
+func normalizeProviderType(raw string) ProviderType {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "comet-api", "comet_api":
+		return ProviderTypeCometAPI
+	default:
+		return ProviderType(strings.ToLower(strings.TrimSpace(raw)))
+	}
 }
 
 // ModelRPMConfig represents RPM and TPM limits for a specific model
@@ -532,13 +542,14 @@ func (s *ServerConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type CredentialConfig struct {
-	Name    string       `yaml:"name"`
-	Type    ProviderType `yaml:"type"`
-	APIKey  string       `yaml:"api_key"`
-	BaseURL string       `yaml:"base_url"`
-	RPM     int          `yaml:"rpm"`
-	TPM     int          `yaml:"tpm"`
-	Weight  int          `yaml:"weight"` // Default weighted round-robin weight for this credential (0 = 1)
+	Name     string       `yaml:"name"`
+	Type     ProviderType `yaml:"type"`
+	APIKey   string       `yaml:"api_key"`
+	BaseURL  string       `yaml:"base_url"`
+	AuthType string       `yaml:"auth_type,omitempty"`
+	RPM      int          `yaml:"rpm"`
+	TPM      int          `yaml:"tpm"`
+	Weight   int          `yaml:"weight"` // Default weighted round-robin weight for this credential (0 = 1)
 
 	// Models associated with this credential (used for x-model-templates)
 	Models []ModelRPMConfig `yaml:"models,omitempty"`
@@ -561,6 +572,7 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 		Type            string           `yaml:"type"`
 		APIKey          string           `yaml:"api_key"`
 		BaseURL         string           `yaml:"base_url"`
+		AuthType        string           `yaml:"auth_type,omitempty"`
 		RPM             string           `yaml:"rpm"`
 		TPM             string           `yaml:"tpm"`
 		Weight          string           `yaml:"weight"`
@@ -579,9 +591,10 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 
 	// Resolve string fields
 	c.Name = resolveEnvString(temp.Name)
-	c.Type = ProviderType(resolveEnvString(temp.Type))
+	c.Type = normalizeProviderType(resolveEnvString(temp.Type))
 	c.APIKey = resolveEnvString(temp.APIKey)
 	c.BaseURL = resolveEnvString(temp.BaseURL)
+	c.AuthType = strings.ToLower(resolveEnvString(temp.AuthType))
 
 	// Resolve Vertex AI specific fields
 	c.ProjectID = resolveEnvString(temp.ProjectID)
@@ -1194,7 +1207,10 @@ func (c *Config) Validate() error {
 
 		// Validate provider type
 		if !cred.Type.IsValid() {
-			return fmt.Errorf("credential %s: invalid type: %s (must be 'openai', 'vertex-ai', 'gemini', 'anthropic', 'bedrock', or 'proxy')", cred.Name, cred.Type)
+			return fmt.Errorf("credential %s: invalid type: %s (must be 'openai', 'vertex-ai', 'gemini', 'anthropic', 'cometapi', 'bedrock', or 'proxy')", cred.Name, cred.Type)
+		}
+		if cred.AuthType != "" && cred.AuthType != "bearer" && cred.AuthType != "x-api-key" {
+			return fmt.Errorf("credential %s: invalid auth_type: %s (must be 'bearer' or 'x-api-key')", cred.Name, cred.AuthType)
 		}
 
 		// Validate by provider type

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoad_ValidConfig(t *testing.T) {
@@ -40,6 +41,7 @@ credentials:
     type: "openai"
     api_key: "sk-yyyy"
     base_url: "https://api.custom-provider.com"
+    auth_type: "bearer"
     rpm: 120
 
 monitoring:
@@ -70,10 +72,30 @@ monitoring:
 	assert.Len(t, cfg.Credentials, 2)
 	assert.Equal(t, "provider_1", cfg.Credentials[0].Name)
 	assert.Equal(t, 60, cfg.Credentials[0].RPM)
+	assert.Equal(t, "bearer", cfg.Credentials[1].AuthType)
 
 	// Validate monitoring
 	assert.True(t, cfg.Monitoring.PrometheusEnabled)
 	assert.Equal(t, "/health", cfg.Monitoring.HealthCheckPath)
+}
+
+func TestConfig_Validate_InvalidAuthType(t *testing.T) {
+	cfg := &Config{
+		Server: ServerConfig{
+			Port:           8080,
+			MaxBodySizeMB:  10,
+			MasterKey:      "test-key",
+			RequestTimeout: 30 * time.Second,
+		},
+		Credentials: []CredentialConfig{
+			{Name: "test", Type: "anthropic", APIKey: "key", BaseURL: "http://test.com", AuthType: "basic", RPM: 10},
+		},
+		Fail2Ban: Fail2BanConfig{MaxAttempts: 3},
+	}
+
+	err := cfg.Validate()
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid auth_type")
 }
 
 func TestLoad_FileNotFound(t *testing.T) {
@@ -599,6 +621,7 @@ func TestProviderType_IsValid(t *testing.T) {
 	}{
 		{"openai", ProviderTypeOpenAI, true},
 		{"vertex-ai", ProviderTypeVertexAI, true},
+		{"cometapi", ProviderTypeCometAPI, true},
 		{"invalid", ProviderType("azure"), false},
 		{"empty", ProviderType(""), false},
 	}
@@ -608,6 +631,20 @@ func TestProviderType_IsValid(t *testing.T) {
 			assert.Equal(t, tt.valid, tt.provider.IsValid())
 		})
 	}
+}
+
+func TestCredentialConfig_NormalizeCometAPIProviderType(t *testing.T) {
+	var cred CredentialConfig
+	err := yaml.Unmarshal([]byte(`
+name: comet
+type: comet-api
+api_key: key
+base_url: https://api.cometapi.com/v1
+rpm: 60
+`), &cred)
+
+	require.NoError(t, err)
+	assert.Equal(t, ProviderTypeCometAPI, cred.Type)
 }
 
 func TestConfig_Validate_VertexAI(t *testing.T) {

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -121,6 +121,7 @@ func PrintConfig(logger *slog.Logger, cfg *Config) {
 			"name":        cred.Name,
 			"type":        cred.Type,
 			"base_url":    cred.BaseURL,
+			"auth_type":   cred.AuthType,
 			"rpm":         rpmToString(cred.RPM),
 			"tpm":         tpmToString(cred.TPM),
 			"is_fallback": cred.IsFallback,
@@ -234,7 +235,7 @@ func banDurationToString(d time.Duration) string {
 func convertMapToArgs(m map[string]any) []any {
 	// Define preferred order of keys
 	keyOrder := []string{
-		"name", "type", "base_url", "api_key", "project_id", "location",
+		"name", "type", "base_url", "auth_type", "api_key", "project_id", "location",
 		"credentials_file", "credentials_json", "rpm", "tpm", "is_fallback",
 	}
 

--- a/internal/converter/anthropic/messages.go
+++ b/internal/converter/anthropic/messages.go
@@ -92,6 +92,7 @@ func OpenAIToAnthropic(openAIBody []byte, model string) ([]byte, error) {
 	if tc, oc := mapThinkingConfig(thinkingParam, req.ReasoningEffort, anthropicReq.Model); tc != nil {
 		anthropicReq.Thinking = tc
 		anthropicReq.OutputConfig = oc
+		anthropicReq.MaxTokens = EnsureMaxTokensForThinking(anthropicReq.MaxTokens, tc)
 		if oc != nil {
 			// effort-based adaptive thinking requires the effort beta header
 			anthropicReq.AnthropicBeta = appendBetaUnique(anthropicReq.AnthropicBeta, "effort-2025-11-24")

--- a/internal/converter/anthropic/response.go
+++ b/internal/converter/anthropic/response.go
@@ -124,7 +124,8 @@ func convertAnthropicUsageToOpenAI(usage *AnthropicUsage) *openai.OpenAIUsage {
 	// map cache_read + cache_creation tokens to prompt_tokens_details
 	if usage.CacheReadInputTokens > 0 || usage.CacheCreationInputTokens > 0 {
 		result.PromptTokensDetails = &openai.TokenDetails{
-			CachedTokens: usage.CacheReadInputTokens,
+			CachedTokens:        usage.CacheReadInputTokens,
+			CacheCreationTokens: usage.CacheCreationInputTokens,
 		}
 	}
 	return result

--- a/internal/converter/anthropic/responses/converter.go
+++ b/internal/converter/anthropic/responses/converter.go
@@ -5,14 +5,17 @@ package anthropicresponses
 
 import (
 	"io"
-	"strings"
 
 	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/converter/responses"
 )
 
 func init() {
 	responses.RegisterProviderResponses(config.ProviderTypeAnthropic, func(mode responses.ResponsesRequestMode) responses.ProviderResponses {
+		return &AnthropicResponses{mode: mode}
+	})
+	responses.RegisterProviderResponses(config.ProviderTypeCometAPI, func(mode responses.ResponsesRequestMode) responses.ProviderResponses {
 		return &AnthropicResponses{mode: mode}
 	})
 }
@@ -57,6 +60,5 @@ func (a *AnthropicResponses) StreamTo(
 
 // BuildURL constructs the Anthropic Messages API endpoint URL.
 func (a *AnthropicResponses) BuildURL(cred *config.CredentialConfig) string {
-	baseURL := strings.TrimSuffix(cred.BaseURL, "/")
-	return baseURL + "/v1/messages"
+	return converterutil.BuildVersionedURL(cred.BaseURL, "/v1/messages")
 }

--- a/internal/converter/anthropic/responses/request.go
+++ b/internal/converter/anthropic/responses/request.go
@@ -79,6 +79,7 @@ func buildAnthropicRequest(req *responses.Request, model string) (*anthropic.Ant
 		if tc != nil {
 			ar.Thinking = tc
 			ar.OutputConfig = oc
+			ar.MaxTokens = anthropic.EnsureMaxTokensForThinking(ar.MaxTokens, tc)
 			if oc != nil {
 				ar.AnthropicBeta = appendUnique(ar.AnthropicBeta, "effort-2025-11-24")
 			} else {

--- a/internal/converter/anthropic/responses/request_test.go
+++ b/internal/converter/anthropic/responses/request_test.go
@@ -245,6 +245,26 @@ func TestResponsesRequestToAnthropic_ReasoningEffortLow(t *testing.T) {
 	assert.Equal(t, "low", outputConfig["effort"])
 }
 
+func TestResponsesRequestToAnthropic_ReasoningBudgetRaisesMaxTokens(t *testing.T) {
+	body := `{
+		"model": "claude-sonnet-4-5",
+		"input": "test",
+		"reasoning": {"effort": "low"},
+		"max_output_tokens": 5000
+	}`
+
+	result, err := ResponsesRequestToAnthropic([]byte(body), "claude-sonnet-4-5")
+	require.NoError(t, err)
+
+	var ar map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &ar))
+
+	thinking := ar["thinking"].(map[string]interface{})
+	assert.Equal(t, "enabled", thinking["type"])
+	assert.Equal(t, float64(5000), thinking["budget_tokens"])
+	assert.Equal(t, float64(6024), ar["max_tokens"])
+}
+
 func TestResponsesRequestToAnthropic_ReasoningEffortNone(t *testing.T) {
 	body := `{
 		"model": "claude-opus-4-5",

--- a/internal/converter/anthropic/thinking.go
+++ b/internal/converter/anthropic/thinking.go
@@ -2,6 +2,8 @@ package anthropic
 
 import "strings"
 
+const minTextTokensWithThinking = 1024
+
 // mapThinkingConfig maps OpenAI thinking / reasoning_effort parameters to an Anthropic
 // ThinkingConfig (and optional OutputConfig for Claude 4+ adaptive thinking).
 //
@@ -78,6 +80,19 @@ func appendBetaUnique(slice []string, s string) []string {
 // that only have an effort string and model name, without a raw thinking param.
 func MapThinkingConfigFromEffort(effort, modelName string) (*AnthropicThinking, *AnthropicOutputConfig) {
 	return mapThinkingConfig(nil, effort, modelName)
+}
+
+// EnsureMaxTokensForThinking raises max_tokens when legacy thinking uses a
+// budget_tokens value. Anthropic requires max_tokens to be greater than the
+// thinking budget; otherwise the provider rejects the request before generation.
+func EnsureMaxTokensForThinking(maxTokens int, thinking *AnthropicThinking) int {
+	if thinking == nil || thinking.Type != "enabled" || thinking.BudgetTokens <= 0 {
+		return maxTokens
+	}
+	if maxTokens > thinking.BudgetTokens {
+		return maxTokens
+	}
+	return thinking.BudgetTokens + minTextTokensWithThinking
 }
 
 // isAdaptiveThinkingModel reports whether the model uses the Claude 4+ adaptive thinking API

--- a/internal/converter/anthropic/thinking_test.go
+++ b/internal/converter/anthropic/thinking_test.go
@@ -27,6 +27,16 @@ func TestMapReasoningEffortToBudget(t *testing.T) {
 	}
 }
 
+func TestEnsureMaxTokensForThinking(t *testing.T) {
+	thinking := &AnthropicThinking{Type: "enabled", BudgetTokens: 5000}
+
+	assert.Equal(t, 6000, EnsureMaxTokensForThinking(6000, thinking))
+	assert.Equal(t, 6024, EnsureMaxTokensForThinking(5000, thinking))
+	assert.Equal(t, 6024, EnsureMaxTokensForThinking(4096, thinking))
+	assert.Equal(t, 4096, EnsureMaxTokensForThinking(4096, nil))
+	assert.Equal(t, 4096, EnsureMaxTokensForThinking(4096, &AnthropicThinking{Type: "adaptive"}))
+}
+
 // Claude 3.x: expects type="enabled" + budget_tokens, no output_config.
 func TestMapThinkingConfig_Classic(t *testing.T) {
 	const model = "claude-3-7-sonnet-20250219"

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mixaill76/auto_ai_router/internal/config"
 	"github.com/mixaill76/auto_ai_router/internal/converter/anthropic"
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	openaiconv "github.com/mixaill76/auto_ai_router/internal/converter/openai"
 	"github.com/mixaill76/auto_ai_router/internal/converter/vertex"
 )
@@ -111,8 +112,8 @@ func (c *ProviderConverter) RequestFrom(body []byte) ([]byte, error) {
 				c.inputTexts = texts
 			}
 			return vertex.OpenAIEmbeddingToGemini(body, c.mode.ModelID)
-		case config.ProviderTypeAnthropic:
-			return nil, errors.New("anthropic does not support embeddings")
+		case config.ProviderTypeAnthropic, config.ProviderTypeCometAPI:
+			return nil, errors.New(string(c.providerType) + " does not support embeddings")
 		case config.ProviderTypeBedrock:
 			return nil, errors.New("bedrock does not support embeddings")
 		default:
@@ -123,10 +124,10 @@ func (c *ProviderConverter) RequestFrom(body []byte) ([]byte, error) {
 	switch c.providerType {
 	case config.ProviderTypeVertexAI, config.ProviderTypeGemini:
 		return vertex.OpenAIToVertex(body, c.mode.IsImageGeneration, c.mode.IsImageEdit, c.mode.ModelID, c.mode.ContentType)
-	case config.ProviderTypeAnthropic:
-		// Anthropic does not support image generation
+	case config.ProviderTypeAnthropic, config.ProviderTypeCometAPI:
+		// Anthropic-compatible providers do not support image generation
 		if c.mode.IsImageGeneration {
-			return nil, errors.New("anthropic does not support image generation")
+			return nil, errors.New(string(c.providerType) + " does not support image generation")
 		}
 		return anthropic.OpenAIToAnthropic(body, c.mode.ModelID)
 	case config.ProviderTypeBedrock:
@@ -191,7 +192,7 @@ func (c *ProviderConverter) ResponseTo(body []byte) ([]byte, error) {
 			return vertex.VertexImageToOpenAI(body)
 		}
 		return vertex.VertexToOpenAI(body, c.mode.responseModel())
-	case config.ProviderTypeAnthropic:
+	case config.ProviderTypeAnthropic, config.ProviderTypeCometAPI:
 		return anthropic.AnthropicToOpenAI(body, c.mode.responseModel())
 	case config.ProviderTypeBedrock:
 		if isAnthropicBedrockModel(c.mode.ModelID) {
@@ -213,7 +214,7 @@ func (c *ProviderConverter) StreamTo(reader io.Reader, writer io.Writer) error {
 	switch c.providerType {
 	case config.ProviderTypeVertexAI, config.ProviderTypeGemini:
 		return vertex.TransformVertexStreamToOpenAI(reader, c.mode.responseModel(), writer)
-	case config.ProviderTypeAnthropic:
+	case config.ProviderTypeAnthropic, config.ProviderTypeCometAPI:
 		return anthropic.TransformAnthropicStreamToOpenAI(reader, c.mode.responseModel(), writer)
 	case config.ProviderTypeBedrock:
 		// Bedrock uses AWS Event Stream binary framing instead of SSE.
@@ -272,9 +273,8 @@ func (c *ProviderConverter) BuildURL(cred *config.CredentialConfig) string {
 			return vertex.BuildGeminiImageURL(cred, c.mode.ModelID)
 		}
 		return vertex.BuildGeminiURL(cred, c.mode.ModelID, c.mode.IsStreaming)
-	case config.ProviderTypeAnthropic:
-		baseURL := strings.TrimSuffix(cred.BaseURL, "/")
-		return baseURL + "/v1/messages"
+	case config.ProviderTypeAnthropic, config.ProviderTypeCometAPI:
+		return converterutil.BuildVersionedURL(cred.BaseURL, "/v1/messages")
 	case config.ProviderTypeBedrock:
 		baseURL := strings.TrimSuffix(cred.BaseURL, "/")
 		if c.mode.IsStreaming {
@@ -341,9 +341,10 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 			PromptTokens        int `json:"prompt_tokens"`
 			CompletionTokens    int `json:"completion_tokens"`
 			PromptTokensDetails struct {
-				CachedTokens int `json:"cached_tokens,omitempty"`
-				AudioTokens  int `json:"audio_tokens,omitempty"`
-				TextTokens   int `json:"text_tokens,omitempty"`
+				CachedTokens        int `json:"cached_tokens,omitempty"`
+				CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+				AudioTokens         int `json:"audio_tokens,omitempty"`
+				TextTokens          int `json:"text_tokens,omitempty"`
 			} `json:"prompt_tokens_details,omitempty"`
 			CompletionTokensDetails struct {
 				AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
@@ -390,6 +391,7 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 	if cachedTokens == 0 {
 		cachedTokens = resp.Usage.InputTokensDetails.CachedTokens
 	}
+	cacheCreationTokens := resp.Usage.PromptTokensDetails.CacheCreationTokens
 	audioIn := resp.Usage.PromptTokensDetails.AudioTokens
 	if audioIn == 0 {
 		audioIn = resp.Usage.InputTokensDetails.AudioTokens
@@ -424,6 +426,7 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		PromptTokens:             promptTokens,
 		CompletionTokens:         completionTokens,
 		CachedInputTokens:        cachedTokens,
+		CacheCreationTokens:      cacheCreationTokens,
 		AudioInputTokens:         audioIn,
 		ImageTokens:              resp.Usage.InputTokensDetails.ImageTokens,
 		AcceptedPredictionTokens: resp.Usage.CompletionTokensDetails.AcceptedPredictionTokens,

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -225,9 +225,10 @@ func TestProviderConverter_ResponseTo_Anthropic(t *testing.T) {
 		Model:      "claude",
 		StopReason: "end_turn",
 		Usage: anthropic.AnthropicUsage{
-			InputTokens:          5,
-			OutputTokens:         7,
-			CacheReadInputTokens: 2,
+			InputTokens:              5,
+			OutputTokens:             7,
+			CacheReadInputTokens:     2,
+			CacheCreationInputTokens: 3,
 		},
 		Content: []anthropic.ContentBlock{
 			{Type: "text", Text: "hello"},
@@ -254,11 +255,13 @@ func TestProviderConverter_ResponseTo_Anthropic(t *testing.T) {
 	if msg.Content != "hello" || msg.ReasoningContent != "hmm" || len(msg.ToolCalls) != 1 {
 		t.Fatalf("unexpected message: %+v", msg)
 	}
-	// PromptTokens = InputTokens + CacheReadInputTokens + CacheCreationInputTokens = 5 + 2 + 0 = 7
-	if resp.Usage == nil || resp.Usage.PromptTokens != 7 || resp.Usage.CompletionTokens != 7 || resp.Usage.TotalTokens != 14 {
+	// PromptTokens = InputTokens + CacheReadInputTokens + CacheCreationInputTokens = 5 + 2 + 3 = 10
+	if resp.Usage == nil || resp.Usage.PromptTokens != 10 || resp.Usage.CompletionTokens != 7 || resp.Usage.TotalTokens != 17 {
 		t.Fatalf("unexpected usage: %+v", resp.Usage)
 	}
-	if resp.Usage.PromptTokensDetails == nil || resp.Usage.PromptTokensDetails.CachedTokens != 2 {
+	if resp.Usage.PromptTokensDetails == nil ||
+		resp.Usage.PromptTokensDetails.CachedTokens != 2 ||
+		resp.Usage.PromptTokensDetails.CacheCreationTokens != 3 {
 		t.Fatalf("unexpected prompt token details: %+v", resp.Usage.PromptTokensDetails)
 	}
 }
@@ -428,6 +431,12 @@ func TestProviderConverter_BuildURL(t *testing.T) {
 		t.Fatalf("unexpected anthropic url: %q", got)
 	}
 
+	cred.BaseURL = "https://example.com/v1"
+	got = cAnthropic.BuildURL(cred)
+	if got != "https://example.com/v1/messages" {
+		t.Fatalf("unexpected anthropic versioned url: %q", got)
+	}
+
 	cOpenAI := New(config.ProviderTypeOpenAI, RequestMode{})
 	if got = cOpenAI.BuildURL(cred); got != "" {
 		t.Fatalf("expected empty url for openai, got %q", got)
@@ -463,7 +472,7 @@ func TestExtractTokenUsage(t *testing.T) {
 		t.Fatalf("expected nil for invalid json")
 	}
 
-	chatBody := []byte(`{"usage":{"prompt_tokens":5,"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":2,"audio_tokens":1},"completion_tokens_details":{"accepted_prediction_tokens":3,"rejected_prediction_tokens":1,"audio_tokens":4,"reasoning_tokens":6}}}`)
+	chatBody := []byte(`{"usage":{"prompt_tokens":5,"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":2,"cache_creation_tokens":4,"audio_tokens":1},"completion_tokens_details":{"accepted_prediction_tokens":3,"rejected_prediction_tokens":1,"audio_tokens":4,"reasoning_tokens":6}}}`)
 	usage := ExtractTokenUsage(chatBody)
 	if usage == nil {
 		t.Fatalf("expected usage for chat format")
@@ -472,7 +481,7 @@ func TestExtractTokenUsage(t *testing.T) {
 	if usage.PromptTokens != 5 || usage.CompletionTokens != 7 {
 		t.Fatalf("unexpected chat token counts: %+v", usage)
 	}
-	if usage.CachedInputTokens != 2 || usage.AudioInputTokens != 1 || usage.AudioOutputTokens != 4 || usage.ReasoningTokens != 6 {
+	if usage.CachedInputTokens != 2 || usage.CacheCreationTokens != 4 || usage.AudioInputTokens != 1 || usage.AudioOutputTokens != 4 || usage.ReasoningTokens != 6 {
 		t.Fatalf("unexpected details: %+v", usage)
 	}
 	if usage.AcceptedPredictionTokens != 3 || usage.RejectedPredictionTokens != 1 {

--- a/internal/converter/converterutil/utils.go
+++ b/internal/converter/converterutil/utils.go
@@ -4,6 +4,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/hex"
+	"strings"
 
 	"github.com/mixaill76/auto_ai_router/internal/utils"
 )
@@ -81,4 +82,61 @@ func DecodeBase64(encoded string) []byte {
 		return nil
 	}
 	return decoded
+}
+
+// BuildVersionedURL joins a provider base URL and API path without duplicating
+// a leading version segment such as /v1 when the base URL already includes it.
+func BuildVersionedURL(baseURL, apiPath string) string {
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	if apiPath == "" {
+		return baseURL
+	}
+	if apiPath[0] != '/' {
+		apiPath = "/" + apiPath
+	}
+
+	if baseVersion := versionSuffix(baseURL); baseVersion != "" {
+		if pathVersion := versionPrefix(apiPath); pathVersion == baseVersion {
+			apiPath = strings.TrimPrefix(apiPath, pathVersion)
+			if apiPath == "" {
+				return baseURL
+			}
+		}
+	}
+
+	return baseURL + apiPath
+}
+
+func versionSuffix(baseURL string) string {
+	idx := strings.LastIndex(baseURL, "/")
+	if idx < 0 {
+		return ""
+	}
+	return versionSegment(baseURL[idx:])
+}
+
+func versionPrefix(path string) string {
+	if len(path) < 3 || path[0] != '/' {
+		return ""
+	}
+	i := 2
+	for i < len(path) && path[i] >= '0' && path[i] <= '9' {
+		i++
+	}
+	if i == 2 || (i < len(path) && path[i] != '/') {
+		return ""
+	}
+	return versionSegment(path[:i])
+}
+
+func versionSegment(segment string) string {
+	if len(segment) < 3 || segment[0] != '/' || segment[1] != 'v' {
+		return ""
+	}
+	for _, c := range segment[2:] {
+		if c < '0' || c > '9' {
+			return ""
+		}
+	}
+	return segment
 }

--- a/internal/converter/converterutil/utils_test.go
+++ b/internal/converter/converterutil/utils_test.go
@@ -76,3 +76,56 @@ func TestDecodeBase64(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildVersionedURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		baseURL string
+		apiPath string
+		want    string
+	}{
+		{
+			name:    "base without version",
+			baseURL: "https://api.example.com",
+			apiPath: "/v1/messages",
+			want:    "https://api.example.com/v1/messages",
+		},
+		{
+			name:    "base with same version",
+			baseURL: "https://api.example.com/v1",
+			apiPath: "/v1/messages",
+			want:    "https://api.example.com/v1/messages",
+		},
+		{
+			name:    "base with trailing slash and same version",
+			baseURL: "https://api.example.com/v1/",
+			apiPath: "/v1/messages",
+			want:    "https://api.example.com/v1/messages",
+		},
+		{
+			name:    "path without leading slash",
+			baseURL: "https://api.example.com/v1",
+			apiPath: "v1/messages",
+			want:    "https://api.example.com/v1/messages",
+		},
+		{
+			name:    "different versions are preserved",
+			baseURL: "https://api.example.com/v2",
+			apiPath: "/v1/messages",
+			want:    "https://api.example.com/v2/v1/messages",
+		},
+		{
+			name:    "non-version suffix is preserved",
+			baseURL: "https://api.example.com/api",
+			apiPath: "/v1/messages",
+			want:    "https://api.example.com/api/v1/messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildVersionedURL(tt.baseURL, tt.apiPath)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -121,8 +121,9 @@ type ImageData struct {
 }
 
 type TokenDetails struct {
-	CachedTokens int `json:"cached_tokens,omitempty"`
-	AudioTokens  int `json:"audio_tokens,omitempty"`
+	CachedTokens        int `json:"cached_tokens,omitempty"`
+	CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+	AudioTokens         int `json:"audio_tokens,omitempty"`
 }
 
 type CompletionTokenDetails struct {

--- a/internal/litellmdb/model_table/model_table.go
+++ b/internal/litellmdb/model_table/model_table.go
@@ -294,6 +294,8 @@ func mapProviderType(provider string) config.ProviderType {
 		return config.ProviderTypeVertexAI
 	case strings.Contains(p, "google"):
 		return config.ProviderTypeGemini
+	case strings.Contains(p, "cometapi") || strings.Contains(p, "comet-api"):
+		return config.ProviderTypeCometAPI
 	case strings.Contains(p, "xai"):
 		return config.ProviderTypeOpenAI
 	default:

--- a/internal/litellmdb/model_table/model_table_test.go
+++ b/internal/litellmdb/model_table/model_table_test.go
@@ -18,6 +18,8 @@ func TestMapProviderType(t *testing.T) {
 		{"router", "router", config.ProviderTypeOpenAI},
 		{"vertex", "VERTEX", config.ProviderTypeVertexAI},
 		{"google", "GoogleAI", config.ProviderTypeGemini},
+		{"cometapi", "cometapi", config.ProviderTypeCometAPI},
+		{"comet-api", "comet-api", config.ProviderTypeCometAPI},
 		{"xai", "xAI", config.ProviderTypeOpenAI},
 		{"unknown", "some-other", ""},
 	}

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -311,6 +311,7 @@ var providerPassthroughDefaults = map[config.ProviderType]bool{
 	config.ProviderTypeVertexAI:  false,
 	config.ProviderTypeGemini:    false,
 	config.ProviderTypeAnthropic: false,
+	config.ProviderTypeCometAPI:  false,
 	config.ProviderTypeBedrock:   false,
 }
 
@@ -1123,6 +1124,7 @@ var providerTypeLiteLLMPrefix = map[config.ProviderType]string{
 	config.ProviderTypeVertexAI:  "vertex_ai",
 	config.ProviderTypeGemini:    "gemini",
 	config.ProviderTypeAnthropic: "anthropic",
+	config.ProviderTypeCometAPI:  "cometapi",
 	config.ProviderTypeBedrock:   "bedrock",
 	config.ProviderTypeProxy:     "openai",
 }

--- a/internal/proxy/cometapi_test.go
+++ b/internal/proxy/cometapi_test.go
@@ -1,0 +1,49 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsCometAPICredential(t *testing.T) {
+	tests := []struct {
+		name string
+		cred *config.CredentialConfig
+		want bool
+	}{
+		{
+			name: "dedicated provider type",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeCometAPI},
+			want: true,
+		},
+		{
+			name: "comet host fallback",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeAnthropic, BaseURL: "https://api.cometapi.com/v1"},
+			want: true,
+		},
+		{
+			name: "comet name fallback",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeAnthropic, Name: "comet-api-anthropic"},
+			want: true,
+		},
+		{
+			name: "regular anthropic",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeAnthropic, BaseURL: "https://api.anthropic.com"},
+			want: false,
+		},
+		{
+			name: "nil credential",
+			cred: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCometAPICredential(tt.cred))
+			assert.Equal(t, tt.want, shouldMaskUpstreamErrors(tt.cred))
+		})
+	}
+}

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -63,6 +63,30 @@ func WriteJSONError(w http.ResponseWriter, statusCode int, message, errorType st
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+func maskedUpstreamErrorBody(statusCode int) []byte {
+	code := "upstream_error"
+	switch statusCode {
+	case http.StatusTooManyRequests:
+		code = "upstream_rate_limit"
+	case http.StatusRequestTimeout:
+		code = "upstream_timeout"
+	}
+
+	resp := APIErrorResponse{
+		Error: APIError{
+			Message: "Upstream provider error",
+			Type:    errorTypeForStatus(statusCode),
+			Param:   nil,
+			Code:    &code,
+		},
+	}
+	body, err := json.Marshal(resp)
+	if err != nil {
+		return []byte(`{"error":{"message":"Upstream provider error","type":"api_error","param":null,"code":"upstream_error"}}`)
+	}
+	return append(body, '\n')
+}
+
 // WriteErrorBadRequest writes a 400 Bad Request JSON error.
 func WriteErrorBadRequest(w http.ResponseWriter, message string) {
 	WriteJSONError(w, http.StatusBadRequest, message, errorTypeForStatus(http.StatusBadRequest), nil, nil)

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -119,7 +119,7 @@ func (p *Proxy) orchestrateRequest(
 	// Auto-inject Anthropic prompt-caching markers when a session is active.
 	// This maximises cache hit rate when session-sticky routing keeps traffic on one credential.
 	if p.stickyAutoCacheCtrl &&
-		(cred.Type == config.ProviderTypeAnthropic || cred.Type == config.ProviderTypeBedrock) &&
+		(cred.Type == config.ProviderTypeAnthropic || cred.Type == config.ProviderTypeCometAPI || cred.Type == config.ProviderTypeBedrock) &&
 		(logCtx.SessionID != "" || preferredCredentialName != "") {
 		body = anthropicconv.InjectCacheControl(body)
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -551,11 +551,17 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			// Mid-retry failure — the request will be retried with another credential.
 			// The final failure (if all attempts fail) is logged at ERROR when the
 			// response is written to the client.
-			p.logger.WarnContext(r.Context(), "Proxy credential returned retryable error, will retry",
+			retryLogArgs := []any{
 				"error_code", proxyResp.StatusCode, "credential", cred.Name,
 				"reason", retryReason, "model", modelID,
-				"attempt", attempt+1, "max_attempts", p.maxProviderRetries+1,
-				"response_body", logger.TruncateLongFields(string(proxyResp.Body), 500))
+				"attempt", attempt + 1, "max_attempts", p.maxProviderRetries + 1,
+			}
+			if shouldMaskUpstreamErrors(cred) {
+				retryLogArgs = append(retryLogArgs, "response_body_masked", true)
+			} else {
+				retryLogArgs = append(retryLogArgs, "response_body", logger.TruncateLongFields(string(proxyResp.Body), 500))
+			}
+			p.logger.WarnContext(r.Context(), "Proxy credential returned retryable error, will retry", retryLogArgs...)
 		}
 
 		// After retry loop: try fallback proxy as last resort
@@ -1001,8 +1007,12 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			proxyReq.Header.Set("Authorization", "Bearer "+vertexToken)
 		case config.ProviderTypeGemini:
 			proxyReq.Header.Set("x-goog-api-key", cred.APIKey)
-		case config.ProviderTypeAnthropic:
-			proxyReq.Header.Set("X-Api-Key", cred.APIKey)
+		case config.ProviderTypeAnthropic, config.ProviderTypeCometAPI:
+			if cred.AuthType == "bearer" {
+				proxyReq.Header.Set("Authorization", "Bearer "+cred.APIKey)
+			} else {
+				proxyReq.Header.Set("X-Api-Key", cred.APIKey)
+			}
 			proxyReq.Header.Set("anthropic-version", "2023-06-01")
 		case config.ProviderTypeBedrock:
 			proxyReq.Header.Set("Authorization", "Bearer "+cred.APIKey)
@@ -1117,11 +1127,17 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		// Mid-retry failure — the request will be retried with another credential.
 		// The final failure (if all attempts fail) is logged at ERROR when the
 		// response is written to the client.
-		p.logger.WarnContext(r.Context(), "Provider returned retryable error, will retry",
+		retryLogArgs := []any{
 			"error_code", resp.StatusCode, "credential", cred.Name,
 			"reason", retryReason, "model", modelID,
-			"attempt", attempt+1, "max_attempts", p.maxProviderRetries+1,
-			"response_body", logger.TruncateLongFields(string(responseBody), 500))
+			"attempt", attempt + 1, "max_attempts", p.maxProviderRetries + 1,
+		}
+		if shouldMaskUpstreamErrors(cred) {
+			retryLogArgs = append(retryLogArgs, "response_body_masked", true)
+		} else {
+			retryLogArgs = append(retryLogArgs, "response_body", logger.TruncateLongFields(string(responseBody), 500))
+		}
+		p.logger.WarnContext(r.Context(), "Provider returned retryable error, will retry", retryLogArgs...)
 	}
 
 	// After retry loop: try proxy fallback as last resort
@@ -1199,11 +1215,13 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		if resp.StatusCode >= 200 && resp.StatusCode < 300 && !prepared.nativeResponses && conv != nil && !conv.IsPassthrough() {
 			convertedBody, convErr := conv.ResponseTo([]byte(decodedBody))
 			if convErr != nil {
-				p.logger.ErrorContext(r.Context(), "Failed to transform provider response to OpenAI format",
+				args := []any{
 					"credential", cred.Name, "provider", string(cred.Type),
 					"model", modelID, "error", convErr,
 					"request_id", logCtx.RequestID,
-					"response_body", logger.TruncateLongFields(decodedBody, 500))
+				}
+				args = appendResponseBodyForLogs(args, cred, decodedBody)
+				p.logger.ErrorContext(r.Context(), "Failed to transform provider response to OpenAI format", args...)
 				finalResponseBody = []byte(decodedBody)
 			} else {
 				finalResponseBody = convertedBody
@@ -1226,11 +1244,13 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			// Native Responses converter: convert provider response → *responses.Response.
 			nativeResp, convErr := provResponses.ResponseTo([]byte(decodedBody), modelID)
 			if convErr != nil {
-				p.logger.ErrorContext(r.Context(), "Failed to convert native Responses API response",
+				args := []any{
 					"credential", cred.Name, "provider", string(cred.Type),
 					"model", modelID, "error", convErr,
 					"request_id", logCtx.RequestID,
-					"response_body", logger.TruncateLongFields(decodedBody, 500))
+				}
+				args = appendResponseBodyForLogs(args, cred, decodedBody)
+				p.logger.ErrorContext(r.Context(), "Failed to convert native Responses API response", args...)
 				// finalResponseBody already holds decodedBody — return as-is
 			} else {
 				applyResponsesMetadata(nativeResp, prepared.responsesMetadata)
@@ -1287,6 +1307,13 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		rawErrorBody := finalResponseBody
+		if resp.StatusCode >= 400 && shouldMaskUpstreamErrors(cred) {
+			finalResponseBody = maskedUpstreamErrorBody(resp.StatusCode)
+			bodyForTokenExtraction = finalResponseBody
+			resp.Header.Set("Content-Type", "application/json")
+		}
+
 		tokens := extractTokensFromResponse(string(bodyForTokenExtraction), config.ProviderTypeOpenAI)
 		if tokens > 0 {
 			p.rateLimiter.ConsumeTokens(cred.Name, tokens)
@@ -1298,9 +1325,16 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if p.logger.Enabled(context.Background(), slog.LevelDebug) {
-			p.logger.DebugContext(r.Context(), "Proxy response body",
-				"credential", cred.Name, "content_encoding", contentEncoding,
-				"body", logger.TruncateLongFields(string(finalResponseBody), 500))
+			if resp.StatusCode >= 400 && shouldMaskUpstreamErrors(cred) {
+				p.logger.DebugContext(r.Context(), "Proxy response body masked",
+					"credential", cred.Name,
+					"content_encoding", contentEncoding,
+					"status_code", resp.StatusCode)
+			} else {
+				p.logger.DebugContext(r.Context(), "Proxy response body",
+					"credential", cred.Name, "content_encoding", contentEncoding,
+					"body", logger.TruncateLongFields(string(finalResponseBody), 500))
+			}
 		}
 
 		resp.Body = io.NopCloser(bytes.NewReader(finalResponseBody))
@@ -1313,10 +1347,14 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 
 		if resp.StatusCode >= 400 {
 			logCtx.Status = "failure"
-			logCtx.ErrorMsg = extractErrorMessage(finalResponseBody)
+			if shouldMaskUpstreamErrors(cred) {
+				logCtx.ErrorMsg = "Upstream provider error"
+			} else {
+				logCtx.ErrorMsg = extractErrorMessage(finalResponseBody)
+			}
 			// Final error returned to the client — single unified ERROR record
 			// with everything needed for debugging.
-			p.logUpstreamError(r.Context(), "Upstream request completed with error status", resp.StatusCode, cred, modelID, finalResponseBody,
+			p.logUpstreamError(r.Context(), "Upstream request completed with error status", resp.StatusCode, cred, modelID, rawErrorBody,
 				"url", targetURL,
 				"request_id", logCtx.RequestID)
 		} else if logCtx.TokenUsage != nil {
@@ -1353,6 +1391,18 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			p.logUpstreamError(r.Context(), "Upstream returned error status on streaming response", resp.StatusCode, cred, modelID, nil,
 				"url", targetURL,
 				"request_id", logCtx.RequestID)
+			if shouldMaskUpstreamErrors(cred) {
+				body := maskedUpstreamErrorBody(resp.StatusCode)
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+				w.WriteHeader(resp.StatusCode)
+				_, _ = w.Write(body)
+				logCtx.Status = "failure"
+				logCtx.HTTPStatus = resp.StatusCode
+				logCtx.ErrorMsg = "Upstream provider error"
+				logCtx.TargetURL = targetURL
+				return
+			}
 		}
 		w.WriteHeader(resp.StatusCode)
 

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -144,10 +144,11 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 
 	// Build usage_object and additional_usage_values
 	promptTokensDetails := map[string]interface{}{
-		"text_tokens":   nil,
-		"audio_tokens":  0,
-		"image_tokens":  nil,
-		"cached_tokens": 0,
+		"text_tokens":           nil,
+		"audio_tokens":          0,
+		"image_tokens":          nil,
+		"cached_tokens":         0,
+		"cache_creation_tokens": 0,
 	}
 	completionTokensDetails := map[string]interface{}{
 		"text_tokens":                nil,
@@ -162,6 +163,7 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 	if usage != nil {
 		promptTokensDetails["audio_tokens"] = usage.AudioInputTokens
 		promptTokensDetails["cached_tokens"] = usage.CachedInputTokens
+		promptTokensDetails["cache_creation_tokens"] = usage.CacheCreationTokens
 		completionTokensDetails["audio_tokens"] = usage.AudioOutputTokens
 		completionTokensDetails["reasoning_tokens"] = usage.ReasoningTokens
 		completionTokensDetails["accepted_prediction_tokens"] = usage.AcceptedPredictionTokens
@@ -177,8 +179,9 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 
 	additionalUsage := map[string]interface{}{
 		"prompt_tokens_details": map[string]interface{}{
-			"audio_tokens":  promptTokensDetails["audio_tokens"],
-			"cached_tokens": promptTokensDetails["cached_tokens"],
+			"audio_tokens":          promptTokensDetails["audio_tokens"],
+			"cached_tokens":         promptTokensDetails["cached_tokens"],
+			"cache_creation_tokens": promptTokensDetails["cache_creation_tokens"],
 		},
 		"completion_tokens_details": map[string]interface{}{
 			"audio_tokens":               completionTokensDetails["audio_tokens"],

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -32,10 +32,50 @@ func (p *Proxy) logUpstreamError(ctx context.Context, msg string, errorCode int,
 	}
 	args = append(args, "model", modelID)
 	if len(responseBody) > 0 {
-		args = append(args, "response_body", logger.TruncateLongFields(string(responseBody), 500))
+		args = appendResponseBodyForLogs(args, cred, string(responseBody))
 	}
 	args = append(args, extra...)
 	p.logger.ErrorContext(ctx, msg, args...)
+}
+
+func appendResponseBodyForLogs(args []any, cred *config.CredentialConfig, body string) []any {
+	if shouldMaskUpstreamErrors(cred) {
+		return append(args, "response_body_masked", true)
+	}
+	return append(args, "response_body", logger.TruncateLongFields(body, 500))
+}
+
+func shouldMaskUpstreamErrors(cred *config.CredentialConfig) bool {
+	return isCometAPICredential(cred)
+}
+
+func isCometAPICredential(cred *config.CredentialConfig) bool {
+	if cred == nil {
+		return false
+	}
+	if cred.Type == config.ProviderTypeCometAPI {
+		return true
+	}
+	name := strings.ToLower(cred.Name)
+	return isCometAPIHost(cred.BaseURL) ||
+		strings.Contains(name, "cometapi") ||
+		strings.Contains(name, "comet-api")
+}
+
+func isCometAPIHost(rawBaseURL string) bool {
+	baseURL := strings.TrimSpace(rawBaseURL)
+	if baseURL == "" {
+		return false
+	}
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Hostname() == "" {
+		u, err = url.Parse("https://" + baseURL)
+		if err != nil {
+			return false
+		}
+	}
+	host := strings.TrimSuffix(strings.ToLower(u.Hostname()), ".")
+	return host == "cometapi.com" || strings.HasSuffix(host, ".cometapi.com")
 }
 
 // logStreamHandlerError logs a streaming handler failure. Client disconnects are

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -290,7 +290,9 @@ func (p *Proxy) handleProviderStreaming(
 	case config.ProviderTypeVertexAI, config.ProviderTypeGemini:
 		return p.handleVertexStreaming(w, resp, cred.Name, realModelID, displayModelID, logCtx)
 	case config.ProviderTypeAnthropic:
-		return p.handleAnthropicStreaming(w, resp, cred.Name, realModelID, displayModelID, logCtx)
+		return p.handleAnthropicCompatibleStreaming(w, resp, cred.Name, realModelID, displayModelID, cred.Type, "Anthropic", logCtx)
+	case config.ProviderTypeCometAPI:
+		return p.handleAnthropicCompatibleStreaming(w, resp, cred.Name, realModelID, displayModelID, cred.Type, "Comet API", logCtx)
 	case config.ProviderTypeBedrock:
 		return p.handleBedrockStreaming(w, resp, cred.Name, realModelID, displayModelID, logCtx)
 	default:
@@ -306,12 +308,12 @@ func (p *Proxy) handleVertexStreaming(w http.ResponseWriter, resp *http.Response
 	return p.handleTransformedStreaming(w, resp, credName, modelID, "Vertex AI", transformer, logCtx)
 }
 
-func (p *Proxy) handleAnthropicStreaming(w http.ResponseWriter, resp *http.Response, credName, modelID, displayModelID string, logCtx *RequestLogContext) error {
-	conv := converter.New(config.ProviderTypeAnthropic, converter.RequestMode{ModelID: modelID, DisplayModelID: displayModelID, IsStreaming: true})
+func (p *Proxy) handleAnthropicCompatibleStreaming(w http.ResponseWriter, resp *http.Response, credName, modelID, displayModelID string, providerType config.ProviderType, providerLabel string, logCtx *RequestLogContext) error {
+	conv := converter.New(providerType, converter.RequestMode{ModelID: modelID, DisplayModelID: displayModelID, IsStreaming: true})
 	transformer := func(r io.Reader, id string, w io.Writer) error {
 		return conv.StreamTo(r, w)
 	}
-	return p.handleTransformedStreaming(w, resp, credName, modelID, "Anthropic", transformer, logCtx)
+	return p.handleTransformedStreaming(w, resp, credName, modelID, providerLabel, transformer, logCtx)
 }
 
 func (p *Proxy) handleBedrockStreaming(w http.ResponseWriter, resp *http.Response, credName, modelID, displayModelID string, logCtx *RequestLogContext) error {

--- a/tests/vertex/test_thinking.py
+++ b/tests/vertex/test_thinking.py
@@ -384,7 +384,7 @@ class TestThinkingStreaming:
 
 
 # ---------------------------------------------------------------------------
-# Nullable JSON schema — from debug_nullable_vsellm.txt
+# Nullable JSON schema debug fixture
 # ---------------------------------------------------------------------------
 
 _PERSON_ANYOF_SCHEMA = {
@@ -494,7 +494,7 @@ _ENUM_PROMPT = (
 class TestNullableJsonSchema:
     """Nullable fields in JSON schema — critical correctness tests.
 
-    From debug_nullable_vsellm.txt:
+    From nullable JSON schema debug fixture:
     - anyOf [{type:string}, {type:null}] → model returns proper JSON null
     - nullable:true (deprecated) → model may return "null" string instead of null
     """


### PR DESCRIPTION
Добавляем алиасы для Comet API моделей
Чтобы клиентские имена совпадали с VSELLM (anthropic/claude-sonnet-4.5, claude-sonnet-4.5), а в Comet уходили реальные model IDs (claude-sonnet-4-5-20250929).

Поддерживаем Comet API как отдельный провайдер
Чтобы не завязываться на эвристики “это Anthropic, но base_url похож на Comet”. Теперь у Comet свой type: cometapi

Добавили маскирование ошибок
Чтобы raw upstream error body от Comet не возвращался клиентам и не попадал в логи, при этом HTTP status сохраняется.