### PR TITLE
Fix chat image response format

### DIFF
--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -116,6 +116,8 @@ type OpenAIToolFunction struct {
 }
 
 type ImageData struct {
+	Type     string    `json:"type,omitempty"`
+	Index    *int      `json:"index,omitempty"`
 	B64JSON  string    `json:"b64_json,omitempty"`
 	ImageURL *ImageURL `json:"image_url,omitempty"`
 }

--- a/internal/converter/vertex/response.go
+++ b/internal/converter/vertex/response.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 
 	converterutil "github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
@@ -45,10 +46,9 @@ func VertexToOpenAI(vertexBody []byte, model string) ([]byte, error) {
 				}
 				// Handle inline data (images) from Vertex response
 				if part.InlineData != nil {
-					b64Data := base64.StdEncoding.EncodeToString(part.InlineData.Data)
-					images = append(images, openai.ImageData{
-						B64JSON: b64Data,
-					})
+					if imageData, ok := inlineDataToChatImage(len(images), part.InlineData); ok {
+						images = append(images, imageData)
+					}
 				}
 				// Handle function calls from Vertex response
 				if part.FunctionCall != nil {
@@ -126,6 +126,25 @@ func VertexToOpenAI(vertexBody []byte, model string) ([]byte, error) {
 		openAIResp.Usage = convertVertexUsageMetadata(vertexResp.UsageMetadata)
 	}
 	return json.Marshal(openAIResp)
+}
+
+func inlineDataToChatImage(index int, blob *genai.Blob) (openai.ImageData, bool) {
+	mimeType := blob.MIMEType
+	if mimeType == "" {
+		mimeType = http.DetectContentType(blob.Data)
+	}
+	if !strings.HasPrefix(strings.ToLower(mimeType), "image/") {
+		return openai.ImageData{}, false
+	}
+
+	b64Data := base64.StdEncoding.EncodeToString(blob.Data)
+	return openai.ImageData{
+		Type:  "image_url",
+		Index: &index,
+		ImageURL: &openai.ImageURL{
+			URL: "data:" + mimeType + ";base64," + b64Data,
+		},
+	}, true
 }
 
 // convertVertexUsageMetadata converts Vertex AI usage metadata to OpenAI format.

--- a/internal/converter/vertex/response_test.go
+++ b/internal/converter/vertex/response_test.go
@@ -2,6 +2,7 @@ package vertex
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
@@ -44,6 +45,65 @@ func TestConvertVertexUsageMetadata_WithThoughtsTokens(t *testing.T) {
 	}
 	if usage.CompletionTokensDetails.ReasoningTokens != 200 {
 		t.Fatalf("expected ReasoningTokens = 200, got %d", usage.CompletionTokensDetails.ReasoningTokens)
+	}
+}
+
+func TestVertexToOpenAI_ImageUsesChatImageURLShape(t *testing.T) {
+	vertexResp := genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Parts: []*genai.Part{
+						{Text: "created"},
+						{InlineData: &genai.Blob{Data: []byte("img"), MIMEType: "image/png"}},
+					},
+				},
+			},
+		},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     12,
+			CandidatesTokenCount: 1183,
+			ThoughtsTokenCount:   12,
+		},
+	}
+
+	vertexBytes, err := json.Marshal(vertexResp)
+	if err != nil {
+		t.Fatalf("marshal vertex response: %v", err)
+	}
+
+	resultBytes, err := VertexToOpenAI(vertexBytes, "gemini-3-pro-image-preview")
+	if err != nil {
+		t.Fatalf("VertexToOpenAI error: %v", err)
+	}
+
+	var openAIResp openai.OpenAIResponse
+	if err := json.Unmarshal(resultBytes, &openAIResp); err != nil {
+		t.Fatalf("unmarshal OpenAI response: %v", err)
+	}
+
+	if len(openAIResp.Choices) != 1 {
+		t.Fatalf("expected 1 choice, got %d", len(openAIResp.Choices))
+	}
+	images := openAIResp.Choices[0].Message.Images
+	if len(images) != 1 {
+		t.Fatalf("expected 1 image, got %d", len(images))
+	}
+	image := images[0]
+	if image.Type != "image_url" {
+		t.Fatalf("expected image type image_url, got %q", image.Type)
+	}
+	if image.Index == nil || *image.Index != 0 {
+		t.Fatalf("expected image index 0, got %v", image.Index)
+	}
+	if image.ImageURL == nil || image.ImageURL.URL != "data:image/png;base64,aW1n" {
+		t.Fatalf("unexpected image_url: %+v", image.ImageURL)
+	}
+	if image.B64JSON != "" {
+		t.Fatalf("chat images must not use b64_json, got %q", image.B64JSON)
+	}
+	if strings.Contains(string(resultBytes), `"b64_json"`) {
+		t.Fatalf("chat response must not contain b64_json: %s", string(resultBytes))
 	}
 }
 


### PR DESCRIPTION
## What changed

- Return Gemini chat-generated images as OpenAI-compatible `message.images[].image_url` data URLs.
- Keep `/v1/images/generations` responses unchanged with `data[].b64_json`.
- Add a regression test for the LiteLLM-compatible chat image shape.

## Why

LiteLLM expects chat completion images to contain `type`, `index`, and `image_url.url`. AIR was returning `message.images[].b64_json`, which is valid for image generation responses but invalid for chat messages. LiteLLM then failed while building its `Message` object after the provider call had already succeeded, causing a 500 with zero billed cost.

## Checks

- `go test ./internal/converter/vertex ./internal/converter`
- `go test ./...`
- `make lint`
