### PR TITLE
Fix image edit model aliases

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -150,11 +150,12 @@ func (c *ProviderConverter) RequestFrom(body []byte) ([]byte, error) {
 		}
 
 		// /v1/images/edits uses multipart/form-data.  Rewrite the multipart to:
-		//   1. Fix image parts sent as application/octet-stream (detect real MIME from magic bytes).
-		//   2. Strip the response_format field for gpt-image-1 (JSON stripping won't work on multipart).
+		//   1. Replace model aliases with the provider-facing model name.
+		//   2. Fix image parts sent as application/octet-stream (detect real MIME from magic bytes).
+		//   3. Strip the response_format field for gpt-image-1 (JSON stripping won't work on multipart).
 		if c.mode.IsImageEdit && strings.Contains(strings.ToLower(c.mode.ContentType), "multipart/form-data") {
 			stripRF := openaiconv.IsGptImage1Model(c.mode.ModelID)
-			newBody, newCT := openaiconv.RewriteImageEditMultipart(body, c.mode.ContentType, stripRF)
+			newBody, newCT := openaiconv.RewriteImageEditMultipart(body, c.mode.ContentType, c.mode.ModelID, stripRF)
 			// Only replace when something actually changed (boundary or content differs).
 			if newCT != c.mode.ContentType {
 				c.rewrittenContentType = newCT

--- a/internal/converter/openai/multipart_rewrite.go
+++ b/internal/converter/openai/multipart_rewrite.go
@@ -62,19 +62,20 @@ type collectedPart struct {
 }
 
 // RewriteImageEditMultipart rewrites a multipart/form-data body for /v1/images/edits:
-//  1. Fixes image parts whose Content-Type is "application/octet-stream" by
+//  1. Replaces the model field with the provider-facing model name.
+//  2. Fixes image parts whose Content-Type is "application/octet-stream" by
 //     detecting the actual image format from magic bytes and setting the correct
 //     Content-Type (image/png, image/jpeg, or image/webp) and filename.
-//  2. Strips the "response_format" field when stripResponseFormat is true
+//  3. Strips the "response_format" field when stripResponseFormat is true
 //     (used for gpt-image-1 which rejects that parameter).
-//  3. Renames multiple "image" fields to "image[]" — when the client sends
+//  4. Renames multiple "image" fields to "image[]" — when the client sends
 //     more than one image using the same field name "image", OpenAI requires
 //     the array syntax "image[]" instead.
 //
 // Returns the rewritten body bytes and the new Content-Type header value
 // (multipart/form-data with updated boundary).  On any parse error the original
 // body and contentType are returned unchanged so the caller can still forward them.
-func RewriteImageEditMultipart(body []byte, contentType string, stripResponseFormat bool) (newBody []byte, newContentType string) {
+func RewriteImageEditMultipart(body []byte, contentType, modelID string, stripResponseFormat bool) (newBody []byte, newContentType string) {
 	// Parse the boundary from Content-Type.
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil || !strings.HasPrefix(mediaType, "multipart/") {
@@ -126,6 +127,9 @@ func RewriteImageEditMultipart(body []byte, contentType string, stripResponseFor
 		fieldName := p.fieldName
 		filename := p.filename
 		partData := p.data
+		if fieldName == "model" && modelID != "" {
+			partData = []byte(modelID)
+		}
 
 		// Skip response_format field when requested.
 		if stripResponseFormat && fieldName == "response_format" {

--- a/internal/converter/openai/multipart_rewrite_test.go
+++ b/internal/converter/openai/multipart_rewrite_test.go
@@ -188,9 +188,35 @@ func TestMimeTypeToExt(t *testing.T) {
 // RewriteImageEditMultipart — invalid / passthrough cases
 // ---------------------------------------------------------------------------
 
+func TestRewriteImageEditMultipart_ReplacesModel(t *testing.T) {
+	body, ct := buildMultipart(t, []struct {
+		name        string
+		contentType string
+		filename    string
+		data        []byte
+	}{
+		{"model", "", "", []byte("gpt-image-2-vsellm")},
+		{"prompt", "", "", []byte("make it blue")},
+		{"image", "image/png", "input.png", makePNG()},
+	})
+
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "gpt-image-2", false)
+	parts := parseResult(t, newBody, newCT)
+
+	if got := string(parts["model"].data); got != "gpt-image-2" {
+		t.Errorf("model = %q, want %q", got, "gpt-image-2")
+	}
+	if got := string(parts["prompt"].data); got != "make it blue" {
+		t.Errorf("prompt = %q, want %q", got, "make it blue")
+	}
+	if !bytes.Equal(parts["image"].data, makePNG()) {
+		t.Error("image data changed")
+	}
+}
+
 func TestRewriteImageEditMultipart_InvalidContentType(t *testing.T) {
 	body := []byte("not-multipart-data")
-	got, gotCT := RewriteImageEditMultipart(body, "application/json", false)
+	got, gotCT := RewriteImageEditMultipart(body, "application/json", "", false)
 	if !bytes.Equal(got, body) {
 		t.Error("expected original body returned for non-multipart content-type")
 	}
@@ -202,7 +228,7 @@ func TestRewriteImageEditMultipart_InvalidContentType(t *testing.T) {
 func TestRewriteImageEditMultipart_NoBoundary(t *testing.T) {
 	body := []byte("data")
 	ct := "multipart/form-data"
-	got, gotCT := RewriteImageEditMultipart(body, ct, false)
+	got, gotCT := RewriteImageEditMultipart(body, ct, "", false)
 	if !bytes.Equal(got, body) {
 		t.Error("expected original body returned when no boundary")
 	}
@@ -227,7 +253,7 @@ func TestRewriteImageEditMultipart_FixesPNGMIME(t *testing.T) {
 		{"image", "application/octet-stream", "", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 
 	parts := parseResult(t, newBody, newCT)
 	img, ok := parts["image"]
@@ -255,7 +281,7 @@ func TestRewriteImageEditMultipart_FixesJPEGMIME(t *testing.T) {
 		{"image", "application/octet-stream", "", makeJPEG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if parts["image"].contentType != "image/jpeg" {
@@ -276,7 +302,7 @@ func TestRewriteImageEditMultipart_FixesWEBPMIME(t *testing.T) {
 		{"image", "application/octet-stream", "", makeWEBP()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if parts["image"].contentType != "image/webp" {
@@ -295,7 +321,7 @@ func TestRewriteImageEditMultipart_PreservesExplicitPNGMIME(t *testing.T) {
 		{"image", "image/png", "photo.png", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if parts["image"].contentType != "image/png" {
@@ -318,7 +344,7 @@ func TestRewriteImageEditMultipart_UnknownImageData_NotChanged(t *testing.T) {
 		{"image", "application/octet-stream", "", unknownData},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	// Content-Type stays application/octet-stream (no detection possible).
@@ -342,7 +368,7 @@ func TestRewriteImageEditMultipart_MultipleImages_RenamedToArraySyntax(t *testin
 		{"image", "application/octet-stream", "", makeJPEG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 
 	// Count occurrences of "image" vs "image[]" in the rewritten body.
 	_, newParams, _ := mime.ParseMediaType(newCT)
@@ -385,7 +411,7 @@ func TestRewriteImageEditMultipart_SingleImage_KeepsOriginalName(t *testing.T) {
 		{"image", "application/octet-stream", "", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if _, exists := parts["image"]; !exists {
@@ -408,7 +434,7 @@ func TestRewriteImageEditMultipart_MultipleImages_MIMEFixed(t *testing.T) {
 		{"image[1]", "application/octet-stream", "", makeJPEG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if parts["image[0]"].contentType != "image/png" {
@@ -429,7 +455,7 @@ func TestRewriteImageEditMultipart_MaskField(t *testing.T) {
 		{"mask", "application/octet-stream", "", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if parts["mask"].contentType != "image/png" {
@@ -454,7 +480,7 @@ func TestRewriteImageEditMultipart_StripResponseFormat(t *testing.T) {
 		{"image", "application/octet-stream", "", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, true)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", true)
 	parts := parseResult(t, newBody, newCT)
 
 	if _, exists := parts["response_format"]; exists {
@@ -479,7 +505,7 @@ func TestRewriteImageEditMultipart_PreserveResponseFormat_WhenNotStripping(t *te
 		{"image", "application/octet-stream", "", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	if _, exists := parts["response_format"]; !exists {
@@ -505,7 +531,7 @@ func TestRewriteImageEditMultipart_AllFieldsPreserved(t *testing.T) {
 		{"image", "application/octet-stream", "", makePNG()},
 	})
 
-	newBody, newCT := RewriteImageEditMultipart(body, ct, false)
+	newBody, newCT := RewriteImageEditMultipart(body, ct, "", false)
 	parts := parseResult(t, newBody, newCT)
 
 	for _, field := range []string{"model", "prompt", "n", "size", "image"} {
@@ -531,7 +557,7 @@ func TestRewriteImageEditMultipart_NewBoundaryDiffersFromOriginal(t *testing.T) 
 		{"image", "application/octet-stream", "", makePNG()},
 	})
 
-	_, newCT := RewriteImageEditMultipart(body, ct, false)
+	_, newCT := RewriteImageEditMultipart(body, ct, "", false)
 
 	_, origParams, _ := mime.ParseMediaType(ct)
 	_, newParams, _ := mime.ParseMediaType(newCT)

--- a/internal/proxy/image_edit_model_alias_test.go
+++ b/internal/proxy/image_edit_model_alias_test.go
@@ -26,9 +26,9 @@ func TestProxyRequest_ImageEditReplacesModelAlias(t *testing.T) {
 		receivedModel = r.FormValue("model")
 		file, _, err := r.FormFile("image")
 		require.NoError(t, err)
-		defer file.Close()
 		receivedImage, err = io.ReadAll(file)
 		require.NoError(t, err)
+		require.NoError(t, file.Close())
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = io.WriteString(w, `{"created":1,"data":[{"b64_json":"aW1hZ2U="}]}`)

--- a/internal/proxy/image_edit_model_alias_test.go
+++ b/internal/proxy/image_edit_model_alias_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"bytes"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyRequest_ImageEditReplacesModelAlias(t *testing.T) {
+	const modelAlias = "gpt-image-2-vsellm"
+	const realModel = "gpt-image-2"
+	imageData := []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+	var receivedModel string
+	var receivedImage []byte
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		receivedModel = r.FormValue("model")
+		file, _, err := r.FormFile("image")
+		require.NoError(t, err)
+		defer file.Close()
+		receivedImage, err = io.ReadAll(file)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"created":1,"data":[{"b64_json":"aW1hZ2U="}]}`)
+	}))
+	defer upstream.Close()
+
+	logger := testhelpers.NewTestLogger()
+	modelManager := models.New(logger, 50, []config.ModelRPMConfig{
+		{Name: modelAlias, Model: realModel, RPM: 100, TPM: -1},
+	})
+	proxy := NewTestProxyBuilder().
+		WithSingleCredential("azure", config.ProviderTypeOpenAI, upstream.URL, "azure-key").
+		Build()
+	proxy.modelManager = modelManager
+	proxy.balancer.SetModelChecker(modelManager)
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	require.NoError(t, writer.WriteField("model", modelAlias))
+	require.NoError(t, writer.WriteField("prompt", "make it blue"))
+	imagePart, err := writer.CreateFormFile("image", "input.png")
+	require.NoError(t, err)
+	_, err = imagePart.Write(imageData)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	response := httptest.NewRecorder()
+
+	proxy.ProxyRequest(response, req)
+
+	require.Equal(t, http.StatusOK, response.Code)
+	require.Equal(t, realModel, receivedModel)
+	require.Equal(t, imageData, receivedImage)
+}


### PR DESCRIPTION
Fixes provider model rewriting for multipart image edit requests.

The JSON-only alias replacement left `gpt-image-2-vsellm` in the multipart `model` field, so Azure returned `DeploymentNotFound`. Image edits now send the provider-facing model name without changing the uploaded image.

Checks: `go test ./...`, `go vet ./...`.
