### PR TITLE
Support GPT-5.6 cache writes

### DIFF
--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -57,27 +57,27 @@ For reference:
 
 ### Available fields
 
-| Field                                     | Description                                                                  |
-| ----------------------------------------- | ---------------------------------------------------------------------------- |
-| `input_cost_per_token`                    | Regular input tokens                                                         |
-| `output_cost_per_token`                   | Regular output tokens                                                        |
-| `input_cost_per_token_above_200k_tokens`  | Input rate for tokens beyond the 200k threshold                              |
-| `output_cost_per_token_above_200k_tokens` | Output rate for tokens beyond the 200k threshold                             |
-| `input_cost_per_token_above_272k_tokens`  | Full-session input rate when prompt exceeds 272k tokens                       |
-| `output_cost_per_token_above_272k_tokens` | Full-session output rate when prompt exceeds 272k tokens                      |
-| `input_cost_per_audio_token`              | Audio input tokens (falls back to `input_cost_per_token` if absent)          |
-| `output_cost_per_audio_token`             | Audio output tokens (falls back to `output_cost_per_token` if absent)        |
-| `input_cost_per_image_token`              | Image input tokens                                                           |
-| `output_cost_per_image_token`             | Image output tokens                                                          |
-| `output_cost_per_reasoning_token`         | Reasoning/thinking tokens (falls back to `output_cost_per_token`)            |
-| `input_cost_per_cached_token`             | Cached prompt read cost (alias: `cache_read_input_token_cost`)               |
-| `cache_read_input_token_cost`             | LiteLLM-compatible alias for `input_cost_per_cached_token`                   |
-| `cache_creation_input_token_cost`         | Prompt cache write cost (falls back to `input_cost_per_token`)                |
-| `cache_read_input_token_cost_above_272k_tokens` | Full-session cache read rate when prompt exceeds 272k tokens            |
-| `cache_creation_input_token_cost_above_272k_tokens` | Full-session cache write rate when prompt exceeds 272k tokens       |
-| `output_cost_per_cached_token`            | Cached output tokens (falls back to `output_cost_per_token`)                 |
-| `output_cost_per_prediction_token`        | Accepted predicted-output tokens (falls back to `output_cost_per_token`)     |
-| `output_cost_per_image`                   | Cost per generated image (takes priority over `output_cost_per_image_token`) |
+| Field                                               | Description                                                                  |
+| --------------------------------------------------- | ---------------------------------------------------------------------------- |
+| `input_cost_per_token`                              | Regular input tokens                                                         |
+| `output_cost_per_token`                             | Regular output tokens                                                        |
+| `input_cost_per_token_above_200k_tokens`            | Input rate for tokens beyond the 200k threshold                              |
+| `output_cost_per_token_above_200k_tokens`           | Output rate for tokens beyond the 200k threshold                             |
+| `input_cost_per_token_above_272k_tokens`            | Full-session input rate when prompt exceeds 272k tokens                      |
+| `output_cost_per_token_above_272k_tokens`           | Full-session output rate when prompt exceeds 272k tokens                     |
+| `input_cost_per_audio_token`                        | Audio input tokens (falls back to `input_cost_per_token` if absent)          |
+| `output_cost_per_audio_token`                       | Audio output tokens (falls back to `output_cost_per_token` if absent)        |
+| `input_cost_per_image_token`                        | Image input tokens                                                           |
+| `output_cost_per_image_token`                       | Image output tokens                                                          |
+| `output_cost_per_reasoning_token`                   | Reasoning/thinking tokens (falls back to `output_cost_per_token`)            |
+| `input_cost_per_cached_token`                       | Cached prompt read cost (alias: `cache_read_input_token_cost`)               |
+| `cache_read_input_token_cost`                       | LiteLLM-compatible alias for `input_cost_per_cached_token`                   |
+| `cache_creation_input_token_cost`                   | Prompt cache write cost (falls back to `input_cost_per_token`)               |
+| `cache_read_input_token_cost_above_272k_tokens`     | Full-session cache read rate when prompt exceeds 272k tokens                 |
+| `cache_creation_input_token_cost_above_272k_tokens` | Full-session cache write rate when prompt exceeds 272k tokens                |
+| `output_cost_per_cached_token`                      | Cached output tokens (falls back to `output_cost_per_token`)                 |
+| `output_cost_per_prediction_token`                  | Accepted predicted-output tokens (falls back to `output_cost_per_token`)     |
+| `output_cost_per_image`                             | Cost per generated image (takes priority over `output_cost_per_image_token`) |
 
 ## Cost Calculation
 

--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -63,6 +63,8 @@ For reference:
 | `output_cost_per_token`                   | Regular output tokens                                                        |
 | `input_cost_per_token_above_200k_tokens`  | Input rate for tokens beyond the 200k threshold                              |
 | `output_cost_per_token_above_200k_tokens` | Output rate for tokens beyond the 200k threshold                             |
+| `input_cost_per_token_above_272k_tokens`  | Full-session input rate when prompt exceeds 272k tokens                       |
+| `output_cost_per_token_above_272k_tokens` | Full-session output rate when prompt exceeds 272k tokens                      |
 | `input_cost_per_audio_token`              | Audio input tokens (falls back to `input_cost_per_token` if absent)          |
 | `output_cost_per_audio_token`             | Audio output tokens (falls back to `output_cost_per_token` if absent)        |
 | `input_cost_per_image_token`              | Image input tokens                                                           |
@@ -71,6 +73,8 @@ For reference:
 | `input_cost_per_cached_token`             | Cached prompt read cost (alias: `cache_read_input_token_cost`)               |
 | `cache_read_input_token_cost`             | LiteLLM-compatible alias for `input_cost_per_cached_token`                   |
 | `cache_creation_input_token_cost`         | Prompt cache write cost (falls back to `input_cost_per_token`)                |
+| `cache_read_input_token_cost_above_272k_tokens` | Full-session cache read rate when prompt exceeds 272k tokens            |
+| `cache_creation_input_token_cost_above_272k_tokens` | Full-session cache write rate when prompt exceeds 272k tokens       |
 | `output_cost_per_cached_token`            | Cached output tokens (falls back to `output_cost_per_token`)                 |
 | `output_cost_per_prediction_token`        | Accepted predicted-output tokens (falls back to `output_cost_per_token`)     |
 | `output_cost_per_image`                   | Cost per generated image (takes priority over `output_cost_per_image_token`) |
@@ -139,6 +143,10 @@ input_cost = regular_below × input_cost_per_token
 ```
 
 The same logic applies to output tokens using `output_cost_per_token_above_200k_tokens`.
+
+### Long-context pricing (272k threshold)
+
+When the prompt exceeds 272 000 tokens, models such as GPT-5.6 apply their `*_above_272k_tokens` rates to the full session rather than only the tokens beyond the threshold. The prompt size selects the tier for regular input, output, cache reads, and cache writes. At exactly 272 000 tokens, base rates still apply.
 
 ### Specialised token types
 

--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -70,7 +70,7 @@ For reference:
 | `output_cost_per_reasoning_token`         | Reasoning/thinking tokens (falls back to `output_cost_per_token`)            |
 | `input_cost_per_cached_token`             | Cached prompt read cost (alias: `cache_read_input_token_cost`)               |
 | `cache_read_input_token_cost`             | LiteLLM-compatible alias for `input_cost_per_cached_token`                   |
-| `cache_creation_input_token_cost`         | Anthropic cache write cost (falls back to `input_cost_per_token`)            |
+| `cache_creation_input_token_cost`         | Prompt cache write cost (falls back to `input_cost_per_token`)                |
 | `output_cost_per_cached_token`            | Cached output tokens (falls back to `output_cost_per_token`)                 |
 | `output_cost_per_prediction_token`        | Accepted predicted-output tokens (falls back to `output_cost_per_token`)     |
 | `output_cost_per_image`                   | Cost per generated image (takes priority over `output_cost_per_image_token`) |
@@ -81,7 +81,7 @@ All providers return specialised token counts as **subsets** of the totals:
 
 - `prompt_tokens` (Vertex AI, OpenAI) already includes `audio_input_tokens`, `cached_input_tokens`
 - `completion_tokens` (all providers) already includes `reasoning_tokens`, `audio_output_tokens`, prediction tokens
-- Anthropic is the exception: `cached_input_tokens` and `cache_creation_tokens` are reported **separately** and are not included in `prompt_tokens`
+- Anthropic reports cache tokens separately; OpenAI-compatible APIs report them in prompt/input token details
 
 To avoid billing the same tokens at two different rates, the calculator first computes **regular** (base-rate) token counts by subtracting all specialised sub-types, then adds each sub-type back at its own rate:
 
@@ -170,6 +170,8 @@ Loading is handled by `internal/models/price_loader.go`:
 ### DB price merging
 
 When the LiteLLM database is enabled, prices defined in `LiteLLM_ModelTable` are merged on top of the file-based registry via `MergeDB`. Database prices take precedence for any model that appears in both sources. The file-based prices remain intact for all other models.
+
+Cache writes are read from `cache_creation_tokens` or the OpenAI-compatible `cache_write_tokens` alias in both Chat Completions and Responses API usage objects.
 
 ### Lookup
 

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -324,10 +324,12 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		InputTokens        int `json:"input_tokens"`
 		OutputTokens       int `json:"output_tokens"`
 		InputTokensDetails struct {
-			CachedTokens int `json:"cached_tokens,omitempty"`
-			ImageTokens  int `json:"image_tokens,omitempty"`
-			TextTokens   int `json:"text_tokens,omitempty"`
-			AudioTokens  int `json:"audio_tokens,omitempty"`
+			CachedTokens        int `json:"cached_tokens,omitempty"`
+			CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+			CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
+			ImageTokens         int `json:"image_tokens,omitempty"`
+			TextTokens          int `json:"text_tokens,omitempty"`
+			AudioTokens         int `json:"audio_tokens,omitempty"`
 		} `json:"input_tokens_details,omitempty"`
 		OutputTokensDetails struct {
 			AudioTokens     int `json:"audio_tokens,omitempty"`
@@ -343,6 +345,7 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 			PromptTokensDetails struct {
 				CachedTokens        int `json:"cached_tokens,omitempty"`
 				CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+				CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
 				AudioTokens         int `json:"audio_tokens,omitempty"`
 				TextTokens          int `json:"text_tokens,omitempty"`
 			} `json:"prompt_tokens_details,omitempty"`
@@ -392,6 +395,15 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		cachedTokens = resp.Usage.InputTokensDetails.CachedTokens
 	}
 	cacheCreationTokens := resp.Usage.PromptTokensDetails.CacheCreationTokens
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = resp.Usage.PromptTokensDetails.CacheWriteTokens
+	}
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = resp.Usage.InputTokensDetails.CacheCreationTokens
+	}
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = resp.Usage.InputTokensDetails.CacheWriteTokens
+	}
 	audioIn := resp.Usage.PromptTokensDetails.AudioTokens
 	if audioIn == 0 {
 		audioIn = resp.Usage.InputTokensDetails.AudioTokens
@@ -410,6 +422,12 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		u := resp.Response.Usage
 		if cachedTokens == 0 {
 			cachedTokens = u.InputTokensDetails.CachedTokens
+		}
+		if cacheCreationTokens == 0 {
+			cacheCreationTokens = u.InputTokensDetails.CacheCreationTokens
+		}
+		if cacheCreationTokens == 0 {
+			cacheCreationTokens = u.InputTokensDetails.CacheWriteTokens
 		}
 		if audioIn == 0 {
 			audioIn = u.InputTokensDetails.AudioTokens

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -538,6 +538,35 @@ func TestExtractTokenUsage_ResponsesAPI(t *testing.T) {
 	}
 }
 
+func TestExtractTokenUsage_CacheWriteTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "chat completions alias",
+			body: `{"usage":{"prompt_tokens":100,"completion_tokens":10,"prompt_tokens_details":{"cache_write_tokens":60}}}`,
+		},
+		{
+			name: "responses API canonical field",
+			body: `{"usage":{"input_tokens":100,"output_tokens":10,"input_tokens_details":{"cache_creation_tokens":60}}}`,
+		},
+		{
+			name: "responses API streaming alias",
+			body: `{"type":"response.completed","response":{"usage":{"input_tokens":100,"output_tokens":10,"input_tokens_details":{"cache_write_tokens":60}}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			usage := ExtractTokenUsage([]byte(tt.body))
+			if usage == nil || usage.CacheCreationTokens != 60 {
+				t.Fatalf("unexpected cache creation usage: %+v", usage)
+			}
+		})
+	}
+}
+
 func TestExtractTokenUsage_ResponsesAPIStreamingEvent(t *testing.T) {
 	// Responses API streaming event format: response.completed SSE event
 	// Usage is nested inside response.usage, not at top level

--- a/internal/litellmdb/model_table/model_table.go
+++ b/internal/litellmdb/model_table/model_table.go
@@ -400,6 +400,12 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	if p.OutputCostPerTokenAbove200kTokens != nil {
 		price.OutputCostPerTokenAbove200k = *p.OutputCostPerTokenAbove200kTokens
 	}
+	if p.InputCostPerTokenAbove272kTokens != nil {
+		price.InputCostPerTokenAbove272k = *p.InputCostPerTokenAbove272kTokens
+	}
+	if p.OutputCostPerTokenAbove272kTokens != nil {
+		price.OutputCostPerTokenAbove272k = *p.OutputCostPerTokenAbove272kTokens
+	}
 	if p.InputCostPerAudioToken != nil {
 		price.InputCostPerAudioToken = *p.InputCostPerAudioToken
 	}
@@ -414,6 +420,12 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	}
 	if p.CacheCreationInputTokenCost != nil {
 		price.CacheCreationInputTokenCost = *p.CacheCreationInputTokenCost
+	}
+	if p.CacheReadInputTokenCostAbove272kTokens != nil {
+		price.CacheReadInputTokenCostAbove272k = *p.CacheReadInputTokenCostAbove272kTokens
+	}
+	if p.CacheCreationInputTokenCostAbove272kTokens != nil {
+		price.CacheCreationInputTokenCostAbove272k = *p.CacheCreationInputTokenCostAbove272kTokens
 	}
 	if p.OutputCostPerImage != nil {
 		price.OutputCostPerImage = *p.OutputCostPerImage

--- a/internal/litellmdb/model_table/model_table.go
+++ b/internal/litellmdb/model_table/model_table.go
@@ -412,6 +412,9 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	if p.CacheReadInputTokenCost != nil {
 		price.InputCostPerCachedToken = *p.CacheReadInputTokenCost
 	}
+	if p.CacheCreationInputTokenCost != nil {
+		price.CacheCreationInputTokenCost = *p.CacheCreationInputTokenCost
+	}
 	if p.OutputCostPerImage != nil {
 		price.OutputCostPerImage = *p.OutputCostPerImage
 	}

--- a/internal/litellmdb/model_table/model_table_test.go
+++ b/internal/litellmdb/model_table/model_table_test.go
@@ -120,6 +120,7 @@ func TestConvertPricingToModelPrice(t *testing.T) {
 	output := 0.02
 	outputReasoning := 0.03
 	cacheRead := 0.04
+	cacheCreation := 0.05
 	outputImage := 0.5
 	outputImageToken := 0.6
 	inputAbove200k := 0.07
@@ -129,6 +130,7 @@ func TestConvertPricingToModelPrice(t *testing.T) {
 		OutputCostPerToken:                &output,
 		OutputCostPerReasoningToken:       &outputReasoning,
 		CacheReadInputTokenCost:           &cacheRead,
+		CacheCreationInputTokenCost:       &cacheCreation,
 		OutputCostPerImage:                &outputImage,
 		OutputCostPerImageToken:           &outputImageToken,
 		InputCostPerTokenAbove200kTokens:  &inputAbove200k,
@@ -140,6 +142,7 @@ func TestConvertPricingToModelPrice(t *testing.T) {
 	assert.Equal(t, output, price.OutputCostPerToken)
 	assert.Equal(t, outputReasoning, price.OutputCostPerReasoningToken)
 	assert.Equal(t, cacheRead, price.InputCostPerCachedToken)
+	assert.Equal(t, cacheCreation, price.CacheCreationInputTokenCost)
 	assert.Equal(t, outputImage, price.OutputCostPerImage)
 	assert.Equal(t, outputImageToken, price.OutputCostPerImageToken)
 	assert.Equal(t, inputAbove200k, price.InputCostPerTokenAbove200k)
@@ -157,6 +160,7 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	outputAudio := 0.06
 	outputReasoning := 0.07
 	cacheRead := 0.08
+	cacheCreation := 0.085
 	outputImage := 0.09
 	outputImageToken := 0.10
 
@@ -169,6 +173,7 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 		OutputCostPerAudioToken:           &outputAudio,
 		OutputCostPerReasoningToken:       &outputReasoning,
 		CacheReadInputTokenCost:           &cacheRead,
+		CacheCreationInputTokenCost:       &cacheCreation,
 		OutputCostPerImage:                &outputImage,
 		OutputCostPerImageToken:           &outputImageToken,
 	})
@@ -182,6 +187,7 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	assert.Equal(t, outputAudio, price.OutputCostPerAudioToken)
 	assert.Equal(t, outputReasoning, price.OutputCostPerReasoningToken)
 	assert.Equal(t, cacheRead, price.InputCostPerCachedToken)
+	assert.Equal(t, cacheCreation, price.CacheCreationInputTokenCost)
 	assert.Equal(t, outputImage, price.OutputCostPerImage)
 	assert.Equal(t, outputImageToken, price.OutputCostPerImageToken)
 }

--- a/internal/litellmdb/model_table/model_table_test.go
+++ b/internal/litellmdb/model_table/model_table_test.go
@@ -156,26 +156,34 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	output := 0.02
 	inputAbove200k := 0.03
 	outputAbove200k := 0.04
+	inputAbove272k := 0.045
+	outputAbove272k := 0.047
 	inputAudio := 0.05
 	outputAudio := 0.06
 	outputReasoning := 0.07
 	cacheRead := 0.08
 	cacheCreation := 0.085
+	cacheReadAbove272k := 0.086
+	cacheCreationAbove272k := 0.087
 	outputImage := 0.09
 	outputImageToken := 0.10
 
 	price := convertPricingToModelPrice(&queries.CustomPricingLiteLLMParams{
-		InputCostPerToken:                 &input,
-		OutputCostPerToken:                &output,
-		InputCostPerTokenAbove200kTokens:  &inputAbove200k,
-		OutputCostPerTokenAbove200kTokens: &outputAbove200k,
-		InputCostPerAudioToken:            &inputAudio,
-		OutputCostPerAudioToken:           &outputAudio,
-		OutputCostPerReasoningToken:       &outputReasoning,
-		CacheReadInputTokenCost:           &cacheRead,
-		CacheCreationInputTokenCost:       &cacheCreation,
-		OutputCostPerImage:                &outputImage,
-		OutputCostPerImageToken:           &outputImageToken,
+		InputCostPerToken:                          &input,
+		OutputCostPerToken:                         &output,
+		InputCostPerTokenAbove200kTokens:           &inputAbove200k,
+		OutputCostPerTokenAbove200kTokens:          &outputAbove200k,
+		InputCostPerTokenAbove272kTokens:           &inputAbove272k,
+		OutputCostPerTokenAbove272kTokens:          &outputAbove272k,
+		InputCostPerAudioToken:                     &inputAudio,
+		OutputCostPerAudioToken:                    &outputAudio,
+		OutputCostPerReasoningToken:                &outputReasoning,
+		CacheReadInputTokenCost:                    &cacheRead,
+		CacheCreationInputTokenCost:                &cacheCreation,
+		CacheReadInputTokenCostAbove272kTokens:     &cacheReadAbove272k,
+		CacheCreationInputTokenCostAbove272kTokens: &cacheCreationAbove272k,
+		OutputCostPerImage:                         &outputImage,
+		OutputCostPerImageToken:                    &outputImageToken,
 	})
 
 	assert.NotNil(t, price)
@@ -183,11 +191,15 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	assert.Equal(t, output, price.OutputCostPerToken)
 	assert.Equal(t, inputAbove200k, price.InputCostPerTokenAbove200k)
 	assert.Equal(t, outputAbove200k, price.OutputCostPerTokenAbove200k)
+	assert.Equal(t, inputAbove272k, price.InputCostPerTokenAbove272k)
+	assert.Equal(t, outputAbove272k, price.OutputCostPerTokenAbove272k)
 	assert.Equal(t, inputAudio, price.InputCostPerAudioToken)
 	assert.Equal(t, outputAudio, price.OutputCostPerAudioToken)
 	assert.Equal(t, outputReasoning, price.OutputCostPerReasoningToken)
 	assert.Equal(t, cacheRead, price.InputCostPerCachedToken)
 	assert.Equal(t, cacheCreation, price.CacheCreationInputTokenCost)
+	assert.Equal(t, cacheReadAbove272k, price.CacheReadInputTokenCostAbove272k)
+	assert.Equal(t, cacheCreationAbove272k, price.CacheCreationInputTokenCostAbove272k)
 	assert.Equal(t, outputImage, price.OutputCostPerImage)
 	assert.Equal(t, outputImageToken, price.OutputCostPerImageToken)
 }

--- a/internal/litellmdb/queries/model_table.go
+++ b/internal/litellmdb/queries/model_table.go
@@ -10,18 +10,22 @@ type CustomPricingLiteLLMParams struct {
 	OutputCostPerToken                *float64 `json:"output_cost_per_token,omitempty"`
 	OutputCostPerTokenAbove128kTokens *float64 `json:"output_cost_per_token_above_128k_tokens,omitempty"`
 	OutputCostPerTokenAbove200kTokens *float64 `json:"output_cost_per_token_above_200k_tokens,omitempty"`
+	OutputCostPerTokenAbove272kTokens *float64 `json:"output_cost_per_token_above_272k_tokens,omitempty"`
 
 	InputCostPerSecond  *float64 `json:"input_cost_per_second,omitempty"`
 	OutputCostPerSecond *float64 `json:"output_cost_per_second,omitempty"`
 
 	// Гибкие настройки стоимости (Flex/Priority/Cache)
-	CacheReadInputTokenCost                *float64 `json:"cache_read_input_token_cost,omitempty"`
-	CacheCreationInputTokenCost            *float64 `json:"cache_creation_input_token_cost,omitempty"`
-	CacheReadInputTokenCostAbove200kTokens *float64 `json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
-	CacheReadInputAudioTokenCost           *float64 `json:"cache_read_input_audio_token_cost,omitempty"`
+	CacheReadInputTokenCost                    *float64 `json:"cache_read_input_token_cost,omitempty"`
+	CacheCreationInputTokenCost                *float64 `json:"cache_creation_input_token_cost,omitempty"`
+	CacheReadInputTokenCostAbove200kTokens     *float64 `json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove272kTokens     *float64 `json:"cache_read_input_token_cost_above_272k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove272kTokens *float64 `json:"cache_creation_input_token_cost_above_272k_tokens,omitempty"`
+	CacheReadInputAudioTokenCost               *float64 `json:"cache_read_input_audio_token_cost,omitempty"`
 
 	InputCostPerTokenAbove128kTokens *float64 `json:"input_cost_per_token_above_128k_tokens,omitempty"`
 	InputCostPerTokenAbove200kTokens *float64 `json:"input_cost_per_token_above_200k_tokens,omitempty"`
+	InputCostPerTokenAbove272kTokens *float64 `json:"input_cost_per_token_above_272k_tokens,omitempty"`
 
 	InputCostPerAudioToken                    *float64 `json:"input_cost_per_audio_token,omitempty"`
 	InputCostPerAudioPerSecond                *float64 `json:"input_cost_per_audio_per_second,omitempty"`

--- a/internal/litellmdb/queries/model_table.go
+++ b/internal/litellmdb/queries/model_table.go
@@ -16,6 +16,7 @@ type CustomPricingLiteLLMParams struct {
 
 	// Гибкие настройки стоимости (Flex/Priority/Cache)
 	CacheReadInputTokenCost                *float64 `json:"cache_read_input_token_cost,omitempty"`
+	CacheCreationInputTokenCost            *float64 `json:"cache_creation_input_token_cost,omitempty"`
 	CacheReadInputTokenCostAbove200kTokens *float64 `json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
 	CacheReadInputAudioTokenCost           *float64 `json:"cache_read_input_audio_token_cost,omitempty"`
 

--- a/internal/litellmdb/queries/queries_test.go
+++ b/internal/litellmdb/queries/queries_test.go
@@ -93,8 +93,10 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 	outputCost := 0.00003
 	inputAbove128k := 0.000008
 	inputAbove200k := 0.000005
+	inputAbove272k := 0.00001
 	outputAbove128k := 0.000024
 	outputAbove200k := 0.000015
+	outputAbove272k := 0.000045
 
 	inputCostPerSecond := 0.0001
 	outputCostPerSecond := 0.0003
@@ -102,6 +104,8 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 	cacheReadInput := 0.000001
 	cacheCreationInput := 0.00000125
 	cacheReadInputAbove200k := 0.0000008
+	cacheReadInputAbove272k := 0.000001
+	cacheCreationInputAbove272k := 0.0000125
 
 	inputAudio := 0.000006
 	inputAudioPerSecond := 0.00006
@@ -125,13 +129,17 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 		OutputCostPerToken:                         &outputCost,
 		InputCostPerTokenAbove128kTokens:           &inputAbove128k,
 		InputCostPerTokenAbove200kTokens:           &inputAbove200k,
+		InputCostPerTokenAbove272kTokens:           &inputAbove272k,
 		OutputCostPerTokenAbove128kTokens:          &outputAbove128k,
 		OutputCostPerTokenAbove200kTokens:          &outputAbove200k,
+		OutputCostPerTokenAbove272kTokens:          &outputAbove272k,
 		InputCostPerSecond:                         &inputCostPerSecond,
 		OutputCostPerSecond:                        &outputCostPerSecond,
 		CacheReadInputTokenCost:                    &cacheReadInput,
 		CacheCreationInputTokenCost:                &cacheCreationInput,
 		CacheReadInputTokenCostAbove200kTokens:     &cacheReadInputAbove200k,
+		CacheReadInputTokenCostAbove272kTokens:     &cacheReadInputAbove272k,
+		CacheCreationInputTokenCostAbove272kTokens: &cacheCreationInputAbove272k,
 		InputCostPerAudioToken:                     &inputAudio,
 		InputCostPerAudioPerSecond:                 &inputAudioPerSecond,
 		InputCostPerAudioPerSecondAbove128kTokens:  &inputAudioAbove128k,
@@ -154,6 +162,10 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 	assert.Equal(t, 0.00003, *params.OutputCostPerToken)
 	assert.Equal(t, 0.000018, *params.OutputCostPerReasoningToken)
 	assert.Equal(t, 0.00000125, *params.CacheCreationInputTokenCost)
+	assert.Equal(t, 0.00001, *params.InputCostPerTokenAbove272kTokens)
+	assert.Equal(t, 0.000045, *params.OutputCostPerTokenAbove272kTokens)
+	assert.Equal(t, 0.000001, *params.CacheReadInputTokenCostAbove272kTokens)
+	assert.Equal(t, 0.0000125, *params.CacheCreationInputTokenCostAbove272kTokens)
 }
 
 // TestGenericLiteLLMParamsFields verifies GenericLiteLLMParams structure with embedded types

--- a/internal/litellmdb/queries/queries_test.go
+++ b/internal/litellmdb/queries/queries_test.go
@@ -100,6 +100,7 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 	outputCostPerSecond := 0.0003
 
 	cacheReadInput := 0.000001
+	cacheCreationInput := 0.00000125
 	cacheReadInputAbove200k := 0.0000008
 
 	inputAudio := 0.000006
@@ -129,6 +130,7 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 		InputCostPerSecond:                         &inputCostPerSecond,
 		OutputCostPerSecond:                        &outputCostPerSecond,
 		CacheReadInputTokenCost:                    &cacheReadInput,
+		CacheCreationInputTokenCost:                &cacheCreationInput,
 		CacheReadInputTokenCostAbove200kTokens:     &cacheReadInputAbove200k,
 		InputCostPerAudioToken:                     &inputAudio,
 		InputCostPerAudioPerSecond:                 &inputAudioPerSecond,
@@ -151,6 +153,7 @@ func TestCustomPricingLiteLLMParamsFields(t *testing.T) {
 	assert.Equal(t, 0.00001, *params.InputCostPerToken)
 	assert.Equal(t, 0.00003, *params.OutputCostPerToken)
 	assert.Equal(t, 0.000018, *params.OutputCostPerReasoningToken)
+	assert.Equal(t, 0.00000125, *params.CacheCreationInputTokenCost)
 }
 
 // TestGenericLiteLLMParamsFields verifies GenericLiteLLMParams structure with embedded types

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -26,6 +26,8 @@ type ModelPrice struct {
 	// Tiered pricing: tokens above 200k threshold billed at a different rate
 	InputCostPerTokenAbove200k  float64 `json:"input_cost_per_token_above_200k_tokens,omitempty"`
 	OutputCostPerTokenAbove200k float64 `json:"output_cost_per_token_above_200k_tokens,omitempty"`
+	InputCostPerTokenAbove272k  float64 `json:"input_cost_per_token_above_272k_tokens,omitempty"`
+	OutputCostPerTokenAbove272k float64 `json:"output_cost_per_token_above_272k_tokens,omitempty"`
 
 	// Audio tokens (can be more specific than regular tokens)
 	InputCostPerAudioToken  float64 `json:"input_cost_per_audio_token,omitempty"`
@@ -39,11 +41,13 @@ type ModelPrice struct {
 	OutputCostPerReasoningToken float64 `json:"output_cost_per_reasoning_token,omitempty"`
 
 	// Cached/Prediction tokens
-	OutputCostPerCachedToken     float64 `json:"output_cost_per_cached_token,omitempty"`
-	InputCostPerCachedToken      float64 `json:"input_cost_per_cached_token,omitempty"`
-	CacheReadInputTokenCost      float64 `json:"cache_read_input_token_cost,omitempty"`
-	CacheCreationInputTokenCost  float64 `json:"cache_creation_input_token_cost,omitempty"`
-	OutputCostPerPredictionToken float64 `json:"output_cost_per_prediction_token,omitempty"`
+	OutputCostPerCachedToken             float64 `json:"output_cost_per_cached_token,omitempty"`
+	InputCostPerCachedToken              float64 `json:"input_cost_per_cached_token,omitempty"`
+	CacheReadInputTokenCost              float64 `json:"cache_read_input_token_cost,omitempty"`
+	CacheCreationInputTokenCost          float64 `json:"cache_creation_input_token_cost,omitempty"`
+	CacheReadInputTokenCostAbove272k     float64 `json:"cache_read_input_token_cost_above_272k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove272k float64 `json:"cache_creation_input_token_cost_above_272k_tokens,omitempty"`
+	OutputCostPerPredictionToken         float64 `json:"output_cost_per_prediction_token,omitempty"`
 
 	// Vision/Images cost per image (not per token)
 	OutputCostPerImage float64 `json:"output_cost_per_image,omitempty"`

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -41,8 +41,8 @@ type ModelPrice struct {
 	// Cached/Prediction tokens
 	OutputCostPerCachedToken     float64 `json:"output_cost_per_cached_token,omitempty"`
 	InputCostPerCachedToken      float64 `json:"input_cost_per_cached_token,omitempty"`
-	CacheReadInputTokenCost      float64 `json:"cache_read_input_token_cost,omitempty"`     // LiteLLM alias for InputCostPerCachedToken
-	CacheCreationInputTokenCost  float64 `json:"cache_creation_input_token_cost,omitempty"` // Anthropic cache write cost
+	CacheReadInputTokenCost      float64 `json:"cache_read_input_token_cost,omitempty"`
+	CacheCreationInputTokenCost  float64 `json:"cache_creation_input_token_cost,omitempty"`
 	OutputCostPerPredictionToken float64 `json:"output_cost_per_prediction_token,omitempty"`
 
 	// Vision/Images cost per image (not per token)

--- a/internal/models/price_calculator.go
+++ b/internal/models/price_calculator.go
@@ -4,8 +4,10 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/converter"
 )
 
-// Tiered pricing threshold: tokens above this count are billed at a different rate
-const tokenTiering200kThreshold = 200_000
+const (
+	tokenTiering200kThreshold = 200_000
+	tokenTiering272kThreshold = 272_000
+)
 
 // CalculateTokenCosts computes costs based on token usage and model pricing
 // Returns nil if price is nil (model not found in pricing database)
@@ -26,6 +28,15 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	}
 
 	costs := &converter.TokenCosts{}
+	longContext272k := usage.PromptTokens > tokenTiering272kThreshold
+	inputCostPerToken := price.InputCostPerToken
+	if longContext272k && price.InputCostPerTokenAbove272k > 0 {
+		inputCostPerToken = price.InputCostPerTokenAbove272k
+	}
+	outputCostPerToken := price.OutputCostPerToken
+	if longContext272k && price.OutputCostPerTokenAbove272k > 0 {
+		outputCostPerToken = price.OutputCostPerTokenAbove272k
+	}
 
 	// Calculate "regular" input tokens by subtracting specialized token types.
 	// Vertex/OpenAI: audio/cached tokens are included in PromptTokens; Anthropic: same + cache creation.
@@ -35,7 +46,9 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	}
 
 	// Regular input with 200k tiering
-	if price.InputCostPerTokenAbove200k > 0 && usage.PromptTokens > tokenTiering200kThreshold {
+	if longContext272k && price.InputCostPerTokenAbove272k > 0 {
+		costs.InputCost = float64(regularInputTokens) * inputCostPerToken
+	} else if price.InputCostPerTokenAbove200k > 0 && usage.PromptTokens > tokenTiering200kThreshold {
 		above := usage.PromptTokens - tokenTiering200kThreshold
 		// Distribute regular tokens proportionally between below/above threshold
 		regularAbove := int(int64(regularInputTokens) * int64(above) / int64(usage.PromptTokens))
@@ -43,7 +56,7 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 		costs.InputCost = float64(regularBelow)*price.InputCostPerToken +
 			float64(regularAbove)*price.InputCostPerTokenAbove200k
 	} else {
-		costs.InputCost = float64(regularInputTokens) * price.InputCostPerToken
+		costs.InputCost = float64(regularInputTokens) * inputCostPerToken
 	}
 
 	// Calculate "regular" output tokens by subtracting specialized token types
@@ -54,7 +67,9 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	}
 
 	// Regular output with 200k tiering
-	if price.OutputCostPerTokenAbove200k > 0 && usage.CompletionTokens > tokenTiering200kThreshold {
+	if longContext272k && price.OutputCostPerTokenAbove272k > 0 {
+		costs.OutputCost = float64(regularOutputTokens) * outputCostPerToken
+	} else if price.OutputCostPerTokenAbove200k > 0 && usage.CompletionTokens > tokenTiering200kThreshold {
 		above := usage.CompletionTokens - tokenTiering200kThreshold
 		// Distribute regular tokens proportionally between below/above threshold
 		regularAbove := int(int64(regularOutputTokens) * int64(above) / int64(usage.CompletionTokens))
@@ -62,19 +77,19 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 		costs.OutputCost = float64(regularBelow)*price.OutputCostPerToken +
 			float64(regularAbove)*price.OutputCostPerTokenAbove200k
 	} else {
-		costs.OutputCost = float64(regularOutputTokens) * price.OutputCostPerToken
+		costs.OutputCost = float64(regularOutputTokens) * outputCostPerToken
 	}
 
 	// Audio tokens with fallback to regular tokens
 	audioInputCost := price.InputCostPerAudioToken
 	if audioInputCost == 0 {
-		audioInputCost = price.InputCostPerToken
+		audioInputCost = inputCostPerToken
 	}
 	costs.AudioInputCost = float64(usage.AudioInputTokens) * audioInputCost
 
 	audioOutputCost := price.OutputCostPerAudioToken
 	if audioOutputCost == 0 {
-		audioOutputCost = price.OutputCostPerToken
+		audioOutputCost = outputCostPerToken
 	}
 	costs.AudioOutputCost = float64(usage.AudioOutputTokens) * audioOutputCost
 
@@ -84,40 +99,45 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	if cachedInputCost == 0 {
 		cachedInputCost = price.CacheReadInputTokenCost
 	}
+	if longContext272k && price.CacheReadInputTokenCostAbove272k > 0 {
+		cachedInputCost = price.CacheReadInputTokenCostAbove272k
+	}
 	if cachedInputCost == 0 {
-		cachedInputCost = price.InputCostPerToken
+		cachedInputCost = inputCostPerToken
 	}
 	costs.CachedInputCost = float64(usage.CachedInputTokens) * cachedInputCost
 
-	// Cache creation tokens (Anthropic prompt caching write cost).
 	cacheCreationCost := price.CacheCreationInputTokenCost
+	if longContext272k && price.CacheCreationInputTokenCostAbove272k > 0 {
+		cacheCreationCost = price.CacheCreationInputTokenCostAbove272k
+	}
 	if cacheCreationCost == 0 {
-		cacheCreationCost = price.InputCostPerToken
+		cacheCreationCost = inputCostPerToken
 	}
 	costs.CacheCreationCost = float64(usage.CacheCreationTokens) * cacheCreationCost
 
 	cachedOutputCost := price.OutputCostPerCachedToken
 	if cachedOutputCost == 0 {
-		cachedOutputCost = price.OutputCostPerToken
+		cachedOutputCost = outputCostPerToken
 	}
 	costs.CachedOutputCost = float64(usage.CachedOutputTokens) * cachedOutputCost
 
 	// Reasoning tokens with fallback
 	reasoningCost := price.OutputCostPerReasoningToken
 	if reasoningCost == 0 {
-		reasoningCost = price.OutputCostPerToken
+		reasoningCost = outputCostPerToken
 	}
 	costs.ReasoningCost = float64(usage.ReasoningTokens) * reasoningCost
 
 	// Prediction tokens with fallback (accepted tokens)
 	predictionCost := price.OutputCostPerPredictionToken
 	if predictionCost == 0 {
-		predictionCost = price.OutputCostPerToken
+		predictionCost = outputCostPerToken
 	}
 	costs.PredictionCost = float64(usage.AcceptedPredictionTokens) * predictionCost
 
 	// Rejected prediction tokens count as regular output tokens
-	costs.PredictionCost += float64(usage.RejectedPredictionTokens) * price.OutputCostPerToken
+	costs.PredictionCost += float64(usage.RejectedPredictionTokens) * outputCostPerToken
 
 	// Image cost calculation: supports both per-image and per-image-token pricing
 	// Priority: 1) Per-image cost if available (typical for image generation APIs)

--- a/internal/models/price_calculator_test.go
+++ b/internal/models/price_calculator_test.go
@@ -447,3 +447,28 @@ func TestCalculateTokenCosts_CacheCreationTokens(t *testing.T) {
 	// Total: 0.0015 + 0.00009 + 0.00075 + 0.0015 = $0.00384
 	assert.InDelta(t, 0.00384, costs.TotalCost, 1e-9)
 }
+
+func TestCalculateTokenCosts_GPT56CacheWrite(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens:        1000,
+		CompletionTokens:    100,
+		CachedInputTokens:   300,
+		CacheCreationTokens: 600,
+	}
+
+	price := &ModelPrice{
+		InputCostPerToken:           0.000005,
+		OutputCostPerToken:          0.00003,
+		CacheReadInputTokenCost:     0.0000005,
+		CacheCreationInputTokenCost: 0.00000625,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	assert.NotNil(t, costs)
+	assert.InDelta(t, 0.0005, costs.InputCost, 1e-9)
+	assert.InDelta(t, 0.00015, costs.CachedInputCost, 1e-9)
+	assert.InDelta(t, 0.00375, costs.CacheCreationCost, 1e-9)
+	assert.InDelta(t, 0.003, costs.OutputCost, 1e-9)
+	assert.InDelta(t, 0.0074, costs.TotalCost, 1e-9)
+}

--- a/internal/models/price_calculator_test.go
+++ b/internal/models/price_calculator_test.go
@@ -472,3 +472,51 @@ func TestCalculateTokenCosts_GPT56CacheWrite(t *testing.T) {
 	assert.InDelta(t, 0.003, costs.OutputCost, 1e-9)
 	assert.InDelta(t, 0.0074, costs.TotalCost, 1e-9)
 }
+
+func TestCalculateTokenCosts_GPT56LongContext(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens:        300_000,
+		CompletionTokens:    10_000,
+		CachedInputTokens:   60_000,
+		CacheCreationTokens: 90_000,
+	}
+
+	price := &ModelPrice{
+		InputCostPerToken:                    0.0000065,
+		OutputCostPerToken:                   0.000039,
+		CacheReadInputTokenCost:              0.00000065,
+		CacheCreationInputTokenCost:          0.000008125,
+		InputCostPerTokenAbove272k:           0.000013,
+		OutputCostPerTokenAbove272k:          0.0000585,
+		CacheReadInputTokenCostAbove272k:     0.0000013,
+		CacheCreationInputTokenCostAbove272k: 0.00001625,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	assert.NotNil(t, costs)
+	assert.InDelta(t, 1.95, costs.InputCost, 1e-9)
+	assert.InDelta(t, 0.078, costs.CachedInputCost, 1e-9)
+	assert.InDelta(t, 1.4625, costs.CacheCreationCost, 1e-9)
+	assert.InDelta(t, 0.585, costs.OutputCost, 1e-9)
+	assert.InDelta(t, 4.0755, costs.TotalCost, 1e-9)
+}
+
+func TestCalculateTokenCosts_GPT56ThresholdIsExclusive(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens:     tokenTiering272kThreshold,
+		CompletionTokens: 1,
+	}
+	price := &ModelPrice{
+		InputCostPerToken:           0.0000065,
+		OutputCostPerToken:          0.000039,
+		InputCostPerTokenAbove272k:  0.000013,
+		OutputCostPerTokenAbove272k: 0.0000585,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	assert.NotNil(t, costs)
+	assert.InDelta(t, 1.768, costs.InputCost, 1e-9)
+	assert.InDelta(t, 0.000039, costs.OutputCost, 1e-12)
+}

--- a/internal/models/price_loader_test.go
+++ b/internal/models/price_loader_test.go
@@ -41,6 +41,32 @@ func TestLoadModelPrices_FromFile(t *testing.T) {
 	assert.Len(t, prices, 2)
 }
 
+func TestLoadModelPrices_GPT56LongContext(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "prices.json")
+	pricesJSON := `{
+		"gpt-5.6-sol": {
+			"input_cost_per_token": 0.0000065,
+			"output_cost_per_token": 0.000039,
+			"cache_read_input_token_cost": 0.00000065,
+			"cache_creation_input_token_cost": 0.000008125,
+			"input_cost_per_token_above_272k_tokens": 0.000013,
+			"output_cost_per_token_above_272k_tokens": 0.0000585,
+			"cache_read_input_token_cost_above_272k_tokens": 0.0000013,
+			"cache_creation_input_token_cost_above_272k_tokens": 0.00001625
+		}
+	}`
+	require.NoError(t, os.WriteFile(filePath, []byte(pricesJSON), 0o600))
+
+	prices, err := LoadModelPrices(filePath)
+	require.NoError(t, err)
+	price := prices["gpt-5.6-sol"]
+	require.NotNil(t, price)
+	assert.InDelta(t, 0.000013, price.InputCostPerTokenAbove272k, 1e-12)
+	assert.InDelta(t, 0.0000585, price.OutputCostPerTokenAbove272k, 1e-12)
+	assert.InDelta(t, 0.0000013, price.CacheReadInputTokenCostAbove272k, 1e-12)
+	assert.InDelta(t, 0.00001625, price.CacheCreationInputTokenCostAbove272k, 1e-12)
+}
+
 func TestLoadModelPrices_FromFilePath(t *testing.T) {
 	// Create a temporary file with valid JSON
 	tmpDir := t.TempDir()

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -44,8 +44,8 @@ type StreamUsageInfo struct {
 	AudioOutputTokens   int // Audio tokens in the response
 	ImageTokens         int // Image/video tokens (if reported)
 	ReasoningTokens     int // Reasoning/thoughts tokens (output)
-	CacheCreationTokens int // Anthropic: tokens created for cache (billed at different rate)
-	CacheReadTokens     int // Anthropic: tokens read from cache (billed at cheaper rate)
+	CacheCreationTokens int // Tokens created for cache (billed at different rate)
+	CacheReadTokens     int // Tokens read from cache (billed at cheaper rate)
 }
 
 // StreamUsageExtractor provides a provider-agnostic interface for extracting
@@ -94,8 +94,10 @@ func (o *openAIStreamUsageExtractor) extractChatCompletionUsage(payload []byte) 
 			PromptTokens        int `json:"prompt_tokens"`
 			CompletionTokens    int `json:"completion_tokens"`
 			PromptTokensDetails struct {
-				CachedTokens int `json:"cached_tokens,omitempty"`
-				AudioTokens  int `json:"audio_tokens,omitempty"`
+				CachedTokens        int `json:"cached_tokens,omitempty"`
+				CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+				CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
+				AudioTokens         int `json:"audio_tokens,omitempty"`
 			} `json:"prompt_tokens_details,omitempty"`
 			CompletionTokensDetails struct {
 				AudioTokens     int `json:"audio_tokens,omitempty"`
@@ -112,13 +114,19 @@ func (o *openAIStreamUsageExtractor) extractChatCompletionUsage(payload []byte) 
 		return nil
 	}
 
+	cacheCreationTokens := data.Usage.PromptTokensDetails.CacheCreationTokens
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = data.Usage.PromptTokensDetails.CacheWriteTokens
+	}
+
 	return &StreamUsageInfo{
-		PromptTokens:      data.Usage.PromptTokens,
-		CompletionTokens:  data.Usage.CompletionTokens,
-		CachedTokens:      data.Usage.PromptTokensDetails.CachedTokens,
-		AudioInputTokens:  data.Usage.PromptTokensDetails.AudioTokens,
-		AudioOutputTokens: data.Usage.CompletionTokensDetails.AudioTokens,
-		ReasoningTokens:   data.Usage.CompletionTokensDetails.ReasoningTokens,
+		PromptTokens:        data.Usage.PromptTokens,
+		CompletionTokens:    data.Usage.CompletionTokens,
+		CachedTokens:        data.Usage.PromptTokensDetails.CachedTokens,
+		CacheCreationTokens: cacheCreationTokens,
+		AudioInputTokens:    data.Usage.PromptTokensDetails.AudioTokens,
+		AudioOutputTokens:   data.Usage.CompletionTokensDetails.AudioTokens,
+		ReasoningTokens:     data.Usage.CompletionTokensDetails.ReasoningTokens,
 	}
 }
 
@@ -149,13 +157,19 @@ func (o *openAIStreamUsageExtractor) extractResponsesAPIUsage(payload []byte) *S
 		return nil
 	}
 
+	cacheCreationTokens := usage.InputTokensDetails.CacheCreationTokens
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = usage.InputTokensDetails.CacheWriteTokens
+	}
+
 	return &StreamUsageInfo{
-		PromptTokens:      usage.InputTokens,
-		CompletionTokens:  usage.OutputTokens,
-		CachedTokens:      usage.InputTokensDetails.CachedTokens,
-		AudioInputTokens:  usage.InputTokensDetails.AudioTokens,
-		AudioOutputTokens: usage.OutputTokensDetails.AudioTokens,
-		ReasoningTokens:   usage.OutputTokensDetails.ReasoningTokens,
+		PromptTokens:        usage.InputTokens,
+		CompletionTokens:    usage.OutputTokens,
+		CachedTokens:        usage.InputTokensDetails.CachedTokens,
+		CacheCreationTokens: cacheCreationTokens,
+		AudioInputTokens:    usage.InputTokensDetails.AudioTokens,
+		AudioOutputTokens:   usage.OutputTokensDetails.AudioTokens,
+		ReasoningTokens:     usage.OutputTokensDetails.ReasoningTokens,
 	}
 }
 
@@ -164,8 +178,10 @@ type responsesAPIUsage struct {
 	InputTokens        int `json:"input_tokens"`
 	OutputTokens       int `json:"output_tokens"`
 	InputTokensDetails struct {
-		CachedTokens int `json:"cached_tokens,omitempty"`
-		AudioTokens  int `json:"audio_tokens,omitempty"`
+		CachedTokens        int `json:"cached_tokens,omitempty"`
+		CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
+		CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
+		AudioTokens         int `json:"audio_tokens,omitempty"`
 	} `json:"input_tokens_details,omitempty"`
 	OutputTokensDetails struct {
 		AudioTokens     int `json:"audio_tokens,omitempty"`

--- a/internal/proxy/stream_test.go
+++ b/internal/proxy/stream_test.go
@@ -497,6 +497,14 @@ func TestOpenAIStreamUsageExtractor(t *testing.T) {
 			},
 		},
 		{
+			name:      "usage with cache write tokens",
+			chunk:     []byte(`{"usage":{"prompt_tokens":100,"completion_tokens":50,"prompt_tokens_details":{"cache_write_tokens":40}}}`),
+			expectNil: false,
+			expectUsage: func(u *StreamUsageInfo) bool {
+				return u.PromptTokens == 100 && u.CacheCreationTokens == 40
+			},
+		},
+		{
 			name:      "usage with audio output tokens",
 			chunk:     []byte(`{"usage":{"prompt_tokens":100,"completion_tokens":50,"completion_tokens_details":{"audio_tokens":10}}}`),
 			expectNil: false,
@@ -550,6 +558,14 @@ func TestOpenAIStreamUsageExtractor(t *testing.T) {
 			expectNil: false,
 			expectUsage: func(u *StreamUsageInfo) bool {
 				return u.PromptTokens == 300 && u.CompletionTokens == 50 && u.CachedTokens == 100
+			},
+		},
+		{
+			name:      "responses API - with cache creation tokens",
+			chunk:     []byte(`{"usage":{"input_tokens":300,"output_tokens":50,"input_tokens_details":{"cache_creation_tokens":120}}}`),
+			expectNil: false,
+			expectUsage: func(u *StreamUsageInfo) bool {
+				return u.PromptTokens == 300 && u.CacheCreationTokens == 120
 			},
 		},
 		{


### PR DESCRIPTION
Adds GPT-5.6 cache-write and long-context pricing support.

- Loads cache-write and 272k-tier prices from JSON and LiteLLM model config.
- Reads cache-write usage from Chat Completions and Responses API, including streams.
- Applies 272k rates to the full session, including input, output, cache reads, and cache writes.
- Adds pricing, usage, boundary, and cost coverage.
