### PR TITLE
Fix Gemini image Responses output and billing

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -335,6 +335,7 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		OutputTokensDetails struct {
 			AudioTokens     int `json:"audio_tokens,omitempty"`
 			ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+			ImageTokens     int `json:"image_tokens,omitempty"`
 		} `json:"output_tokens_details,omitempty"`
 	}
 
@@ -349,12 +350,14 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 				CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
 				AudioTokens         int `json:"audio_tokens,omitempty"`
 				TextTokens          int `json:"text_tokens,omitempty"`
+				ImageTokens         int `json:"image_tokens,omitempty"`
 			} `json:"prompt_tokens_details,omitempty"`
 			CompletionTokensDetails struct {
 				AcceptedPredictionTokens int `json:"accepted_prediction_tokens,omitempty"`
 				RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
 				AudioTokens              int `json:"audio_tokens,omitempty"`
 				ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
+				ImageTokens              int `json:"image_tokens,omitempty"`
 			} `json:"completion_tokens_details,omitempty"`
 			// Responses API / Image generation format (input_tokens/output_tokens)
 			responsesUsageDetails
@@ -409,6 +412,10 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 	if audioIn == 0 {
 		audioIn = resp.Usage.InputTokensDetails.AudioTokens
 	}
+	inputImageTokens := resp.Usage.PromptTokensDetails.ImageTokens
+	if inputImageTokens == 0 {
+		inputImageTokens = resp.Usage.InputTokensDetails.ImageTokens
+	}
 	audioOut := resp.Usage.CompletionTokensDetails.AudioTokens
 	if audioOut == 0 {
 		audioOut = resp.Usage.OutputTokensDetails.AudioTokens
@@ -416,6 +423,10 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 	reasoning := resp.Usage.CompletionTokensDetails.ReasoningTokens
 	if reasoning == 0 {
 		reasoning = resp.Usage.OutputTokensDetails.ReasoningTokens
+	}
+	outputImageTokens := resp.Usage.CompletionTokensDetails.ImageTokens
+	if outputImageTokens == 0 {
+		outputImageTokens = resp.Usage.OutputTokensDetails.ImageTokens
 	}
 
 	// If tokens came from the nested response.completed event, use its detail fields
@@ -433,11 +444,17 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		if audioIn == 0 {
 			audioIn = u.InputTokensDetails.AudioTokens
 		}
+		if inputImageTokens == 0 {
+			inputImageTokens = u.InputTokensDetails.ImageTokens
+		}
 		if audioOut == 0 {
 			audioOut = u.OutputTokensDetails.AudioTokens
 		}
 		if reasoning == 0 {
 			reasoning = u.OutputTokensDetails.ReasoningTokens
+		}
+		if outputImageTokens == 0 {
+			outputImageTokens = u.OutputTokensDetails.ImageTokens
 		}
 	}
 
@@ -447,7 +464,8 @@ func ExtractTokenUsage(body []byte) *TokenUsage {
 		CachedInputTokens:        cachedTokens,
 		CacheCreationTokens:      cacheCreationTokens,
 		AudioInputTokens:         audioIn,
-		ImageTokens:              resp.Usage.InputTokensDetails.ImageTokens,
+		ImageTokens:              inputImageTokens,
+		OutputImageTokens:        outputImageTokens,
 		AcceptedPredictionTokens: resp.Usage.CompletionTokensDetails.AcceptedPredictionTokens,
 		RejectedPredictionTokens: resp.Usage.CompletionTokensDetails.RejectedPredictionTokens,
 		AudioOutputTokens:        audioOut,

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -518,7 +518,7 @@ func TestExtractTokenUsage(t *testing.T) {
 		t.Fatalf("expected nil for invalid json")
 	}
 
-	chatBody := []byte(`{"usage":{"prompt_tokens":5,"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":2,"cache_creation_tokens":4,"audio_tokens":1},"completion_tokens_details":{"accepted_prediction_tokens":3,"rejected_prediction_tokens":1,"audio_tokens":4,"reasoning_tokens":6}}}`)
+	chatBody := []byte(`{"usage":{"prompt_tokens":5,"completion_tokens":7,"prompt_tokens_details":{"cached_tokens":2,"cache_creation_tokens":4,"audio_tokens":1},"completion_tokens_details":{"accepted_prediction_tokens":3,"rejected_prediction_tokens":1,"audio_tokens":4,"reasoning_tokens":6,"image_tokens":2}}}`)
 	usage := ExtractTokenUsage(chatBody)
 	if usage == nil {
 		t.Fatalf("expected usage for chat format")
@@ -532,6 +532,9 @@ func TestExtractTokenUsage(t *testing.T) {
 	}
 	if usage.AcceptedPredictionTokens != 3 || usage.RejectedPredictionTokens != 1 {
 		t.Fatalf("unexpected prediction tokens: %+v", usage)
+	}
+	if usage.OutputImageTokens != 2 {
+		t.Fatalf("expected output image tokens, got %+v", usage)
 	}
 
 	imageBody := []byte(`{"usage":{"input_tokens":9,"output_tokens":10,"input_tokens_details":{"image_tokens":8}}}`)
@@ -561,7 +564,7 @@ func TestExtractTokenUsage_ImageFallback(t *testing.T) {
 func TestExtractTokenUsage_ResponsesAPI(t *testing.T) {
 	// Responses API format (GPT-5, /v1/responses) uses input_tokens/output_tokens
 	// with output_tokens_details instead of completion_tokens_details
-	body := []byte(`{"usage":{"input_tokens":150,"output_tokens":80,"total_tokens":230,"input_tokens_details":{"cached_tokens":30,"audio_tokens":10},"output_tokens_details":{"reasoning_tokens":25,"audio_tokens":5}}}`)
+	body := []byte(`{"usage":{"input_tokens":150,"output_tokens":80,"total_tokens":230,"input_tokens_details":{"cached_tokens":30,"audio_tokens":10},"output_tokens_details":{"reasoning_tokens":25,"audio_tokens":5,"image_tokens":40}}}`)
 	usage := ExtractTokenUsage(body)
 	if usage == nil {
 		t.Fatalf("expected usage for Responses API format")
@@ -581,6 +584,9 @@ func TestExtractTokenUsage_ResponsesAPI(t *testing.T) {
 	}
 	if usage.AudioOutputTokens != 5 {
 		t.Fatalf("expected audio_output=5, got %d", usage.AudioOutputTokens)
+	}
+	if usage.OutputImageTokens != 40 {
+		t.Fatalf("expected output_image_tokens=40, got %d", usage.OutputImageTokens)
 	}
 }
 
@@ -616,7 +622,7 @@ func TestExtractTokenUsage_CacheWriteTokens(t *testing.T) {
 func TestExtractTokenUsage_ResponsesAPIStreamingEvent(t *testing.T) {
 	// Responses API streaming event format: response.completed SSE event
 	// Usage is nested inside response.usage, not at top level
-	body := []byte(`{"type":"response.completed","response":{"id":"resp_123","object":"response","status":"completed","model":"qwen3","output":[],"usage":{"input_tokens":16,"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0},"input_tokens_details":{"cached_tokens":5},"total_tokens":18}}}`)
+	body := []byte(`{"type":"response.completed","response":{"id":"resp_123","object":"response","status":"completed","model":"qwen3","output":[],"usage":{"input_tokens":16,"output_tokens":2,"output_tokens_details":{"reasoning_tokens":0,"image_tokens":2},"input_tokens_details":{"cached_tokens":5},"total_tokens":18}}}`)
 	usage := ExtractTokenUsage(body)
 	if usage == nil {
 		t.Fatalf("expected usage for Responses API streaming event format")
@@ -627,6 +633,9 @@ func TestExtractTokenUsage_ResponsesAPIStreamingEvent(t *testing.T) {
 	}
 	if usage.CompletionTokens != 2 {
 		t.Fatalf("expected completion_tokens=2, got %d", usage.CompletionTokens)
+	}
+	if usage.OutputImageTokens != 2 {
+		t.Fatalf("expected output_image_tokens=2, got %d", usage.OutputImageTokens)
 	}
 	if usage.CachedInputTokens != 5 {
 		t.Fatalf("expected cached_tokens=5, got %d", usage.CachedInputTokens)

--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -133,6 +133,7 @@ type CompletionTokenDetails struct {
 	RejectedPredictionTokens int `json:"rejected_prediction_tokens,omitempty"`
 	AudioTokens              int `json:"audio_tokens,omitempty"`
 	ReasoningTokens          int `json:"reasoning_tokens,omitempty"`
+	ImageTokens              int `json:"image_tokens,omitempty"`
 }
 
 type OpenAIUsage struct {

--- a/internal/converter/responses/response.go
+++ b/internal/converter/responses/response.go
@@ -3,6 +3,7 @@ package responses
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 )
 
 // chatToResponseConfig holds optional parameters for ChatToResponse.
@@ -35,9 +36,15 @@ func ChatToResponse(body []byte, opts ...ChatToResponseOption) ([]byte, error) {
 		Choices []struct {
 			Index   int `json:"index"`
 			Message struct {
-				Role      string      `json:"role"`
-				Content   interface{} `json:"content"`
-				Refusal   string      `json:"refusal,omitempty"`
+				Role    string      `json:"role"`
+				Content interface{} `json:"content"`
+				Refusal string      `json:"refusal,omitempty"`
+				Images  []struct {
+					B64JSON  string `json:"b64_json,omitempty"`
+					ImageURL *struct {
+						URL string `json:"url"`
+					} `json:"image_url,omitempty"`
+				} `json:"images,omitempty"`
 				ToolCalls []struct {
 					ID       string `json:"id"`
 					Type     string `json:"type"`
@@ -58,6 +65,7 @@ func ChatToResponse(body []byte, opts ...ChatToResponseOption) ([]byte, error) {
 			} `json:"prompt_tokens_details,omitempty"`
 			CompletionTokensDetails *struct {
 				ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+				ImageTokens     int `json:"image_tokens,omitempty"`
 			} `json:"completion_tokens_details,omitempty"`
 		} `json:"usage,omitempty"`
 	}
@@ -100,6 +108,20 @@ func ChatToResponse(body []byte, opts ...ChatToResponseOption) ([]byte, error) {
 					Content: msgContent,
 				}
 				output = append(output, msgItem)
+			}
+
+			for _, image := range choice.Message.Images {
+				result, outputFormat := responseImageResult(image.B64JSON, image.ImageURL)
+				if result == "" {
+					continue
+				}
+				output = append(output, OutputItem{
+					Type:         "image_generation_call",
+					ID:           GenerateItemID("ig_"),
+					Status:       "completed",
+					Result:       result,
+					OutputFormat: outputFormat,
+				})
 			}
 
 			// Add function_call output items for each tool call
@@ -151,6 +173,7 @@ func ChatToResponse(body []byte, opts ...ChatToResponseOption) ([]byte, error) {
 		}
 		if ccResp.Usage.CompletionTokensDetails != nil {
 			usage.OutputTokensDetails.ReasoningTokens = ccResp.Usage.CompletionTokensDetails.ReasoningTokens
+			usage.OutputTokensDetails.ImageTokens = ccResp.Usage.CompletionTokensDetails.ImageTokens
 		}
 	}
 
@@ -173,6 +196,32 @@ func ChatToResponse(body []byte, opts ...ChatToResponseOption) ([]byte, error) {
 		return nil, fmt.Errorf("failed to marshal responses API response: %w", err)
 	}
 	return result, nil
+}
+
+func responseImageResult(b64JSON string, imageURL *struct {
+	URL string `json:"url"`
+}) (result, outputFormat string) {
+	if b64JSON != "" {
+		return b64JSON, ""
+	}
+	if imageURL == nil {
+		return "", ""
+	}
+	url := imageURL.URL
+	comma := strings.IndexByte(url, ',')
+	if comma < 0 || !strings.HasPrefix(strings.ToLower(url), "data:image/") {
+		return "", ""
+	}
+	header := url[:comma]
+	if !strings.Contains(strings.ToLower(header), ";base64") {
+		return "", ""
+	}
+	mimeType := strings.TrimPrefix(strings.SplitN(header, ";", 2)[0], "data:")
+	format := strings.TrimPrefix(strings.ToLower(mimeType), "image/")
+	if format == "jpg" {
+		format = "jpeg"
+	}
+	return url[comma+1:], format
 }
 
 func convertChatMessageContent(content interface{}) []OutputContent {

--- a/internal/converter/responses/response_test.go
+++ b/internal/converter/responses/response_test.go
@@ -265,6 +265,42 @@ func TestChatToResponse_Usage(t *testing.T) {
 	assert.Equal(t, 10, resp.Usage.OutputTokensDetails.ReasoningTokens)
 }
 
+func TestChatToResponse_GeminiImageAndImageTokenUsage(t *testing.T) {
+	ccBody := `{
+		"id": "chatcmpl-image",
+		"object": "chat.completion",
+		"created": 1700000000,
+		"model": "gemini-3.1-flash-image-preview",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"content": "",
+				"images": [{"type": "image_url", "image_url": {"url": "data:image/png;base64,aW1hZ2U="}}]
+			},
+			"finish_reason": "stop"
+		}],
+		"usage": {
+			"prompt_tokens": 22,
+			"completion_tokens": 1120,
+			"total_tokens": 1142,
+			"completion_tokens_details": {"image_tokens": 1120}
+		}
+	}`
+
+	result, err := ChatToResponse([]byte(ccBody))
+	require.NoError(t, err)
+
+	var resp Response
+	require.NoError(t, json.Unmarshal(result, &resp))
+	require.Len(t, resp.Output, 1)
+	assert.Equal(t, "image_generation_call", resp.Output[0].Type)
+	assert.Equal(t, "aW1hZ2U=", resp.Output[0].Result)
+	assert.Equal(t, "png", resp.Output[0].OutputFormat)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, 1120, resp.Usage.OutputTokensDetails.ImageTokens)
+}
+
 func TestChatToResponse_Status(t *testing.T) {
 	tests := []struct {
 		finishReason string

--- a/internal/converter/responses/streaming.go
+++ b/internal/converter/responses/streaming.go
@@ -75,6 +75,7 @@ type chatCompletionsUsage struct {
 	ReasoningTokens   int
 	AudioInputTokens  int
 	AudioOutputTokens int
+	ImageOutputTokens int
 }
 
 // chatStreamChunk represents a parsed Chat Completions streaming chunk.
@@ -112,6 +113,7 @@ type chatStreamChunk struct {
 		CompletionTokensDetails *struct {
 			ReasoningTokens int `json:"reasoning_tokens,omitempty"`
 			AudioTokens     int `json:"audio_tokens,omitempty"`
+			ImageTokens     int `json:"image_tokens,omitempty"`
 		} `json:"completion_tokens_details,omitempty"`
 	} `json:"usage,omitempty"`
 }
@@ -220,6 +222,7 @@ func transformChatStreamToResponsesInner(reader io.Reader, writer io.Writer, mod
 			if chunk.Usage.CompletionTokensDetails != nil {
 				acc.usage.ReasoningTokens = chunk.Usage.CompletionTokensDetails.ReasoningTokens
 				acc.usage.AudioOutputTokens = chunk.Usage.CompletionTokensDetails.AudioTokens
+				acc.usage.ImageOutputTokens = chunk.Usage.CompletionTokensDetails.ImageTokens
 			}
 		}
 
@@ -453,7 +456,7 @@ func buildTypedCompletedResponse(acc *streamAccumulator) *Response {
 			OutputTokens:        acc.usage.CompletionTokens,
 			TotalTokens:         acc.usage.TotalTokens,
 			InputTokensDetails:  InputDetails{CachedTokens: acc.usage.CachedTokens, AudioTokens: acc.usage.AudioInputTokens},
-			OutputTokensDetails: OutputDetails{ReasoningTokens: acc.usage.ReasoningTokens, AudioTokens: acc.usage.AudioOutputTokens},
+			OutputTokensDetails: OutputDetails{ReasoningTokens: acc.usage.ReasoningTokens, AudioTokens: acc.usage.AudioOutputTokens, ImageTokens: acc.usage.ImageOutputTokens},
 		}
 	}
 
@@ -706,9 +709,12 @@ func buildCompletedResponse(acc *streamAccumulator) map[string]interface{} {
 			TotalTokens:  acc.usage.TotalTokens,
 			InputTokensDetails: InputDetails{
 				CachedTokens: acc.usage.CachedTokens,
+				AudioTokens:  acc.usage.AudioInputTokens,
 			},
 			OutputTokensDetails: OutputDetails{
 				ReasoningTokens: acc.usage.ReasoningTokens,
+				AudioTokens:     acc.usage.AudioOutputTokens,
+				ImageTokens:     acc.usage.ImageOutputTokens,
 			},
 		}
 	}

--- a/internal/converter/responses/types.go
+++ b/internal/converter/responses/types.go
@@ -240,6 +240,7 @@ type InputDetails struct {
 type OutputDetails struct {
 	ReasoningTokens int `json:"reasoning_tokens"`
 	AudioTokens     int `json:"audio_tokens,omitempty"` // extension: audio output tokens
+	ImageTokens     int `json:"image_tokens,omitempty"` // extension: generated image/video tokens
 }
 
 // ===== Incomplete Details =====

--- a/internal/converter/token_usage.go
+++ b/internal/converter/token_usage.go
@@ -14,7 +14,8 @@ type TokenUsage struct {
 	AcceptedPredictionTokens int
 	RejectedPredictionTokens int
 	ImageCount               int // Number of images to generate (1-10)
-	ImageTokens              int // Token count for image processing
+	ImageTokens              int // Input image/video tokens
+	OutputImageTokens        int // Generated image/video tokens
 }
 
 // Total returns the sum of prompt and completion tokens.

--- a/internal/converter/vertex/response.go
+++ b/internal/converter/vertex/response.go
@@ -189,8 +189,11 @@ func convertVertexUsageMetadata(meta *genai.GenerateContentResponseUsageMetadata
 			case genai.MediaModalityAudio:
 				usage.CompletionTokensDetails.AudioTokens += int(detail.TokenCount)
 			case genai.MediaModalityImage, genai.MediaModalityVideo:
-				// Image/video tokens are already included in CompletionTokens total;
-				// OpenAI format has no dedicated field for these modalities
+				// LiteLLM supports image_tokens as an extension to the OpenAI
+				// completion token details. Preserve the modality so generated
+				// images are billed with output_cost_per_image_token instead of
+				// the much lower text output rate.
+				usage.CompletionTokensDetails.ImageTokens += int(detail.TokenCount)
 			}
 		}
 	}

--- a/internal/converter/vertex/response_test.go
+++ b/internal/converter/vertex/response_test.go
@@ -392,9 +392,9 @@ func TestConvertVertexUsageMetadata_NilModalityEntries(t *testing.T) {
 	}
 }
 
-// TestConvertVertexUsageMetadata_ImageVideoTokensIgnored verifies that image and video
-// tokens in modality details are not mapped to any OpenAI field (no dedicated field exists).
-func TestConvertVertexUsageMetadata_ImageVideoTokensIgnored(t *testing.T) {
+// TestConvertVertexUsageMetadata_ImageVideoTokens verifies that generated media tokens
+// are exposed through LiteLLM's completion_tokens_details.image_tokens extension.
+func TestConvertVertexUsageMetadata_ImageVideoTokens(t *testing.T) {
 	meta := &genai.GenerateContentResponseUsageMetadata{
 		PromptTokenCount:     200,
 		CandidatesTokenCount: 50,
@@ -411,13 +411,16 @@ func TestConvertVertexUsageMetadata_ImageVideoTokensIgnored(t *testing.T) {
 
 	usage := convertVertexUsageMetadata(meta)
 
-	// Image/video have no OpenAI field → PromptTokensDetails has no audio entry
+	// Input image/video details remain part of PromptTokens; this converter only
+	// exposes the generated media breakdown needed for output billing.
 	if usage.PromptTokensDetails != nil && usage.PromptTokensDetails.AudioTokens != 0 {
 		t.Fatalf("expected no audio tokens from image/video, got %d", usage.PromptTokensDetails.AudioTokens)
 	}
-	// CompletionTokensDetails may be nil or have zero audio tokens
-	if usage.CompletionTokensDetails != nil && usage.CompletionTokensDetails.AudioTokens != 0 {
-		t.Fatalf("expected no audio output tokens from image/video, got %d", usage.CompletionTokensDetails.AudioTokens)
+	if usage.CompletionTokensDetails == nil {
+		t.Fatal("expected completion token details for generated media")
+	}
+	if usage.CompletionTokensDetails.ImageTokens != 50 {
+		t.Fatalf("expected 50 image/video output tokens, got %d", usage.CompletionTokensDetails.ImageTokens)
 	}
 	// Total tokens still correct
 	if usage.PromptTokens != 200 || usage.CompletionTokens != 50 {

--- a/internal/converter/vertex/responses/request.go
+++ b/internal/converter/vertex/responses/request.go
@@ -266,6 +266,17 @@ func buildGenConfig(req *responses.Request, model string) *genai.GenerationConfi
 	cfg := &genai.GenerationConfig{}
 	hasParams := false
 
+	// OpenAI exposes image generation as a built-in Responses tool. Vertex does
+	// not have an equivalent tool object; Gemini image models select generated
+	// image output through generationConfig.responseModalities instead.
+	for _, tool := range req.Tools {
+		if tool.Type == "image_generation" {
+			cfg.ResponseModalities = []genai.Modality{genai.Modality("IMAGE")}
+			hasParams = true
+			break
+		}
+	}
+
 	if req.MaxOutputTokens != nil {
 		cfg.MaxOutputTokens = int32(*req.MaxOutputTokens)
 		hasParams = true

--- a/internal/converter/vertex/responses/request_test.go
+++ b/internal/converter/vertex/responses/request_test.go
@@ -122,6 +122,24 @@ func TestResponsesRequestToVertex_CodeInterpreterTool(t *testing.T) {
 	assert.Contains(t, tool, "codeExecution")
 }
 
+func TestResponsesRequestToVertex_ImageGenerationToolRequestsImageModality(t *testing.T) {
+	body := `{
+		"model": "gemini-3.1-flash-image-preview",
+		"input": "Generate a product image",
+		"tools": [{"type": "image_generation"}]
+	}`
+
+	result, err := ResponsesRequestToVertex([]byte(body), "gemini-3.1-flash-image-preview")
+	require.NoError(t, err)
+
+	var vr map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &vr))
+	assert.NotContains(t, vr, "tools", "image_generation is a response modality, not a Vertex tool")
+
+	cfg := vr["generationConfig"].(map[string]interface{})
+	assert.Equal(t, []interface{}{"IMAGE"}, cfg["responseModalities"])
+}
+
 func TestResponsesRequestToVertex_ConversationHistory(t *testing.T) {
 	body := `{
 		"model": "gemini-2.0-flash",

--- a/internal/converter/vertex/responses/response.go
+++ b/internal/converter/vertex/responses/response.go
@@ -1,8 +1,10 @@
 package vertexresponses
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/responses"
@@ -139,6 +141,22 @@ func candidatesToOutputItems(vertexResp *genai.GenerateContentResponse) []respon
 					}
 				}
 
+			case part.InlineData != nil:
+				// Gemini image models return generated media as inlineData. The
+				// Responses API represents a generated image as a standalone
+				// image_generation_call whose result is raw base64 (without the
+				// data-URL prefix).
+				if strings.HasPrefix(strings.ToLower(part.InlineData.MIMEType), "image/") {
+					flushMessage()
+					output = append(output, responses.OutputItem{
+						Type:         "image_generation_call",
+						ID:           responses.GenerateItemID("ig_"),
+						Status:       "completed",
+						Result:       base64.StdEncoding.EncodeToString(part.InlineData.Data),
+						OutputFormat: imageOutputFormat(part.InlineData.MIMEType),
+					})
+				}
+
 			case part.Text != "":
 				// Regular text → accumulate as output_text content part.
 				msgContent = append(msgContent, responses.OutputContent{
@@ -181,6 +199,14 @@ func candidatesToOutputItems(vertexResp *genai.GenerateContentResponse) []respon
 	}
 
 	return output
+}
+
+func imageOutputFormat(mimeType string) string {
+	format := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(mimeType)), "image/")
+	if format == "jpg" {
+		return "jpeg"
+	}
+	return format
 }
 
 type textPartRef struct {
@@ -299,6 +325,16 @@ func usageMetadataToUsage(meta *genai.GenerateContentResponseUsageMetadata) *res
 	// Extract specialized token counts from modality details.
 	thoughtTokens := int(meta.ThoughtsTokenCount)
 	cachedTokens := int(meta.CachedContentTokenCount)
+	imageTokens := 0
+	for _, detail := range meta.CandidatesTokensDetails {
+		if detail == nil {
+			continue
+		}
+		switch genai.MediaModality(detail.Modality) {
+		case genai.MediaModalityImage, genai.MediaModalityVideo:
+			imageTokens += int(detail.TokenCount)
+		}
+	}
 
 	return &responses.Usage{
 		InputTokens:  int(meta.PromptTokenCount),
@@ -309,6 +345,7 @@ func usageMetadataToUsage(meta *genai.GenerateContentResponseUsageMetadata) *res
 		},
 		OutputTokensDetails: responses.OutputDetails{
 			ReasoningTokens: thoughtTokens,
+			ImageTokens:     imageTokens,
 		},
 	}
 }

--- a/internal/converter/vertex/responses/response_test.go
+++ b/internal/converter/vertex/responses/response_test.go
@@ -1,6 +1,7 @@
 package vertexresponses
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
@@ -8,6 +9,87 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genai"
 )
+
+func TestCandidatesToOutputItems_InlineImageBecomesImageGenerationCall(t *testing.T) {
+	imageBytes := []byte("generated-png")
+	vertexResp := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{
+			{
+				Content: &genai.Content{
+					Role: "model",
+					Parts: []*genai.Part{
+						{Text: "Here is the image."},
+						{InlineData: &genai.Blob{MIMEType: "image/png", Data: imageBytes}},
+					},
+				},
+				FinishReason: genai.FinishReasonStop,
+			},
+		},
+	}
+
+	output := candidatesToOutputItems(vertexResp)
+	require.Len(t, output, 2)
+	assert.Equal(t, "message", output[0].Type)
+	assert.Equal(t, "Here is the image.", output[0].Content[0].Text)
+
+	imageCall := output[1]
+	assert.Equal(t, "image_generation_call", imageCall.Type)
+	assert.Equal(t, "completed", imageCall.Status)
+	assert.NotEmpty(t, imageCall.ID)
+	assert.Equal(t, base64.StdEncoding.EncodeToString(imageBytes), imageCall.Result)
+	assert.Equal(t, "png", imageCall.OutputFormat)
+}
+
+func TestUsageMetadataToUsage_PreservesImageOutputTokens(t *testing.T) {
+	meta := &genai.GenerateContentResponseUsageMetadata{
+		PromptTokenCount:     22,
+		CandidatesTokenCount: 1127,
+		TotalTokenCount:      1149,
+		CandidatesTokensDetails: []*genai.ModalityTokenCount{
+			{Modality: genai.MediaModalityText, TokenCount: 7},
+			{Modality: genai.MediaModalityImage, TokenCount: 1120},
+		},
+	}
+
+	usage := usageMetadataToUsage(meta)
+	require.NotNil(t, usage)
+	assert.Equal(t, 22, usage.InputTokens)
+	assert.Equal(t, 1127, usage.OutputTokens)
+	assert.Equal(t, 1120, usage.OutputTokensDetails.ImageTokens)
+
+	raw, err := json.Marshal(usage)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"input_tokens": 22,
+		"output_tokens": 1127,
+		"total_tokens": 1149,
+		"input_tokens_details": {"cached_tokens": 0},
+		"output_tokens_details": {"reasoning_tokens": 0, "image_tokens": 1120}
+	}`, string(raw))
+}
+
+func TestVertexToResponsesResponse_ImageGenerationRoundTrip(t *testing.T) {
+	providerBody := `{
+		"candidates": [{
+			"content": {"role": "model", "parts": [{"inlineData": {"mimeType": "image/png", "data": "aW1hZ2U="}}]},
+			"finishReason": "STOP"
+		}],
+		"usageMetadata": {
+			"promptTokenCount": 22,
+			"candidatesTokenCount": 1120,
+			"totalTokenCount": 1142,
+			"candidatesTokensDetails": [{"modality": "IMAGE", "tokenCount": 1120}]
+		}
+	}`
+
+	resp, err := VertexToResponsesResponse([]byte(providerBody), "gemini-3.1-flash-image-preview", "resp_test", 123)
+	require.NoError(t, err)
+	require.Len(t, resp.Output, 1)
+	assert.Equal(t, "image_generation_call", resp.Output[0].Type)
+	assert.Equal(t, "aW1hZ2U=", resp.Output[0].Result)
+	require.NotNil(t, resp.Usage)
+	assert.Equal(t, 1120, resp.Usage.OutputTokensDetails.ImageTokens)
+}
 
 func TestCandidatesToOutputItems_CodeInterpreter_CodeAndResult(t *testing.T) {
 	vertexResp := &genai.GenerateContentResponse{

--- a/internal/converter/vertex/responses/streaming.go
+++ b/internal/converter/vertex/responses/streaming.go
@@ -2,6 +2,7 @@ package vertexresponses
 
 import (
 	"bufio"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -26,6 +27,7 @@ type vertexStreamAccumulator struct {
 	fullText       string
 	fullReasoning  string
 	toolCalls      []accumulatedCall
+	images         []accumulatedImage
 	codeCallID     string
 	codeCallCode   string
 	codeCallOutput string
@@ -57,6 +59,13 @@ type accumulatedCall struct {
 	arguments   string
 	itemID      string
 	outputIndex int // output_index at which the item was announced
+}
+
+type accumulatedImage struct {
+	itemID      string
+	result      string
+	format      string
+	outputIndex int
 }
 
 // TransformVertexStreamToResponses reads Vertex AI SSE and writes Responses API SSE events.
@@ -157,10 +166,43 @@ func processPart(w io.Writer, acc *vertexStreamAccumulator, part *genai.Part) er
 		acc.codeCallOutput += part.CodeExecutionResult.Output
 		return nil
 
+	case part.InlineData != nil:
+		return processImagePart(w, acc, part.InlineData)
+
 	case part.Text != "":
 		return processTextDelta(w, acc, part.Text)
 	}
 	return nil
+}
+
+func processImagePart(w io.Writer, acc *vertexStreamAccumulator, blob *genai.Blob) error {
+	if blob == nil || !strings.HasPrefix(strings.ToLower(blob.MIMEType), "image/") {
+		return nil
+	}
+	if !acc.headerEmitted {
+		if err := emitVertexHeaderEvents(w, acc); err != nil {
+			return err
+		}
+	}
+
+	image := accumulatedImage{
+		itemID:      generateItemID("ig_"),
+		result:      base64.StdEncoding.EncodeToString(blob.Data),
+		format:      imageOutputFormat(blob.MIMEType),
+		outputIndex: currentOutputIndex(acc),
+	}
+	acc.images = append(acc.images, image)
+
+	return writeVertexSSE(w, "response.output_item.added", map[string]interface{}{
+		"type":         "response.output_item.added",
+		"output_index": image.outputIndex,
+		"item": map[string]interface{}{
+			"type":          "image_generation_call",
+			"id":            image.itemID,
+			"status":        "in_progress",
+			"output_format": image.format,
+		},
+	}, acc)
 }
 
 func processTextDelta(w io.Writer, acc *vertexStreamAccumulator, delta string) error {
@@ -305,6 +347,7 @@ func currentOutputIndex(acc *vertexStreamAccumulator) int {
 		idx++
 	}
 	idx += len(acc.toolCalls)
+	idx += len(acc.images)
 	if acc.codeCallID != "" {
 		idx++
 	}
@@ -422,6 +465,26 @@ func emitVertexCompletionEvents(w io.Writer, acc *vertexStreamAccumulator) error
 		})
 	}
 
+	for _, image := range acc.images {
+		image := image
+		closures = append(closures, closureItem{
+			outputIndex: image.outputIndex,
+			fn: func() error {
+				return writeVertexSSE(w, "response.output_item.done", map[string]interface{}{
+					"type":         "response.output_item.done",
+					"output_index": image.outputIndex,
+					"item": map[string]interface{}{
+						"type":          "image_generation_call",
+						"id":            image.itemID,
+						"status":        "completed",
+						"result":        image.result,
+						"output_format": image.format,
+					},
+				}, acc)
+			},
+		})
+	}
+
 	if acc.codeCallID != "" {
 		idx := acc.codeOutputIndex
 		closures = append(closures, closureItem{
@@ -470,44 +533,79 @@ func buildVertexInProgressResponse(acc *vertexStreamAccumulator) map[string]inte
 func buildVertexCompletedResponse(acc *vertexStreamAccumulator) *responses.Response {
 	status, incompleteDetails := vertexFinishReasonToStatus(acc.finishReason)
 
-	var output []responses.OutputItem
+	type indexedOutputItem struct {
+		index int
+		item  responses.OutputItem
+	}
+	var indexedOutput []indexedOutputItem
 	if acc.reasoningStarted && acc.fullReasoning != "" {
-		output = append(output, responses.OutputItem{
-			Type:   "reasoning",
-			ID:     acc.reasoningItemID,
-			Status: "completed",
-			Summary: []responses.OutputContent{
-				{Type: "summary_text", Text: acc.fullReasoning},
+		indexedOutput = append(indexedOutput, indexedOutputItem{
+			index: acc.reasoningOutputIndex,
+			item: responses.OutputItem{
+				Type:   "reasoning",
+				ID:     acc.reasoningItemID,
+				Status: "completed",
+				Summary: []responses.OutputContent{
+					{Type: "summary_text", Text: acc.fullReasoning},
+				},
 			},
 		})
 	}
 	if acc.messageStarted {
-		output = append(output, responses.OutputItem{
-			Type:    "message",
-			ID:      acc.messageItemID,
-			Status:  "completed",
-			Role:    "assistant",
-			Content: []responses.OutputContent{{Type: "output_text", Text: acc.fullText, Annotations: []responses.Annotation{}}},
+		indexedOutput = append(indexedOutput, indexedOutputItem{
+			index: acc.messageOutputIndex,
+			item: responses.OutputItem{
+				Type:    "message",
+				ID:      acc.messageItemID,
+				Status:  "completed",
+				Role:    "assistant",
+				Content: []responses.OutputContent{{Type: "output_text", Text: acc.fullText, Annotations: []responses.Annotation{}}},
+			},
 		})
 	}
 	for _, tc := range acc.toolCalls {
-		output = append(output, responses.OutputItem{
-			Type:      "function_call",
-			ID:        tc.itemID,
-			Status:    "completed",
-			CallID:    tc.callID,
-			Name:      tc.name,
-			Arguments: tc.arguments,
+		indexedOutput = append(indexedOutput, indexedOutputItem{
+			index: tc.outputIndex,
+			item: responses.OutputItem{
+				Type:      "function_call",
+				ID:        tc.itemID,
+				Status:    "completed",
+				CallID:    tc.callID,
+				Name:      tc.name,
+				Arguments: tc.arguments,
+			},
+		})
+	}
+	for _, image := range acc.images {
+		indexedOutput = append(indexedOutput, indexedOutputItem{
+			index: image.outputIndex,
+			item: responses.OutputItem{
+				Type:         "image_generation_call",
+				ID:           image.itemID,
+				Status:       "completed",
+				Result:       image.result,
+				OutputFormat: image.format,
+			},
 		})
 	}
 	if acc.codeCallID != "" {
-		output = append(output, responses.OutputItem{
-			Type:    "code_interpreter_call",
-			ID:      acc.codeCallID,
-			Status:  "completed",
-			Code:    acc.codeCallCode,
-			Outputs: []map[string]interface{}{{"type": "text", "text": acc.codeCallOutput}},
+		indexedOutput = append(indexedOutput, indexedOutputItem{
+			index: acc.codeOutputIndex,
+			item: responses.OutputItem{
+				Type:    "code_interpreter_call",
+				ID:      acc.codeCallID,
+				Status:  "completed",
+				Code:    acc.codeCallCode,
+				Outputs: []map[string]interface{}{{"type": "text", "text": acc.codeCallOutput}},
+			},
 		})
+	}
+	sort.SliceStable(indexedOutput, func(i, j int) bool {
+		return indexedOutput[i].index < indexedOutput[j].index
+	})
+	output := make([]responses.OutputItem, 0, len(indexedOutput))
+	for _, indexed := range indexedOutput {
+		output = append(output, indexed.item)
 	}
 	if len(output) == 0 {
 		output = []responses.OutputItem{{

--- a/internal/converter/vertex/responses/streaming_test.go
+++ b/internal/converter/vertex/responses/streaming_test.go
@@ -92,3 +92,67 @@ func TestTransformVertexStreamToResponses_MessageEventsIncludeRequiredFields(t *
 		}
 	}
 }
+
+func TestTransformVertexStreamToResponses_ImageGenerationCallAndUsage(t *testing.T) {
+	stream := buildVertexSSEStream([]map[string]interface{}{
+		{
+			"candidates": []map[string]interface{}{
+				{
+					"content": map[string]interface{}{
+						"role": "model",
+						"parts": []map[string]interface{}{
+							{"inlineData": map[string]interface{}{"mimeType": "image/png", "data": "aW1hZ2U="}},
+						},
+					},
+					"finishReason": "STOP",
+				},
+			},
+			"usageMetadata": map[string]interface{}{
+				"promptTokenCount":     22,
+				"candidatesTokenCount": 1120,
+				"totalTokenCount":      1142,
+				"candidatesTokensDetails": []map[string]interface{}{
+					{"modality": "IMAGE", "tokenCount": 1120},
+				},
+			},
+		},
+	})
+
+	var out bytes.Buffer
+	err := TransformVertexStreamToResponses(
+		strings.NewReader(stream), &out, "gemini-3.1-flash-image-preview", "", nil, nil,
+	)
+	require.NoError(t, err)
+
+	events := parseVertexSSEEvents(out.String())
+	var completed map[string]interface{}
+	var sawImageAdded, sawImageDone bool
+	for _, event := range events {
+		switch event["type"] {
+		case "response.output_item.added":
+			item, _ := event["item"].(map[string]interface{})
+			sawImageAdded = sawImageAdded || item["type"] == "image_generation_call"
+		case "response.output_item.done":
+			item, _ := event["item"].(map[string]interface{})
+			if item["type"] == "image_generation_call" {
+				sawImageDone = true
+				assert.Equal(t, "aW1hZ2U=", item["result"])
+			}
+		case "response.completed":
+			completed, _ = event["response"].(map[string]interface{})
+		}
+	}
+	assert.True(t, sawImageAdded)
+	assert.True(t, sawImageDone)
+	require.NotNil(t, completed)
+
+	output := completed["output"].([]interface{})
+	require.Len(t, output, 1)
+	imageCall := output[0].(map[string]interface{})
+	assert.Equal(t, "image_generation_call", imageCall["type"])
+	assert.Equal(t, "aW1hZ2U=", imageCall["result"])
+
+	usage := completed["usage"].(map[string]interface{})
+	details := usage["output_tokens_details"].(map[string]interface{})
+	assert.Equal(t, float64(1120), details["image_tokens"])
+}

--- a/internal/converter/vertex/responses/tools.go
+++ b/internal/converter/vertex/responses/tools.go
@@ -42,8 +42,10 @@ func responsesToolsToVertex(tools []responses.Tool) []*genai.Tool {
 				CodeExecution: &genai.ToolCodeExecution{},
 			})
 
-			// Other tool types (file_search, computer_use, mcp, image_generation) are
-			// not supported by Vertex — silently skip them.
+			// Other tool types (file_search, computer_use, mcp) are not supported by
+			// Vertex and are silently skipped. image_generation is intentionally not
+			// emitted as a tool either: buildGenConfig translates it to the IMAGE
+			// response modality.
 		}
 	}
 

--- a/internal/models/price_calculator.go
+++ b/internal/models/price_calculator.go
@@ -40,7 +40,7 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 
 	// Calculate "regular" input tokens by subtracting specialized token types.
 	// Vertex/OpenAI: audio/cached tokens are included in PromptTokens; Anthropic: same + cache creation.
-	regularInputTokens := usage.PromptTokens - usage.AudioInputTokens - usage.CachedInputTokens - usage.CacheCreationTokens
+	regularInputTokens := usage.PromptTokens - usage.AudioInputTokens - usage.CachedInputTokens - usage.CacheCreationTokens - usage.ImageTokens
 	if regularInputTokens < 0 {
 		regularInputTokens = 0
 	}
@@ -61,7 +61,7 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 
 	// Calculate "regular" output tokens by subtracting specialized token types
 	regularOutputTokens := usage.CompletionTokens - usage.AudioOutputTokens - usage.ReasoningTokens -
-		usage.AcceptedPredictionTokens - usage.RejectedPredictionTokens
+		usage.AcceptedPredictionTokens - usage.RejectedPredictionTokens - usage.OutputImageTokens
 	if regularOutputTokens < 0 {
 		regularOutputTokens = 0
 	}
@@ -139,16 +139,25 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	// Rejected prediction tokens count as regular output tokens
 	costs.PredictionCost += float64(usage.RejectedPredictionTokens) * outputCostPerToken
 
-	// Image cost calculation: supports both per-image and per-image-token pricing
-	// Priority: 1) Per-image cost if available (typical for image generation APIs)
-	//           2) Per-image-token cost as fallback (rarely used for image generation)
-	//           3) Default: $0 if neither is configured
-	if usage.ImageCount > 0 && price.OutputCostPerImage > 0 {
-		// Per-image cost (e.g., $0.02 per image)
-		costs.ImageCost = float64(usage.ImageCount) * price.OutputCostPerImage
-	} else if usage.ImageCount > 0 && price.OutputCostPerImageToken > 0 {
-		// Per-image-token cost fallback (rarely used for image generation)
-		costs.ImageCost = float64(usage.ImageCount) * price.OutputCostPerImageToken
+	// Input image tokens are part of PromptTokens. Price them separately when a
+	// modality-specific rate exists, otherwise keep the regular input rate.
+	inputImageCost := price.InputCostPerImageToken
+	if inputImageCost == 0 {
+		inputImageCost = inputCostPerToken
+	}
+	costs.ImageCost = float64(usage.ImageTokens) * inputImageCost
+
+	// Generated image tokens are part of CompletionTokens and must not also be
+	// charged as text. Prefer the token-based image rate when the provider reports
+	// a token breakdown; otherwise use the per-image price for Imagen-style APIs.
+	if usage.OutputImageTokens > 0 {
+		outputImageCost := price.OutputCostPerImageToken
+		if outputImageCost == 0 {
+			outputImageCost = outputCostPerToken
+		}
+		costs.ImageCost += float64(usage.OutputImageTokens) * outputImageCost
+	} else if usage.ImageCount > 0 && price.OutputCostPerImage > 0 {
+		costs.ImageCost += float64(usage.ImageCount) * price.OutputCostPerImage
 	}
 
 	// Calculate total

--- a/internal/models/price_calculator_test.go
+++ b/internal/models/price_calculator_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/mixaill76/auto_ai_router/internal/converter"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCalculateTokenCosts_RegularTokensOnly(t *testing.T) {
@@ -24,6 +25,36 @@ func TestCalculateTokenCosts_RegularTokensOnly(t *testing.T) {
 	assert.Equal(t, 1.0, costs.InputCost)  // 100 * 0.01
 	assert.Equal(t, 1.0, costs.OutputCost) // 50 * 0.02
 	assert.Equal(t, 2.0, costs.TotalCost)  // 1.0 + 1.0
+}
+
+func TestCalculateTokenCosts_GeneratedImageTokensUseImageRate(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens:      22,
+		CompletionTokens:  1120,
+		OutputImageTokens: 1120,
+	}
+	price := &ModelPrice{
+		InputCostPerToken:       0.00000045,
+		OutputCostPerToken:      0.0000027,
+		OutputCostPerImageToken: 0.000054,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+	require.NotNil(t, costs)
+	assert.InDelta(t, 0.0000099, costs.InputCost, 1e-12)
+	assert.Zero(t, costs.OutputCost, "image tokens must not also be charged as text")
+	assert.InDelta(t, 0.06048, costs.ImageCost, 1e-12)
+	assert.InDelta(t, 0.0604899, costs.TotalCost, 1e-12)
+}
+
+func TestCalculateTokenCosts_ImagenUsesPerImageRate(t *testing.T) {
+	usage := &converter.TokenUsage{ImageCount: 2}
+	price := &ModelPrice{OutputCostPerImage: 0.018}
+
+	costs := CalculateTokenCosts(usage, price)
+	require.NotNil(t, costs)
+	assert.InDelta(t, 0.036, costs.ImageCost, 1e-12)
+	assert.InDelta(t, 0.036, costs.TotalCost, 1e-12)
 }
 
 func TestCalculateTokenCosts_Vertex_WithAudioAndCached(t *testing.T) {

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -162,9 +162,11 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 	var usageObject interface{}
 	if usage != nil {
 		promptTokensDetails["audio_tokens"] = usage.AudioInputTokens
+		promptTokensDetails["image_tokens"] = usage.ImageTokens
 		promptTokensDetails["cached_tokens"] = usage.CachedInputTokens
 		promptTokensDetails["cache_creation_tokens"] = usage.CacheCreationTokens
 		completionTokensDetails["audio_tokens"] = usage.AudioOutputTokens
+		completionTokensDetails["image_tokens"] = usage.OutputImageTokens
 		completionTokensDetails["reasoning_tokens"] = usage.ReasoningTokens
 		completionTokensDetails["accepted_prediction_tokens"] = usage.AcceptedPredictionTokens
 		completionTokensDetails["rejected_prediction_tokens"] = usage.RejectedPredictionTokens
@@ -180,11 +182,13 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 	additionalUsage := map[string]interface{}{
 		"prompt_tokens_details": map[string]interface{}{
 			"audio_tokens":          promptTokensDetails["audio_tokens"],
+			"image_tokens":          promptTokensDetails["image_tokens"],
 			"cached_tokens":         promptTokensDetails["cached_tokens"],
 			"cache_creation_tokens": promptTokensDetails["cache_creation_tokens"],
 		},
 		"completion_tokens_details": map[string]interface{}{
 			"audio_tokens":               completionTokensDetails["audio_tokens"],
+			"image_tokens":               completionTokensDetails["image_tokens"],
 			"reasoning_tokens":           completionTokensDetails["reasoning_tokens"],
 			"accepted_prediction_tokens": completionTokensDetails["accepted_prediction_tokens"],
 			"rejected_prediction_tokens": completionTokensDetails["rejected_prediction_tokens"],

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -42,7 +42,8 @@ type StreamUsageInfo struct {
 	CachedTokens        int // Tokens from cached prompt content (prompt_caching feature)
 	AudioInputTokens    int // Audio tokens in the request
 	AudioOutputTokens   int // Audio tokens in the response
-	ImageTokens         int // Image/video tokens (if reported)
+	ImageTokens         int // Input image/video tokens (if reported)
+	OutputImageTokens   int // Generated image/video tokens (if reported)
 	ReasoningTokens     int // Reasoning/thoughts tokens (output)
 	CacheCreationTokens int // Tokens created for cache (billed at different rate)
 	CacheReadTokens     int // Tokens read from cache (billed at cheaper rate)
@@ -98,10 +99,12 @@ func (o *openAIStreamUsageExtractor) extractChatCompletionUsage(payload []byte) 
 				CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
 				CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
 				AudioTokens         int `json:"audio_tokens,omitempty"`
+				ImageTokens         int `json:"image_tokens,omitempty"`
 			} `json:"prompt_tokens_details,omitempty"`
 			CompletionTokensDetails struct {
 				AudioTokens     int `json:"audio_tokens,omitempty"`
 				ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+				ImageTokens     int `json:"image_tokens,omitempty"`
 			} `json:"completion_tokens_details,omitempty"`
 		} `json:"usage"`
 	}
@@ -126,6 +129,8 @@ func (o *openAIStreamUsageExtractor) extractChatCompletionUsage(payload []byte) 
 		CacheCreationTokens: cacheCreationTokens,
 		AudioInputTokens:    data.Usage.PromptTokensDetails.AudioTokens,
 		AudioOutputTokens:   data.Usage.CompletionTokensDetails.AudioTokens,
+		ImageTokens:         data.Usage.PromptTokensDetails.ImageTokens,
+		OutputImageTokens:   data.Usage.CompletionTokensDetails.ImageTokens,
 		ReasoningTokens:     data.Usage.CompletionTokensDetails.ReasoningTokens,
 	}
 }
@@ -169,6 +174,8 @@ func (o *openAIStreamUsageExtractor) extractResponsesAPIUsage(payload []byte) *S
 		CacheCreationTokens: cacheCreationTokens,
 		AudioInputTokens:    usage.InputTokensDetails.AudioTokens,
 		AudioOutputTokens:   usage.OutputTokensDetails.AudioTokens,
+		ImageTokens:         usage.InputTokensDetails.ImageTokens,
+		OutputImageTokens:   usage.OutputTokensDetails.ImageTokens,
 		ReasoningTokens:     usage.OutputTokensDetails.ReasoningTokens,
 	}
 }
@@ -182,10 +189,12 @@ type responsesAPIUsage struct {
 		CacheCreationTokens int `json:"cache_creation_tokens,omitempty"`
 		CacheWriteTokens    int `json:"cache_write_tokens,omitempty"`
 		AudioTokens         int `json:"audio_tokens,omitempty"`
+		ImageTokens         int `json:"image_tokens,omitempty"`
 	} `json:"input_tokens_details,omitempty"`
 	OutputTokensDetails struct {
 		AudioTokens     int `json:"audio_tokens,omitempty"`
 		ReasoningTokens int `json:"reasoning_tokens,omitempty"`
+		ImageTokens     int `json:"image_tokens,omitempty"`
 	} `json:"output_tokens_details,omitempty"`
 }
 
@@ -597,6 +606,9 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 			if usageInfo.ImageTokens > 0 {
 				logCtx.TokenUsage.ImageTokens = usageInfo.ImageTokens
 			}
+			if usageInfo.OutputImageTokens > 0 {
+				logCtx.TokenUsage.OutputImageTokens = usageInfo.OutputImageTokens
+			}
 			if usageInfo.ReasoningTokens > 0 {
 				logCtx.TokenUsage.ReasoningTokens = usageInfo.ReasoningTokens
 			}
@@ -613,6 +625,7 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 				"audio_input_tokens", usageInfo.AudioInputTokens,
 				"audio_output_tokens", usageInfo.AudioOutputTokens,
 				"image_tokens", usageInfo.ImageTokens,
+				"output_image_tokens", usageInfo.OutputImageTokens,
 				"reasoning_tokens", usageInfo.ReasoningTokens,
 			)
 		}


### PR DESCRIPTION
## What changed

- translate the OpenAI Responses `image_generation` tool into Vertex `responseModalities: ["IMAGE"]`
- return Gemini `inlineData` as Responses API `image_generation_call` items in non-streaming and streaming responses
- preserve generated image token counts as `image_tokens` across Vertex, Chat Completions, Responses, streaming, and spend metadata conversions
- price generated image tokens with `output_cost_per_image_token` instead of the text output rate
- keep Imagen-style per-image pricing when token-level output usage is unavailable

## Root cause

AIR received both the generated image bytes and Vertex `CandidatesTokensDetails`, but dropped them while building the OpenAI Responses payload. The client therefore received an empty assistant message, and LiteLLM classified all generated image tokens as text output. For the reproduced 22-input / 1120-image-token request this produced `$0.0030339` instead of `$0.0604899`.

## Impact

Gemini image generation through `/v1/responses` now returns an `image_generation_call.result`, and downstream LiteLLM can apply the configured image-output token rate. AIR's own spend metadata and calculator use the same modality breakdown.

## Validation

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/converter/... ./internal/models ./internal/proxy`
- focused image/Imagen regression tests, including native Responses, fallback conversion, streaming, exact token cost, and per-image cost
