### PR TITLE
Fix Gemini image sizing

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -125,6 +125,48 @@ func TestProviderConverter_RequestFrom_VertexImageGeneration_Imagen(t *testing.T
 	}
 }
 
+func TestProviderConverter_RequestFrom_GeminiImageGeneration_Size(t *testing.T) {
+	tests := []struct {
+		size        string
+		aspectRatio string
+		imageSize   string
+	}{
+		{size: "1024x1024", aspectRatio: "1:1", imageSize: "1K"},
+		{size: "1x1", aspectRatio: "1:1", imageSize: "1K"},
+		{size: "1792x1024", aspectRatio: "16:9", imageSize: "1K"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.size, func(t *testing.T) {
+			body := mustJSON(t, openai.OpenAIImageRequest{
+				Model:  "gemini-3.1-flash-image-preview",
+				Prompt: "make image",
+				Size:   tt.size,
+			})
+			c := New(config.ProviderTypeGemini, RequestMode{
+				IsImageGeneration: true,
+				ModelID:           "gemini-3.1-flash-image-preview",
+			})
+
+			got, err := c.RequestFrom(body)
+			if err != nil {
+				t.Fatalf("RequestFrom error: %v", err)
+			}
+
+			req := mustUnmarshal[vertex.VertexRequest](t, got)
+			if req.GenerationConfig == nil || req.GenerationConfig.ImageConfig == nil {
+				t.Fatalf("missing generationConfig.imageConfig in %s", got)
+			}
+			if req.GenerationConfig.ImageConfig.AspectRatio != tt.aspectRatio {
+				t.Fatalf("expected aspectRatio %q, got %q", tt.aspectRatio, req.GenerationConfig.ImageConfig.AspectRatio)
+			}
+			if req.GenerationConfig.ImageConfig.ImageSize != tt.imageSize {
+				t.Fatalf("expected imageSize %q, got %q", tt.imageSize, req.GenerationConfig.ImageConfig.ImageSize)
+			}
+		})
+	}
+}
+
 func TestProviderConverter_RequestFrom_VertexChat(t *testing.T) {
 	body := mustJSON(t, minimalOpenAIChatRequest())
 	c := New(config.ProviderTypeVertexAI, RequestMode{ModelID: "gemini-1.5-flash"})

--- a/internal/converter/vertex/genconfig.go
+++ b/internal/converter/vertex/genconfig.go
@@ -9,7 +9,7 @@ import (
 
 // buildGenerationConfig constructs Vertex GenerationConfig from OpenAI request params.
 // Returns nil if no config parameters are set.
-func buildGenerationConfig(req *openai.OpenAIRequest, model string) *genai.GenerationConfig {
+func buildGenerationConfig(req *openai.OpenAIRequest, model string) *VertexGenerationConfig {
 	// Check if any config params are present
 	hasParams := req.Temperature != nil || req.MaxTokens != nil || req.MaxCompletionTokens != nil ||
 		req.TopP != nil || req.ExtraBody != nil || req.N != nil || req.Seed != nil ||
@@ -35,7 +35,7 @@ func buildGenerationConfig(req *openai.OpenAIRequest, model string) *genai.Gener
 	//   - ParallelToolCalls: Vertex AI always allows parallel tool calls (cannot be disabled)
 	//   - StreamOptions: stream_options.include_usage is always enabled in this proxy
 
-	cfg := &genai.GenerationConfig{}
+	cfg := &VertexGenerationConfig{GenerationConfig: &genai.GenerationConfig{}}
 
 	// Direct scalar params
 	if req.Temperature != nil {
@@ -99,7 +99,7 @@ func buildGenerationConfig(req *openai.OpenAIRequest, model string) *genai.Gener
 
 	// ExtraBody overrides
 	if req.ExtraBody != nil {
-		applyExtraBodyToConfig(cfg, req.ExtraBody, req.Model)
+		cfg.ImageConfig = applyExtraBodyToConfig(cfg.GenerationConfig, req.ExtraBody, req.Model)
 	}
 
 	// Deduplicate ResponseModalities (modalities may be added from multiple sources:
@@ -203,7 +203,9 @@ func buildGenerationConfig(req *openai.OpenAIRequest, model string) *genai.Gener
 }
 
 // applyExtraBodyToConfig applies extra_body generation_config overrides to genai.GenerationConfig.
-func applyExtraBodyToConfig(cfg *genai.GenerationConfig, extraBody map[string]interface{}, model string) {
+func applyExtraBodyToConfig(cfg *genai.GenerationConfig, extraBody map[string]interface{}, model string) *genai.ImageConfig {
+	var imageConfig *genai.ImageConfig
+
 	// generation_config nested object
 	if gcMap, ok := extraBody["generation_config"].(map[string]interface{}); ok {
 		if mimeType, ok := gcMap["response_mime_type"].(string); ok {
@@ -231,6 +233,10 @@ func applyExtraBodyToConfig(cfg *genai.GenerationConfig, extraBody map[string]in
 			v := float32(temp)
 			cfg.Temperature = &v
 		}
+		imageConfig = parseImageConfig(gcMap["image_config"])
+		if imageConfig == nil {
+			imageConfig = parseImageConfig(gcMap["imageConfig"])
+		}
 	}
 
 	// top-level modalities in extra_body
@@ -240,6 +246,32 @@ func applyExtraBodyToConfig(cfg *genai.GenerationConfig, extraBody map[string]in
 				cfg.ResponseModalities = append(cfg.ResponseModalities, genai.Modality(strings.ToUpper(mod)))
 			}
 		}
+	}
+
+	return imageConfig
+}
+
+func parseImageConfig(value interface{}) *genai.ImageConfig {
+	params, ok := value.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	aspectRatio, _ := params["aspectRatio"].(string)
+	if aspectRatio == "" {
+		aspectRatio, _ = params["aspect_ratio"].(string)
+	}
+	imageSize, _ := params["imageSize"].(string)
+	if imageSize == "" {
+		imageSize, _ = params["image_size"].(string)
+	}
+	if aspectRatio == "" && imageSize == "" {
+		return nil
+	}
+
+	return &genai.ImageConfig{
+		AspectRatio: aspectRatio,
+		ImageSize:   imageSize,
 	}
 }
 

--- a/internal/converter/vertex/genconfig_test.go
+++ b/internal/converter/vertex/genconfig_test.go
@@ -136,6 +136,22 @@ func TestApplyExtraBodyToConfig(t *testing.T) {
 		assert.Contains(t, cfg.ResponseModalities, genai.Modality("IMAGE"))
 	})
 
+	t.Run("with image_config in generation_config", func(t *testing.T) {
+		cfg := &genai.GenerationConfig{}
+		extraBody := map[string]interface{}{
+			"generation_config": map[string]interface{}{
+				"image_config": map[string]interface{}{
+					"aspectRatio": "1:1",
+					"imageSize":   "1K",
+				},
+			},
+		}
+		imageConfig := applyExtraBodyToConfig(cfg, extraBody, "gemini-3.1-flash-image-preview")
+		require.NotNil(t, imageConfig)
+		assert.Equal(t, "1:1", imageConfig.AspectRatio)
+		assert.Equal(t, "1K", imageConfig.ImageSize)
+	})
+
 	t.Run("with top-level modalities uppercased", func(t *testing.T) {
 		cfg := &genai.GenerationConfig{}
 		extraBody := map[string]interface{}{

--- a/internal/converter/vertex/responses/request.go
+++ b/internal/converter/vertex/responses/request.go
@@ -74,7 +74,9 @@ func buildVertexRequest(req *responses.Request, model string) (*vertex.VertexReq
 	}
 
 	// Generation config.
-	vr.GenerationConfig = buildGenConfig(req, model)
+	if generationConfig := buildGenConfig(req, model); generationConfig != nil {
+		vr.GenerationConfig = &vertex.VertexGenerationConfig{GenerationConfig: generationConfig}
+	}
 
 	return vr, nil
 }

--- a/internal/converter/vertex/types.go
+++ b/internal/converter/vertex/types.go
@@ -8,10 +8,15 @@ type VertexStreamingChunk struct {
 	UsageMetadata *genai.GenerateContentResponseUsageMetadata `json:"usageMetadata,omitempty"`
 }
 
+type VertexGenerationConfig struct {
+	*genai.GenerationConfig
+	ImageConfig *genai.ImageConfig `json:"imageConfig,omitempty"`
+}
+
 // VertexRequest represents the Vertex AI API request format
 type VertexRequest struct {
 	Contents          []*genai.Content        `json:"contents"`
-	GenerationConfig  *genai.GenerationConfig `json:"generationConfig,omitempty"`
+	GenerationConfig  *VertexGenerationConfig `json:"generationConfig,omitempty"`
 	SystemInstruction *genai.Content          `json:"systemInstruction,omitempty"`
 	Tools             []*genai.Tool           `json:"tools,omitempty"`
 	ToolConfig        *genai.ToolConfig       `json:"toolConfig,omitempty"`

--- a/tests/vertex/test_gemini_image.py
+++ b/tests/vertex/test_gemini_image.py
@@ -63,6 +63,41 @@ def _assert_b64_valid(b64: str) -> None:
     )
 
 
+def _image_dimensions(b64: str) -> tuple[int, int]:
+    raw = base64.b64decode(b64)
+    if raw.startswith(b"\x89PNG\r\n\x1a\n"):
+        return struct.unpack(">II", raw[16:24])
+
+    if raw.startswith(b"\xff\xd8"):
+        offset = 2
+        sof_markers = {
+            0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7,
+            0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF,
+        }
+        while offset + 4 <= len(raw):
+            if raw[offset] != 0xFF:
+                offset += 1
+                continue
+            while offset < len(raw) and raw[offset] == 0xFF:
+                offset += 1
+            if offset >= len(raw):
+                break
+            marker = raw[offset]
+            offset += 1
+            if marker in sof_markers:
+                height = int.from_bytes(raw[offset + 3:offset + 5], "big")
+                width = int.from_bytes(raw[offset + 5:offset + 7], "big")
+                return width, height
+            if marker == 0xD9 or marker == 0xDA:
+                break
+            segment_length = int.from_bytes(raw[offset:offset + 2], "big")
+            if segment_length < 2:
+                break
+            offset += segment_length
+
+    raise AssertionError("Unable to determine generated image dimensions")
+
+
 # ---------------------------------------------------------------------------
 # Text-to-Image Generation
 # ---------------------------------------------------------------------------
@@ -86,6 +121,25 @@ class TestGeminiImageGeneration:
         assert resp is not None
         assert len(resp.data) >= 1
         _assert_image_item(resp.data[0])
+
+    def test_generation_respects_square_size(self, openai_client):
+        """1024x1024 is forwarded to Gemini as a 1:1 1K image config."""
+        model = "gemini-3.1-flash-image-preview"
+        try:
+            resp = openai_client.images.generate(
+                model=model,
+                prompt="A mountain landscape at sunset",
+                response_format="b64_json",
+                n=1,
+                size="1024x1024",
+            )
+        except Exception as e:
+            _skip_on_error(e, model)
+
+        assert resp.data, "Response data is empty"
+        b64 = resp.data[0].b64_json
+        assert b64, "Model did not return b64_json"
+        assert _image_dimensions(b64) == (1024, 1024)
 
     @pytest.mark.parametrize("model", TestModels.GEMINI_IMAGE_MODELS)
     def test_generation_count(self, openai_client, model):


### PR DESCRIPTION
Preserves Gemini imageConfig through image-to-chat conversion so size controls aspect ratio and resolution.

Root cause: generation_config.image_config was dropped before Vertex serialization.

Tests:
- go test ./...
- make lint