### PR TITLE
Fix Gemini 3.1 Flash 21:9 image sizing

### DIFF
--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -138,6 +138,7 @@ func TestProviderConverter_RequestFrom_GeminiImageGeneration_Size(t *testing.T) 
 		{size: "1792x2400", aspectRatio: "3:4", imageSize: "2K"},
 		{size: "896x1152", aspectRatio: "4:5", imageSize: "1K"},
 		{size: "640x1024", aspectRatio: "2:3", imageSize: "1K"},
+		{size: "792x168", aspectRatio: "21:9", imageSize: "512"},
 	}
 
 	for _, tt := range tests {

--- a/internal/converter/vertex/image_size.go
+++ b/internal/converter/vertex/image_size.go
@@ -8,11 +8,17 @@ import (
 )
 
 type geminiImageRatio struct {
-	value              string
-	ratioWidth         int
-	ratioHeight        int
-	resolution1KWidth  int
-	resolution1KHeight int
+	value               string
+	ratioWidth          int
+	ratioHeight         int
+	resolution1KWidth   int
+	resolution1KHeight  int
+	resolutionOverrides map[string]geminiImageDimensions
+}
+
+type geminiImageDimensions struct {
+	width  int
+	height int
 }
 
 type geminiImageResolution struct {
@@ -70,7 +76,16 @@ var gemini31FlashImageRatios = []geminiImageRatio{
 	{value: "8:1", ratioWidth: 8, ratioHeight: 1, resolution1KWidth: 3072, resolution1KHeight: 384},
 	{value: "9:16", ratioWidth: 9, ratioHeight: 16, resolution1KWidth: 768, resolution1KHeight: 1376},
 	{value: "16:9", ratioWidth: 16, ratioHeight: 9, resolution1KWidth: 1376, resolution1KHeight: 768},
-	{value: "21:9", ratioWidth: 21, ratioHeight: 9, resolution1KWidth: 1584, resolution1KHeight: 672},
+	{
+		value:              "21:9",
+		ratioWidth:         21,
+		ratioHeight:        9,
+		resolution1KWidth:  1584,
+		resolution1KHeight: 672,
+		resolutionOverrides: map[string]geminiImageDimensions{
+			"512": {width: 792, height: 168},
+		},
+	},
 }
 
 var (
@@ -115,6 +130,12 @@ func mapGeminiImageSize(model, size string) (*geminiImageConfig, error) {
 	}
 
 	profile := geminiImageProfileForModel(model)
+	if !ratioOnly {
+		if config, ok := exactGeminiImageConfig(profile, width, height); ok {
+			return config, nil
+		}
+	}
+
 	ratio := nearestGeminiImageRatio(profile.ratios, width, height)
 	resolution := defaultGeminiImageResolution(profile.resolutions)
 	if !ratioOnly {
@@ -122,6 +143,28 @@ func mapGeminiImageSize(model, size string) (*geminiImageConfig, error) {
 	}
 
 	return &geminiImageConfig{aspectRatio: ratio.value, imageSize: resolution.value}, nil
+}
+
+func exactGeminiImageConfig(profile geminiImageProfile, width, height int) (*geminiImageConfig, bool) {
+	for _, ratio := range profile.ratios {
+		for _, resolution := range profile.resolutions {
+			dimensions := geminiImageDimensions{
+				width:  int(math.Round(float64(ratio.resolution1KWidth) * resolution.scale)),
+				height: int(math.Round(float64(ratio.resolution1KHeight) * resolution.scale)),
+			}
+			if override, ok := ratio.resolutionOverrides[resolution.value]; ok {
+				dimensions = override
+			}
+			if dimensions.width == width && dimensions.height == height {
+				return &geminiImageConfig{
+					aspectRatio: ratio.value,
+					imageSize:   resolution.value,
+				}, true
+			}
+		}
+	}
+
+	return nil, false
 }
 
 func parseGeminiImageSize(size string) (int, int, bool, error) {

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -3,6 +3,7 @@ package vertex
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"mime/multipart"
 	"net/textproto"
 	"testing"
@@ -38,6 +39,86 @@ func TestMapGeminiImageSize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			config, err := mapGeminiImageSize(tt.model, tt.size)
+			require.NoError(t, err)
+			require.NotNil(t, config)
+			assert.Equal(t, tt.aspectRatio, config.aspectRatio)
+			assert.Equal(t, tt.imageSize, config.imageSize)
+		})
+	}
+}
+
+func TestMapGeminiImageSizeOfficialGrid(t *testing.T) {
+	tests := []struct {
+		aspectRatio string
+		imageSize   string
+		width       int
+		height      int
+	}{
+		{aspectRatio: "1:1", imageSize: "512", width: 512, height: 512},
+		{aspectRatio: "1:1", imageSize: "1K", width: 1024, height: 1024},
+		{aspectRatio: "1:1", imageSize: "2K", width: 2048, height: 2048},
+		{aspectRatio: "1:1", imageSize: "4K", width: 4096, height: 4096},
+		{aspectRatio: "1:4", imageSize: "512", width: 256, height: 1024},
+		{aspectRatio: "1:4", imageSize: "1K", width: 512, height: 2048},
+		{aspectRatio: "1:4", imageSize: "2K", width: 1024, height: 4096},
+		{aspectRatio: "1:4", imageSize: "4K", width: 2048, height: 8192},
+		{aspectRatio: "1:8", imageSize: "512", width: 192, height: 1536},
+		{aspectRatio: "1:8", imageSize: "1K", width: 384, height: 3072},
+		{aspectRatio: "1:8", imageSize: "2K", width: 768, height: 6144},
+		{aspectRatio: "1:8", imageSize: "4K", width: 1536, height: 12288},
+		{aspectRatio: "2:3", imageSize: "512", width: 424, height: 632},
+		{aspectRatio: "2:3", imageSize: "1K", width: 848, height: 1264},
+		{aspectRatio: "2:3", imageSize: "2K", width: 1696, height: 2528},
+		{aspectRatio: "2:3", imageSize: "4K", width: 3392, height: 5056},
+		{aspectRatio: "3:2", imageSize: "512", width: 632, height: 424},
+		{aspectRatio: "3:2", imageSize: "1K", width: 1264, height: 848},
+		{aspectRatio: "3:2", imageSize: "2K", width: 2528, height: 1696},
+		{aspectRatio: "3:2", imageSize: "4K", width: 5056, height: 3392},
+		{aspectRatio: "3:4", imageSize: "512", width: 448, height: 600},
+		{aspectRatio: "3:4", imageSize: "1K", width: 896, height: 1200},
+		{aspectRatio: "3:4", imageSize: "2K", width: 1792, height: 2400},
+		{aspectRatio: "3:4", imageSize: "4K", width: 3584, height: 4800},
+		{aspectRatio: "4:1", imageSize: "512", width: 1024, height: 256},
+		{aspectRatio: "4:1", imageSize: "1K", width: 2048, height: 512},
+		{aspectRatio: "4:1", imageSize: "2K", width: 4096, height: 1024},
+		{aspectRatio: "4:1", imageSize: "4K", width: 8192, height: 2048},
+		{aspectRatio: "4:3", imageSize: "512", width: 600, height: 448},
+		{aspectRatio: "4:3", imageSize: "1K", width: 1200, height: 896},
+		{aspectRatio: "4:3", imageSize: "2K", width: 2400, height: 1792},
+		{aspectRatio: "4:3", imageSize: "4K", width: 4800, height: 3584},
+		{aspectRatio: "4:5", imageSize: "512", width: 464, height: 576},
+		{aspectRatio: "4:5", imageSize: "1K", width: 928, height: 1152},
+		{aspectRatio: "4:5", imageSize: "2K", width: 1856, height: 2304},
+		{aspectRatio: "4:5", imageSize: "4K", width: 3712, height: 4608},
+		{aspectRatio: "5:4", imageSize: "512", width: 576, height: 464},
+		{aspectRatio: "5:4", imageSize: "1K", width: 1152, height: 928},
+		{aspectRatio: "5:4", imageSize: "2K", width: 2304, height: 1856},
+		{aspectRatio: "5:4", imageSize: "4K", width: 4608, height: 3712},
+		{aspectRatio: "8:1", imageSize: "512", width: 1536, height: 192},
+		{aspectRatio: "8:1", imageSize: "1K", width: 3072, height: 384},
+		{aspectRatio: "8:1", imageSize: "2K", width: 6144, height: 768},
+		{aspectRatio: "8:1", imageSize: "4K", width: 12288, height: 1536},
+		{aspectRatio: "9:16", imageSize: "512", width: 384, height: 688},
+		{aspectRatio: "9:16", imageSize: "1K", width: 768, height: 1376},
+		{aspectRatio: "9:16", imageSize: "2K", width: 1536, height: 2752},
+		{aspectRatio: "9:16", imageSize: "4K", width: 3072, height: 5504},
+		{aspectRatio: "16:9", imageSize: "512", width: 688, height: 384},
+		{aspectRatio: "16:9", imageSize: "1K", width: 1376, height: 768},
+		{aspectRatio: "16:9", imageSize: "2K", width: 2752, height: 1536},
+		{aspectRatio: "16:9", imageSize: "4K", width: 5504, height: 3072},
+		{aspectRatio: "21:9", imageSize: "512", width: 792, height: 168},
+		{aspectRatio: "21:9", imageSize: "1K", width: 1584, height: 672},
+		{aspectRatio: "21:9", imageSize: "2K", width: 3168, height: 1344},
+		{aspectRatio: "21:9", imageSize: "4K", width: 6336, height: 2688},
+	}
+
+	for _, tt := range tests {
+		name := fmt.Sprintf("%s/%s", tt.aspectRatio, tt.imageSize)
+		t.Run(name, func(t *testing.T) {
+			config, err := mapGeminiImageSize(
+				"gemini-3.1-flash-image-preview",
+				fmt.Sprintf("%dx%d", tt.width, tt.height),
+			)
 			require.NoError(t, err)
 			require.NotNil(t, config)
 			assert.Equal(t, tt.aspectRatio, config.aspectRatio)


### PR DESCRIPTION
## What changed

- prefer exact canonical Gemini image dimensions before the nearest-ratio fallback
- add the Google-specific `21:9` / `512` override for `792x168`
- cover the complete 56-cell Gemini 3.1 Flash Image size grid and the final Vertex payload

## Why

`792x168` has a numeric ratio of about `4.71:1`, so the previous nearest-ratio heuristic selected `4:1`. AIR then sent `aspectRatio: 4:1` with `imageSize: 512`, and Vertex returned `1024x256` instead of the requested `21:9` result.

The new exact lookup recognizes Google's canonical dimensions first while preserving the existing nearest-match behavior for arbitrary sizes.

## Validation

- `go test ./... -count=1`
- `go test -race ./internal/converter/vertex ./internal/converter -count=1`
- `git diff --check`
