### PR TITLE
Revise Gemini image sizing

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -133,7 +133,11 @@ func TestProviderConverter_RequestFrom_GeminiImageGeneration_Size(t *testing.T) 
 	}{
 		{size: "1024x1024", aspectRatio: "1:1", imageSize: "1K"},
 		{size: "1x1", aspectRatio: "1:1", imageSize: "1K"},
+		{size: "3:4", aspectRatio: "3:4", imageSize: "1K"},
 		{size: "1792x1024", aspectRatio: "16:9", imageSize: "1K"},
+		{size: "1792x2400", aspectRatio: "3:4", imageSize: "2K"},
+		{size: "896x1152", aspectRatio: "4:5", imageSize: "1K"},
+		{size: "640x1024", aspectRatio: "2:3", imageSize: "1K"},
 	}
 
 	for _, tt := range tests {

--- a/internal/converter/vertex/image_size.go
+++ b/internal/converter/vertex/image_size.go
@@ -1,0 +1,217 @@
+package vertex
+
+import (
+	"fmt"
+	"math"
+	"strconv"
+	"strings"
+)
+
+type geminiImageRatio struct {
+	value              string
+	ratioWidth         int
+	ratioHeight        int
+	resolution1KWidth  int
+	resolution1KHeight int
+}
+
+type geminiImageResolution struct {
+	value string
+	scale float64
+}
+
+type geminiImageProfile struct {
+	ratios      []geminiImageRatio
+	resolutions []geminiImageResolution
+}
+
+type geminiImageConfig struct {
+	aspectRatio string
+	imageSize   string
+}
+
+var gemini25ImageRatios = []geminiImageRatio{
+	{value: "1:1", ratioWidth: 1, ratioHeight: 1, resolution1KWidth: 1024, resolution1KHeight: 1024},
+	{value: "2:3", ratioWidth: 2, ratioHeight: 3, resolution1KWidth: 832, resolution1KHeight: 1248},
+	{value: "3:2", ratioWidth: 3, ratioHeight: 2, resolution1KWidth: 1248, resolution1KHeight: 832},
+	{value: "3:4", ratioWidth: 3, ratioHeight: 4, resolution1KWidth: 864, resolution1KHeight: 1184},
+	{value: "4:3", ratioWidth: 4, ratioHeight: 3, resolution1KWidth: 1184, resolution1KHeight: 864},
+	{value: "4:5", ratioWidth: 4, ratioHeight: 5, resolution1KWidth: 896, resolution1KHeight: 1152},
+	{value: "5:4", ratioWidth: 5, ratioHeight: 4, resolution1KWidth: 1152, resolution1KHeight: 896},
+	{value: "9:16", ratioWidth: 9, ratioHeight: 16, resolution1KWidth: 768, resolution1KHeight: 1344},
+	{value: "16:9", ratioWidth: 16, ratioHeight: 9, resolution1KWidth: 1344, resolution1KHeight: 768},
+	{value: "21:9", ratioWidth: 21, ratioHeight: 9, resolution1KWidth: 1536, resolution1KHeight: 672},
+}
+
+var gemini3ImageRatios = []geminiImageRatio{
+	{value: "1:1", ratioWidth: 1, ratioHeight: 1, resolution1KWidth: 1024, resolution1KHeight: 1024},
+	{value: "2:3", ratioWidth: 2, ratioHeight: 3, resolution1KWidth: 848, resolution1KHeight: 1264},
+	{value: "3:2", ratioWidth: 3, ratioHeight: 2, resolution1KWidth: 1264, resolution1KHeight: 848},
+	{value: "3:4", ratioWidth: 3, ratioHeight: 4, resolution1KWidth: 896, resolution1KHeight: 1200},
+	{value: "4:3", ratioWidth: 4, ratioHeight: 3, resolution1KWidth: 1200, resolution1KHeight: 896},
+	{value: "4:5", ratioWidth: 4, ratioHeight: 5, resolution1KWidth: 928, resolution1KHeight: 1152},
+	{value: "5:4", ratioWidth: 5, ratioHeight: 4, resolution1KWidth: 1152, resolution1KHeight: 928},
+	{value: "9:16", ratioWidth: 9, ratioHeight: 16, resolution1KWidth: 768, resolution1KHeight: 1376},
+	{value: "16:9", ratioWidth: 16, ratioHeight: 9, resolution1KWidth: 1376, resolution1KHeight: 768},
+	{value: "21:9", ratioWidth: 21, ratioHeight: 9, resolution1KWidth: 1584, resolution1KHeight: 672},
+}
+
+var gemini31FlashImageRatios = []geminiImageRatio{
+	{value: "1:1", ratioWidth: 1, ratioHeight: 1, resolution1KWidth: 1024, resolution1KHeight: 1024},
+	{value: "1:4", ratioWidth: 1, ratioHeight: 4, resolution1KWidth: 512, resolution1KHeight: 2048},
+	{value: "1:8", ratioWidth: 1, ratioHeight: 8, resolution1KWidth: 384, resolution1KHeight: 3072},
+	{value: "2:3", ratioWidth: 2, ratioHeight: 3, resolution1KWidth: 848, resolution1KHeight: 1264},
+	{value: "3:2", ratioWidth: 3, ratioHeight: 2, resolution1KWidth: 1264, resolution1KHeight: 848},
+	{value: "3:4", ratioWidth: 3, ratioHeight: 4, resolution1KWidth: 896, resolution1KHeight: 1200},
+	{value: "4:1", ratioWidth: 4, ratioHeight: 1, resolution1KWidth: 2048, resolution1KHeight: 512},
+	{value: "4:3", ratioWidth: 4, ratioHeight: 3, resolution1KWidth: 1200, resolution1KHeight: 896},
+	{value: "4:5", ratioWidth: 4, ratioHeight: 5, resolution1KWidth: 928, resolution1KHeight: 1152},
+	{value: "5:4", ratioWidth: 5, ratioHeight: 4, resolution1KWidth: 1152, resolution1KHeight: 928},
+	{value: "8:1", ratioWidth: 8, ratioHeight: 1, resolution1KWidth: 3072, resolution1KHeight: 384},
+	{value: "9:16", ratioWidth: 9, ratioHeight: 16, resolution1KWidth: 768, resolution1KHeight: 1376},
+	{value: "16:9", ratioWidth: 16, ratioHeight: 9, resolution1KWidth: 1376, resolution1KHeight: 768},
+	{value: "21:9", ratioWidth: 21, ratioHeight: 9, resolution1KWidth: 1584, resolution1KHeight: 672},
+}
+
+var (
+	fixed1KImageResolutions = []geminiImageResolution{{scale: 1}}
+	oneKImageResolutions    = []geminiImageResolution{{value: "1K", scale: 1}}
+	gemini3ImageResolutions = []geminiImageResolution{
+		{value: "1K", scale: 1},
+		{value: "2K", scale: 2},
+		{value: "4K", scale: 4},
+	}
+	gemini31FlashImageResolutions = []geminiImageResolution{
+		{value: "512", scale: 0.5},
+		{value: "1K", scale: 1},
+		{value: "2K", scale: 2},
+		{value: "4K", scale: 4},
+	}
+)
+
+func geminiImageProfileForModel(model string) geminiImageProfile {
+	lower := strings.ToLower(model)
+	switch {
+	case strings.Contains(lower, "gemini-3.1-flash-lite-image"):
+		return geminiImageProfile{ratios: gemini3ImageRatios, resolutions: oneKImageResolutions}
+	case strings.Contains(lower, "gemini-3.1-flash-image"):
+		return geminiImageProfile{ratios: gemini31FlashImageRatios, resolutions: gemini31FlashImageResolutions}
+	case strings.Contains(lower, "gemini-3-pro-image"):
+		return geminiImageProfile{ratios: gemini3ImageRatios, resolutions: gemini3ImageResolutions}
+	default:
+		return geminiImageProfile{ratios: gemini25ImageRatios, resolutions: fixed1KImageResolutions}
+	}
+}
+
+func mapGeminiImageSize(model, size string) (*geminiImageConfig, error) {
+	size = strings.TrimSpace(size)
+	if size == "" || strings.EqualFold(size, "auto") {
+		return nil, nil
+	}
+
+	width, height, ratioOnly, err := parseGeminiImageSize(size)
+	if err != nil {
+		return nil, err
+	}
+
+	profile := geminiImageProfileForModel(model)
+	ratio := nearestGeminiImageRatio(profile.ratios, width, height)
+	resolution := defaultGeminiImageResolution(profile.resolutions)
+	if !ratioOnly {
+		resolution = nearestGeminiImageResolution(profile.resolutions, ratio, width, height)
+	}
+
+	return &geminiImageConfig{aspectRatio: ratio.value, imageSize: resolution.value}, nil
+}
+
+func parseGeminiImageSize(size string) (int, int, bool, error) {
+	normalized := strings.ToLower(strings.TrimSpace(size))
+	normalized = strings.ReplaceAll(normalized, "×", "x")
+
+	separator := "x"
+	ratioOnly := false
+	for _, candidate := range []string{":", "/"} {
+		if strings.Contains(normalized, candidate) {
+			separator = candidate
+			ratioOnly = true
+			break
+		}
+	}
+
+	left, right, ok := strings.Cut(normalized, separator)
+	if !ok || strings.Contains(right, separator) {
+		return 0, 0, false, fmt.Errorf("invalid image size %q: expected WxH or W:H", size)
+	}
+	width, widthErr := strconv.Atoi(strings.TrimSpace(left))
+	height, heightErr := strconv.Atoi(strings.TrimSpace(right))
+	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
+		return 0, 0, false, fmt.Errorf("invalid image size %q: dimensions must be positive integers", size)
+	}
+	if separator == "x" && width <= 32 && height <= 32 {
+		ratioOnly = true
+	}
+
+	return width, height, ratioOnly, nil
+}
+
+func nearestGeminiImageRatio(ratios []geminiImageRatio, width, height int) geminiImageRatio {
+	requested := float64(width) / float64(height)
+	nearest := ratios[0]
+	nearestDistance := math.Inf(1)
+	for _, ratio := range ratios {
+		candidate := float64(ratio.ratioWidth) / float64(ratio.ratioHeight)
+		distance := math.Abs(math.Log(requested / candidate))
+		if distance < nearestDistance {
+			nearest = ratio
+			nearestDistance = distance
+		}
+	}
+	return nearest
+}
+
+func defaultGeminiImageResolution(resolutions []geminiImageResolution) geminiImageResolution {
+	for _, resolution := range resolutions {
+		if resolution.scale == 1 {
+			return resolution
+		}
+	}
+	return resolutions[0]
+}
+
+func nearestGeminiImageResolution(
+	resolutions []geminiImageResolution,
+	ratio geminiImageRatio,
+	width, height int,
+) geminiImageResolution {
+	nearest := resolutions[0]
+	nearestDistance := math.Inf(1)
+	for _, resolution := range resolutions {
+		candidateWidth := float64(ratio.resolution1KWidth) * resolution.scale
+		candidateHeight := float64(ratio.resolution1KHeight) * resolution.scale
+		widthDistance := math.Log(float64(width) / candidateWidth)
+		heightDistance := math.Log(float64(height) / candidateHeight)
+		distance := widthDistance*widthDistance + heightDistance*heightDistance
+		if distance < nearestDistance {
+			nearest = resolution
+			nearestDistance = distance
+		}
+	}
+	return nearest
+}
+
+func applyGeminiImageSize(genConfig map[string]interface{}, model, size string) error {
+	config, err := mapGeminiImageSize(model, size)
+	if err != nil {
+		return err
+	}
+	if config == nil {
+		return nil
+	}
+
+	imageConfig := map[string]interface{}{"aspectRatio": config.aspectRatio}
+	if config.imageSize != "" {
+		imageConfig["imageSize"] = config.imageSize
+	}
+	genConfig["image_config"] = imageConfig
+	return nil
+}

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -139,6 +139,10 @@ func VertexImageToOpenAI(vertexBody []byte) ([]byte, error) {
 // ImageRequestToOpenAIChatRequest converts OpenAI image generation request to OpenAI chat request format
 // This allows Gemini models to generate images through chat API with response_modalities: ["IMAGE"]
 func ImageRequestToOpenAIChatRequest(openAIBody []byte) ([]byte, error) {
+	return imageRequestToOpenAIChatRequest(openAIBody, "")
+}
+
+func imageRequestToOpenAIChatRequest(openAIBody []byte, providerModel string) ([]byte, error) {
 	var imageReq openai.OpenAIImageRequest
 	if err := json.Unmarshal(openAIBody, &imageReq); err != nil {
 		return nil, fmt.Errorf("failed to parse OpenAI image request: %w", err)
@@ -147,27 +151,11 @@ func ImageRequestToOpenAIChatRequest(openAIBody []byte) ([]byte, error) {
 	genConfig := map[string]interface{}{
 		"response_modalities": []string{"IMAGE"},
 	}
-
-	// Add image config if size is provided
-	if imageReq.Size != "" {
-		imageConfig := map[string]interface{}{}
-
-		// Convert OpenAI size format to Gemini aspect ratio
-		// Supported by Gemini: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9
-		aspectRatio := sizeToAspectRatio(imageReq.Size)
-		if aspectRatio != "" {
-			imageConfig["aspectRatio"] = aspectRatio
-		}
-
-		// Convert size to Gemini image size (1K, 2K, 4K)
-		imageSize := sizeToImageSize(imageReq.Size)
-		if imageSize != "" {
-			imageConfig["imageSize"] = imageSize
-		}
-
-		if len(imageConfig) > 0 {
-			genConfig["image_config"] = imageConfig
-		}
+	if providerModel == "" {
+		providerModel = imageReq.Model
+	}
+	if err := applyGeminiImageSize(genConfig, providerModel, imageReq.Size); err != nil {
+		return nil, err
 	}
 
 	// Convert to OpenAI chat request format
@@ -194,6 +182,10 @@ func ImageRequestToOpenAIChatRequest(openAIBody []byte) ([]byte, error) {
 // ImageEditRequestToOpenAIChatRequest converts OpenAI multipart images.edit payload
 // to an OpenAI chat request for Gemini image-capable models.
 func ImageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType string) ([]byte, error) {
+	return imageEditRequestToOpenAIChatRequest(openAIBody, contentType, "")
+}
+
+func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, providerModel string) ([]byte, error) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse image edit content type: %w", err)
@@ -282,17 +274,11 @@ func ImageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType string) 
 	genConfig := map[string]interface{}{
 		"response_modalities": []string{"IMAGE"},
 	}
-	if size := strings.TrimSpace(fields["size"]); size != "" {
-		imageConfig := map[string]interface{}{}
-		if aspectRatio := sizeToAspectRatio(size); aspectRatio != "" {
-			imageConfig["aspectRatio"] = aspectRatio
-		}
-		if imageSize := sizeToImageSize(size); imageSize != "" {
-			imageConfig["imageSize"] = imageSize
-		}
-		if len(imageConfig) > 0 {
-			genConfig["image_config"] = imageConfig
-		}
+	if providerModel == "" {
+		providerModel = model
+	}
+	if err := applyGeminiImageSize(genConfig, providerModel, fields["size"]); err != nil {
+		return nil, err
 	}
 
 	chatReq := openai.OpenAIRequest{
@@ -313,58 +299,6 @@ func ImageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType string) 
 	}
 
 	return json.Marshal(chatReq)
-}
-
-// sizeToAspectRatio converts OpenAI size format (e.g., "1792x1024") to Gemini aspect ratio
-// Supported by Gemini: 1:1, 2:3, 3:2, 3:4, 4:3, 4:5, 5:4, 9:16, 16:9, 21:9
-func sizeToAspectRatio(size string) string {
-	switch size {
-	case "1024x1024", "512x512", "256x256":
-		return "1:1"
-	case "1792x1024":
-		return "16:9"
-	case "1024x1792":
-		return "9:16"
-	case "1536x1024":
-		return "3:2"
-	case "1024x1536":
-		return "2:3"
-	case "768x1024":
-		return "3:4"
-	case "1024x768":
-		return "4:3"
-	case "819x1024":
-		return "4:5"
-	case "1024x819":
-		return "5:4"
-	case "576x1024":
-		return "9:16"
-	case "2016x1008":
-		return "21:9"
-	default:
-		// Default to 1:1 if size not recognized
-		return "1:1"
-	}
-}
-
-// sizeToImageSize converts OpenAI size to Gemini image size (1K, 2K, 4K)
-// 1K ≈ 1024x1024, 2K ≈ 2048x2048, 4K ≈ 4096x4096
-func sizeToImageSize(size string) string {
-	switch size {
-	// 1K sizes
-	case "1024x1024", "512x512", "256x256", "1792x1024", "1024x1792", "1536x1024", "1024x1536", "768x1024", "1024x768", "819x1024", "1024x819", "576x1024":
-		return "1K"
-	// 2K sizes (larger variations)
-	case "2048x2048", "3584x2048", "2048x3584":
-		return "2K"
-	case "2016x1008":
-		return "2K"
-	// 4K sizes
-	case "4096x4096", "7168x4096", "4096x7168":
-		return "4K"
-	default:
-		return "1K" // Default to 1K
-	}
 }
 
 // VertexChatResponseToOpenAIImage converts Vertex AI chat response with image to OpenAI image format

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -293,6 +293,13 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 			"generation_config": genConfig,
 		},
 	}
+	if rawSeed := strings.TrimSpace(fields["seed"]); rawSeed != "" {
+		seed, err := strconv.ParseInt(rawSeed, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid image edit seed %q", rawSeed)
+		}
+		chatReq.Seed = &seed
+	}
 	if n := parsePositiveInt(fields["n"]); n > 0 {
 		n = clampImageCount(n)
 		chatReq.N = &n

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -133,7 +133,7 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 }
 
 func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
-	buildMultipart := func(t *testing.T, model, size string) ([]byte, string) {
+	buildMultipart := func(t *testing.T, model, size, seed string) ([]byte, string) {
 		t.Helper()
 
 		var buf bytes.Buffer
@@ -142,6 +142,9 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		require.NoError(t, writer.WriteField("prompt", "Make the object blue"))
 		require.NoError(t, writer.WriteField("n", "2"))
 		require.NoError(t, writer.WriteField("size", size))
+		if seed != "" {
+			require.NoError(t, writer.WriteField("seed", seed))
+		}
 
 		part, err := writer.CreatePart(textproto.MIMEHeader{
 			"Content-Disposition": []string{`form-data; name="image"; filename="input.png"`},
@@ -156,7 +159,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 	}
 
 	t.Run("multipart edit request converts to multimodal chat request", func(t *testing.T) {
-		body, contentType := buildMultipart(t, "gemini-2.5-flash-image-preview", "1792x1024")
+		body, contentType := buildMultipart(t, "gemini-2.5-flash-image-preview", "1792x1024", "0")
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		require.NoError(t, err)
 
@@ -165,6 +168,8 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		assert.Equal(t, "gemini-2.5-flash-image-preview", chatReq.Model)
 		require.NotNil(t, chatReq.N)
 		assert.Equal(t, 2, *chatReq.N)
+		require.NotNil(t, chatReq.Seed)
+		assert.Equal(t, int64(0), *chatReq.Seed)
 		require.Len(t, chatReq.Messages, 1)
 
 		blocks, ok := chatReq.Messages[0].Content.([]interface{})
@@ -189,7 +194,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 	})
 
 	t.Run("multipart edit uses model size profile", func(t *testing.T) {
-		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1792x2400")
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1792x2400", "42")
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		require.NoError(t, err)
 
@@ -199,6 +204,16 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		imageConfig := genConfig["image_config"].(map[string]interface{})
 		assert.Equal(t, "3:4", imageConfig["aspectRatio"])
 		assert.Equal(t, "2K", imageConfig["imageSize"])
+		require.NotNil(t, chatReq.Seed)
+		assert.Equal(t, int64(42), *chatReq.Seed)
+	})
+
+	t.Run("invalid seed returns error", func(t *testing.T) {
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", "invalid")
+		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "invalid image edit seed")
 	})
 
 	t.Run("missing model returns error", func(t *testing.T) {

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -13,64 +13,50 @@ import (
 	"google.golang.org/genai"
 )
 
-func TestSizeToAspectRatio(t *testing.T) {
+func TestMapGeminiImageSize(t *testing.T) {
 	tests := []struct {
-		size string
-		want string
+		name        string
+		model       string
+		size        string
+		aspectRatio string
+		imageSize   string
 	}{
-		{"1024x1024", "1:1"},
-		{"512x512", "1:1"},
-		{"256x256", "1:1"},
-		{"1792x1024", "16:9"},
-		{"1024x1792", "9:16"},
-		{"1536x1024", "3:2"},
-		{"1024x1536", "2:3"},
-		{"768x1024", "3:4"},
-		{"1024x768", "4:3"},
-		{"819x1024", "4:5"},
-		{"1024x819", "5:4"},
-		{"576x1024", "9:16"},
-		{"2016x1008", "21:9"},
-		{"unknown", "1:1"}, // default
-		{"", "1:1"},        // default
+		{name: "2.5 fixed 1K", model: "gemini-2.5-flash-image", size: "1792x2400", aspectRatio: "3:4"},
+		{name: "2.5 native dimensions", model: "gemini-2.5-flash-image", size: "896x1152", aspectRatio: "4:5"},
+		{name: "3 Pro 1K", model: "gemini-3-pro-image-preview", size: "896x1152", aspectRatio: "4:5", imageSize: "1K"},
+		{name: "3 Pro 2K", model: "gemini-3-pro-image", size: "1792x2400", aspectRatio: "3:4", imageSize: "2K"},
+		{name: "3 Pro 4K", model: "google/gemini-3-pro-image", size: "3584x4800", aspectRatio: "3:4", imageSize: "4K"},
+		{name: "3.1 Flash 512", model: "gemini-3.1-flash-image", size: "512x512", aspectRatio: "1:1", imageSize: "512"},
+		{name: "3.1 Flash 1K", model: "gemini-3.1-flash-image-preview", size: "768x1024", aspectRatio: "3:4", imageSize: "1K"},
+		{name: "3.1 Flash 2K", model: "gemini-3.1-flash-image", size: "1792x2400", aspectRatio: "3:4", imageSize: "2K"},
+		{name: "3.1 Flash nearest 4:5", model: "gemini-3.1-flash-image", size: "896x1152", aspectRatio: "4:5", imageSize: "1K"},
+		{name: "3.1 Flash nearest 2:3", model: "gemini-3.1-flash-image", size: "640x1024", aspectRatio: "2:3", imageSize: "1K"},
+		{name: "3.1 Flash extended ratio", model: "gemini-3.1-flash-image", size: "1:8", aspectRatio: "1:8", imageSize: "1K"},
+		{name: "3.1 Flash ratio with x", model: "gemini-3.1-flash-image", size: "16x9", aspectRatio: "16:9", imageSize: "1K"},
+		{name: "3.1 Flash Lite fixed 1K", model: "gemini-3.1-flash-lite-image", size: "1792x2400", aspectRatio: "3:4", imageSize: "1K"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.size, func(t *testing.T) {
-			assert.Equal(t, tt.want, sizeToAspectRatio(tt.size))
+		t.Run(tt.name, func(t *testing.T) {
+			config, err := mapGeminiImageSize(tt.model, tt.size)
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.aspectRatio, config.aspectRatio)
+			assert.Equal(t, tt.imageSize, config.imageSize)
 		})
 	}
 }
 
-func TestSizeToImageSize(t *testing.T) {
-	tests := []struct {
-		size string
-		want string
-	}{
-		// 1K sizes
-		{"1024x1024", "1K"},
-		{"512x512", "1K"},
-		{"256x256", "1K"},
-		{"1792x1024", "1K"},
-		{"1024x1792", "1K"},
-		{"576x1024", "1K"},
-		// 2K sizes
-		{"2048x2048", "2K"},
-		{"3584x2048", "2K"},
-		{"2048x3584", "2K"},
-		{"2016x1008", "2K"},
-		// 4K sizes
-		{"4096x4096", "4K"},
-		{"7168x4096", "4K"},
-		{"4096x7168", "4K"},
-		// Unknown → 1K default
-		{"unknown", "1K"},
-		{"", "1K"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.size, func(t *testing.T) {
-			assert.Equal(t, tt.want, sizeToImageSize(tt.size))
-		})
-	}
+func TestMapGeminiImageSizeAuto(t *testing.T) {
+	config, err := mapGeminiImageSize("gemini-3.1-flash-image", "auto")
+	require.NoError(t, err)
+	assert.Nil(t, config)
+}
+
+func TestMapGeminiImageSizeRejectsInvalidValue(t *testing.T) {
+	config, err := mapGeminiImageSize("gemini-3.1-flash-image", "not-a-size")
+	assert.Error(t, err)
+	assert.Nil(t, config)
+	assert.Contains(t, err.Error(), "expected WxH or W:H")
 }
 
 func TestImageRequestToOpenAIChatRequest(t *testing.T) {
@@ -98,7 +84,7 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 	})
 
 	t.Run("request with size includes aspect ratio and image size", func(t *testing.T) {
-		input := `{"model": "gemini-2.0-flash", "prompt": "A landscape", "size": "1792x1024"}`
+		input := `{"model": "gemini-3-pro-image", "prompt": "A landscape", "size": "1792x1024"}`
 		result, err := ImageRequestToOpenAIChatRequest([]byte(input))
 		require.NoError(t, err)
 
@@ -112,6 +98,19 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, "16:9", imageConfig["aspectRatio"])
 		assert.Equal(t, "1K", imageConfig["imageSize"])
+	})
+
+	t.Run("2.5 image request omits unsupported image size", func(t *testing.T) {
+		input := `{"model": "gemini-2.5-flash-image", "prompt": "A landscape", "size": "1792x1024"}`
+		result, err := ImageRequestToOpenAIChatRequest([]byte(input))
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		genConfig := chatReq.ExtraBody["generation_config"].(map[string]interface{})
+		imageConfig := genConfig["image_config"].(map[string]interface{})
+		assert.Equal(t, "16:9", imageConfig["aspectRatio"])
+		assert.NotContains(t, imageConfig, "imageSize")
 	})
 
 	t.Run("request clamps n to 10", func(t *testing.T) {
@@ -134,15 +133,15 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 }
 
 func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
-	buildMultipart := func(t *testing.T) ([]byte, string) {
+	buildMultipart := func(t *testing.T, model, size string) ([]byte, string) {
 		t.Helper()
 
 		var buf bytes.Buffer
 		writer := multipart.NewWriter(&buf)
-		require.NoError(t, writer.WriteField("model", "gemini-2.5-flash-image-preview"))
+		require.NoError(t, writer.WriteField("model", model))
 		require.NoError(t, writer.WriteField("prompt", "Make the object blue"))
 		require.NoError(t, writer.WriteField("n", "2"))
-		require.NoError(t, writer.WriteField("size", "1792x1024"))
+		require.NoError(t, writer.WriteField("size", size))
 
 		part, err := writer.CreatePart(textproto.MIMEHeader{
 			"Content-Disposition": []string{`form-data; name="image"; filename="input.png"`},
@@ -157,7 +156,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 	}
 
 	t.Run("multipart edit request converts to multimodal chat request", func(t *testing.T) {
-		body, contentType := buildMultipart(t)
+		body, contentType := buildMultipart(t, "gemini-2.5-flash-image-preview", "1792x1024")
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		require.NoError(t, err)
 
@@ -186,7 +185,20 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		imageConfig, ok := genConfig["image_config"].(map[string]interface{})
 		require.True(t, ok)
 		assert.Equal(t, "16:9", imageConfig["aspectRatio"])
-		assert.Equal(t, "1K", imageConfig["imageSize"])
+		assert.NotContains(t, imageConfig, "imageSize")
+	})
+
+	t.Run("multipart edit uses model size profile", func(t *testing.T) {
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1792x2400")
+		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		genConfig := chatReq.ExtraBody["generation_config"].(map[string]interface{})
+		imageConfig := genConfig["image_config"].(map[string]interface{})
+		assert.Equal(t, "3:4", imageConfig["aspectRatio"])
+		assert.Equal(t, "2K", imageConfig["imageSize"])
 	})
 
 	t.Run("missing model returns error", func(t *testing.T) {

--- a/internal/converter/vertex/request.go
+++ b/internal/converter/vertex/request.go
@@ -20,9 +20,9 @@ func OpenAIToVertex(openAIBody []byte, isImageGeneration bool, isImageEdit bool,
 				err      error
 			)
 			if isImageEdit {
-				chatBody, err = ImageEditRequestToOpenAIChatRequest(openAIBody, contentType)
+				chatBody, err = imageEditRequestToOpenAIChatRequest(openAIBody, contentType, model)
 			} else {
-				chatBody, err = ImageRequestToOpenAIChatRequest(openAIBody)
+				chatBody, err = imageRequestToOpenAIChatRequest(openAIBody, model)
 			}
 			if err != nil {
 				return nil, err

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -671,7 +671,9 @@ func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 		err := json.NewDecoder(r.Body).Decode(&bodyMap)
 		assert.NoError(t, err)
 		assert.NotNil(t, bodyMap["contents"])
-		assert.NotNil(t, bodyMap["generationConfig"])
+		generationConfig, ok := bodyMap["generationConfig"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, float64(42), generationConfig["seed"])
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"inlineData":{"data":"aW1n","mimeType":"image/png"}}],"role":"model"}}]}`))
@@ -686,6 +688,7 @@ func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 	writer := multipart.NewWriter(&buf)
 	assert.NoError(t, writer.WriteField("model", "gemini-2.5-flash-image-preview"))
 	assert.NoError(t, writer.WriteField("prompt", "Edit this image"))
+	assert.NoError(t, writer.WriteField("seed", "42"))
 	part, err := writer.CreatePart(textproto.MIMEHeader{
 		"Content-Disposition": []string{`form-data; name="image"; filename="input.png"`},
 		"Content-Type":        []string{"image/png"},

--- a/tests/vertex/test_gemini_image.py
+++ b/tests/vertex/test_gemini_image.py
@@ -122,16 +122,29 @@ class TestGeminiImageGeneration:
         assert len(resp.data) >= 1
         _assert_image_item(resp.data[0])
 
-    def test_generation_respects_square_size(self, openai_client):
-        """1024x1024 is forwarded to Gemini as a 1:1 1K image config."""
-        model = "gemini-3.1-flash-image-preview"
+    @pytest.mark.parametrize(
+        ("model", "size", "expected_dimensions"),
+        [
+            ("gemini-2.5-flash-image", "896x1152", (896, 1152)),
+            ("gemini-3-pro-image-preview", "1792x2400", (1792, 2400)),
+            ("gemini-3.1-flash-image-preview", "1024x1024", (1024, 1024)),
+            ("gemini-3.1-flash-image-preview", "3:4", (896, 1200)),
+            ("gemini-3.1-flash-image-preview", "1792x2400", (1792, 2400)),
+            ("gemini-3.1-flash-image-preview", "896x1152", (928, 1152)),
+            ("gemini-3.1-flash-image-preview", "640x1024", (848, 1264)),
+        ],
+    )
+    def test_generation_respects_size_profile(
+        self, openai_client, model, size, expected_dimensions
+    ):
+        """Size is mapped through the selected Gemini model's output grid."""
         try:
             resp = openai_client.images.generate(
                 model=model,
                 prompt="A mountain landscape at sunset",
                 response_format="b64_json",
                 n=1,
-                size="1024x1024",
+                size=size,
             )
         except Exception as e:
             _skip_on_error(e, model)
@@ -139,7 +152,7 @@ class TestGeminiImageGeneration:
         assert resp.data, "Response data is empty"
         b64 = resp.data[0].b64_json
         assert b64, "Model did not return b64_json"
-        assert _image_dimensions(b64) == (1024, 1024)
+        assert _image_dimensions(b64) == expected_dimensions
 
     @pytest.mark.parametrize("model", TestModels.GEMINI_IMAGE_MODELS)
     def test_generation_count(self, openai_client, model):


### PR DESCRIPTION
## Summary
- add model-aware Gemini image grids
- map ratios and dimensions deterministically
- share sizing across generation and edit

## Why
Hardcoded sizes silently fell back to 1:1/1K and mixed incompatible model capabilities.

## Checks
- go test ./...
- make lint
- pytest tests/vertex/test_gemini_image.py --collect-only -q