### PR TITLE
Forward image sampling parameters

### DIFF
--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -189,18 +189,21 @@ type OpenAIStreamingToolFunction struct {
 
 // OpenAIImageRequest represents OpenAI image generation request
 type OpenAIImageRequest struct {
-	Model             string `json:"model"`
-	Prompt            string `json:"prompt"`
-	N                 *int   `json:"n,omitempty"`
-	Size              string `json:"size,omitempty"`
-	Quality           string `json:"quality,omitempty"`
-	ResponseFormat    string `json:"response_format,omitempty"`
-	Style             string `json:"style,omitempty"`
-	User              string `json:"user,omitempty"`
-	Background        string `json:"background,omitempty"`         // gpt-image-1
-	Moderation        string `json:"moderation,omitempty"`         // gpt-image-1
-	OutputCompression int    `json:"output_compression,omitempty"` // gpt-image-1
-	OutputFormat      string `json:"output_format,omitempty"`      // gpt-image-1
+	Model             string   `json:"model"`
+	Prompt            string   `json:"prompt"`
+	N                 *int     `json:"n,omitempty"`
+	Temperature       *float64 `json:"temperature,omitempty"`
+	TopP              *float64 `json:"top_p,omitempty"`
+	Seed              *int64   `json:"seed,omitempty"`
+	Size              string   `json:"size,omitempty"`
+	Quality           string   `json:"quality,omitempty"`
+	ResponseFormat    string   `json:"response_format,omitempty"`
+	Style             string   `json:"style,omitempty"`
+	User              string   `json:"user,omitempty"`
+	Background        string   `json:"background,omitempty"`         // gpt-image-1
+	Moderation        string   `json:"moderation,omitempty"`         // gpt-image-1
+	OutputCompression int      `json:"output_compression,omitempty"` // gpt-image-1
+	OutputFormat      string   `json:"output_format,omitempty"`      // gpt-image-1
 }
 
 type OpenAIImageData struct {

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"math"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -300,6 +301,20 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 		}
 		chatReq.Seed = &seed
 	}
+	if rawTemperature := strings.TrimSpace(fields["temperature"]); rawTemperature != "" {
+		temperature, err := parseImageEditFloat(rawTemperature, "temperature")
+		if err != nil {
+			return nil, err
+		}
+		chatReq.Temperature = &temperature
+	}
+	if rawTopP := strings.TrimSpace(fields["top_p"]); rawTopP != "" {
+		topP, err := parseImageEditFloat(rawTopP, "top_p")
+		if err != nil {
+			return nil, err
+		}
+		chatReq.TopP = &topP
+	}
 	if n := parsePositiveInt(fields["n"]); n > 0 {
 		n = clampImageCount(n)
 		chatReq.N = &n
@@ -397,6 +412,14 @@ func parsePositiveInt(raw string) int {
 		return 0
 	}
 	return n
+}
+
+func parseImageEditFloat(raw, name string) (float64, error) {
+	value, err := strconv.ParseFloat(raw, 64)
+	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
+		return 0, fmt.Errorf("invalid image edit %s %q", name, raw)
+	}
+	return value, nil
 }
 
 func readMultipartPartLimit(part *multipart.Part, maxBytes int64) ([]byte, error) {

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -161,7 +161,9 @@ func imageRequestToOpenAIChatRequest(openAIBody []byte, providerModel string) ([
 
 	// Convert to OpenAI chat request format
 	chatReq := openai.OpenAIRequest{
-		Model: imageReq.Model,
+		Model:       imageReq.Model,
+		Temperature: imageReq.Temperature,
+		TopP:        imageReq.TopP,
 		Messages: []openai.OpenAIMessage{
 			{
 				Role:    "user",
@@ -171,6 +173,12 @@ func imageRequestToOpenAIChatRequest(openAIBody []byte, providerModel string) ([
 		ExtraBody: map[string]interface{}{
 			"generation_config": genConfig,
 		},
+	}
+	if imageReq.Seed != nil {
+		if *imageReq.Seed < math.MinInt32 || *imageReq.Seed > math.MaxInt32 {
+			return nil, fmt.Errorf("invalid image generation seed %d", *imageReq.Seed)
+		}
+		chatReq.Seed = imageReq.Seed
 	}
 	if imageReq.N != nil && *imageReq.N > 0 {
 		n := clampImageCount(*imageReq.N)

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -154,6 +154,9 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 		require.Len(t, chatReq.Messages, 1)
 		assert.Equal(t, "user", chatReq.Messages[0].Role)
 		assert.Equal(t, "A cat sitting on a mat", chatReq.Messages[0].Content)
+		assert.Nil(t, chatReq.Seed)
+		assert.Nil(t, chatReq.Temperature)
+		assert.Nil(t, chatReq.TopP)
 
 		// Check extra_body has generation_config with IMAGE modality
 		require.NotNil(t, chatReq.ExtraBody)
@@ -163,6 +166,46 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 		require.True(t, ok)
 		assert.Contains(t, modalities, "IMAGE")
 	})
+
+	t.Run("request forwards sampling parameters", func(t *testing.T) {
+		input := `{"model":"gemini-3.1-flash-image-preview","prompt":"A landscape","seed":42,"temperature":0.7,"top_p":0.9}`
+		result, err := ImageRequestToOpenAIChatRequest([]byte(input))
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		require.NotNil(t, chatReq.Seed)
+		assert.Equal(t, int64(42), *chatReq.Seed)
+		require.NotNil(t, chatReq.Temperature)
+		assert.Equal(t, 0.7, *chatReq.Temperature)
+		require.NotNil(t, chatReq.TopP)
+		assert.Equal(t, 0.9, *chatReq.TopP)
+	})
+
+	t.Run("zero sampling parameters remain set", func(t *testing.T) {
+		input := `{"model":"gemini-3.1-flash-image-preview","prompt":"A landscape","seed":0,"temperature":0,"top_p":0}`
+		result, err := ImageRequestToOpenAIChatRequest([]byte(input))
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		require.NotNil(t, chatReq.Seed)
+		assert.Equal(t, int64(0), *chatReq.Seed)
+		require.NotNil(t, chatReq.Temperature)
+		assert.Equal(t, float64(0), *chatReq.Temperature)
+		require.NotNil(t, chatReq.TopP)
+		assert.Equal(t, float64(0), *chatReq.TopP)
+	})
+
+	for _, seed := range []string{"2147483648", "-2147483649"} {
+		t.Run("out of range seed returns error "+seed, func(t *testing.T) {
+			input := fmt.Sprintf(`{"model":"gemini-3.1-flash-image-preview","prompt":"A landscape","seed":%s}`, seed)
+			result, err := ImageRequestToOpenAIChatRequest([]byte(input))
+			assert.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "invalid image generation seed")
+		})
+	}
 
 	t.Run("request with size includes aspect ratio and image size", func(t *testing.T) {
 		input := `{"model": "gemini-3-pro-image", "prompt": "A landscape", "size": "1792x1024"}`

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -214,7 +214,7 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 }
 
 func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
-	buildMultipart := func(t *testing.T, model, size, seed string) ([]byte, string) {
+	buildMultipart := func(t *testing.T, model, size string, fields map[string]string) ([]byte, string) {
 		t.Helper()
 
 		var buf bytes.Buffer
@@ -223,8 +223,8 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		require.NoError(t, writer.WriteField("prompt", "Make the object blue"))
 		require.NoError(t, writer.WriteField("n", "2"))
 		require.NoError(t, writer.WriteField("size", size))
-		if seed != "" {
-			require.NoError(t, writer.WriteField("seed", seed))
+		for name, value := range fields {
+			require.NoError(t, writer.WriteField(name, value))
 		}
 
 		part, err := writer.CreatePart(textproto.MIMEHeader{
@@ -240,7 +240,11 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 	}
 
 	t.Run("multipart edit request converts to multimodal chat request", func(t *testing.T) {
-		body, contentType := buildMultipart(t, "gemini-2.5-flash-image-preview", "1792x1024", "0")
+		body, contentType := buildMultipart(t, "gemini-2.5-flash-image-preview", "1792x1024", map[string]string{
+			"seed":        "0",
+			"temperature": "0",
+			"top_p":       "0",
+		})
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		require.NoError(t, err)
 
@@ -251,6 +255,10 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		assert.Equal(t, 2, *chatReq.N)
 		require.NotNil(t, chatReq.Seed)
 		assert.Equal(t, int64(0), *chatReq.Seed)
+		require.NotNil(t, chatReq.Temperature)
+		assert.Equal(t, float64(0), *chatReq.Temperature)
+		require.NotNil(t, chatReq.TopP)
+		assert.Equal(t, float64(0), *chatReq.TopP)
 		require.Len(t, chatReq.Messages, 1)
 
 		blocks, ok := chatReq.Messages[0].Content.([]interface{})
@@ -275,7 +283,11 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 	})
 
 	t.Run("multipart edit uses model size profile", func(t *testing.T) {
-		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1792x2400", "42")
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1792x2400", map[string]string{
+			"seed":        "42",
+			"temperature": "2",
+			"top_p":       "1",
+		})
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		require.NoError(t, err)
 
@@ -287,15 +299,55 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		assert.Equal(t, "2K", imageConfig["imageSize"])
 		require.NotNil(t, chatReq.Seed)
 		assert.Equal(t, int64(42), *chatReq.Seed)
+		require.NotNil(t, chatReq.Temperature)
+		assert.Equal(t, float64(2), *chatReq.Temperature)
+		require.NotNil(t, chatReq.TopP)
+		assert.Equal(t, float64(1), *chatReq.TopP)
+	})
+
+	t.Run("omitted sampling parameters remain unset", func(t *testing.T) {
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", nil)
+		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		assert.Nil(t, chatReq.Temperature)
+		assert.Nil(t, chatReq.TopP)
 	})
 
 	t.Run("invalid seed returns error", func(t *testing.T) {
-		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", "invalid")
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", map[string]string{
+			"seed": "invalid",
+		})
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		assert.Error(t, err)
 		assert.Nil(t, result)
 		assert.Contains(t, err.Error(), "invalid image edit seed")
 	})
+
+	for _, test := range []struct {
+		name  string
+		field string
+		value string
+	}{
+		{name: "invalid temperature", field: "temperature", value: "invalid"},
+		{name: "NaN temperature", field: "temperature", value: "NaN"},
+		{name: "infinite temperature", field: "temperature", value: "+Inf"},
+		{name: "invalid top_p", field: "top_p", value: "invalid"},
+		{name: "NaN top_p", field: "top_p", value: "NaN"},
+		{name: "infinite top_p", field: "top_p", value: "+Inf"},
+	} {
+		t.Run(test.name+" returns error", func(t *testing.T) {
+			body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", map[string]string{
+				test.field: test.value,
+			})
+			result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+			assert.Error(t, err)
+			assert.Nil(t, result)
+			assert.Contains(t, err.Error(), "invalid image edit "+test.field)
+		})
+	}
 
 	t.Run("missing model returns error", func(t *testing.T) {
 		var buf bytes.Buffer

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -674,6 +674,8 @@ func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 		generationConfig, ok := bodyMap["generationConfig"].(map[string]interface{})
 		assert.True(t, ok)
 		assert.Equal(t, float64(42), generationConfig["seed"])
+		assert.InDelta(t, 0.7, generationConfig["temperature"], 1e-6)
+		assert.InDelta(t, 0.9, generationConfig["topP"], 1e-6)
 
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"inlineData":{"data":"aW1n","mimeType":"image/png"}}],"role":"model"}}]}`))
@@ -689,6 +691,8 @@ func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 	assert.NoError(t, writer.WriteField("model", "gemini-2.5-flash-image-preview"))
 	assert.NoError(t, writer.WriteField("prompt", "Edit this image"))
 	assert.NoError(t, writer.WriteField("seed", "42"))
+	assert.NoError(t, writer.WriteField("temperature", "0.7"))
+	assert.NoError(t, writer.WriteField("top_p", "0.9"))
 	part, err := writer.CreatePart(textproto.MIMEHeader{
 		"Content-Disposition": []string{`form-data; name="image"; filename="input.png"`},
 		"Content-Type":        []string{"image/png"},

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -712,6 +712,41 @@ func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestProxyRequest_ImageGenerationSamplingParametersConvertedToJSON(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var bodyMap map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&bodyMap)
+		assert.NoError(t, err)
+		assert.NotNil(t, bodyMap["contents"])
+		generationConfig, ok := bodyMap["generationConfig"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, float64(42), generationConfig["seed"])
+		assert.InDelta(t, 0.7, generationConfig["temperature"], 1e-6)
+		assert.InDelta(t, 0.9, generationConfig["topP"], 1e-6)
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"inlineData":{"data":"aW1n","mimeType":"image/png"}}],"role":"model"}}]}`))
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeGemini, mockServer.URL, "upstream-key-1").
+		Build()
+
+	req := httptest.NewRequest("POST", "/v1/images/generations", strings.NewReader(
+		`{"model":"gemini-3.1-flash-image-preview","prompt":"Generate an image","seed":42,"temperature":0.7,"top_p":0.9}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestProxyRequest_QueryParameters(t *testing.T) {
 	// Create mock server to verify query params
 	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/response_writer_usage_test.go
+++ b/internal/proxy/response_writer_usage_test.go
@@ -119,6 +119,7 @@ func TestWriteProxyStreamingResponseNormalizesQwenUsage(t *testing.T) {
 		"test",
 		"gateway/qwen3.6-35b-a3b-20260415",
 		"qwen3.6-35b-a3b",
+		nil,
 	)
 
 	require.NoError(t, err)
@@ -172,7 +173,7 @@ func TestWriteProxyStreamingResponseQwenDrainCapturesUsage(t *testing.T) {
 	w := newFailAfterNBytesWriter(10)
 	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
 
-	usage, err := prx.writeProxyStreamingResponseWithTokens(w, proxyResp, req, "test", "qwen3.6-35b-a3b", "qwen3.6-35b-a3b")
+	usage, err := prx.writeProxyStreamingResponseWithTokens(w, proxyResp, req, "test", "qwen3.6-35b-a3b", "qwen3.6-35b-a3b", nil)
 
 	require.Error(t, err)
 	require.NotNil(t, usage)


### PR DESCRIPTION
## Summary

- Forward `seed`, `temperature`, and `top_p` from image generation requests
- Forward `temperature` and `top_p` from multipart image edit requests
- Emit `generationConfig.seed`, `generationConfig.temperature`, and `generationConfig.topP` for Gemini
- Preserve zero values and omission semantics
- Reject invalid image generation seed values and malformed image edit values
- Repair stale streaming response test calls on current `main`

## Validation

- `go test -race ./...`
- `go vet ./...`
- `make lint`
- `pre-commit run --all-files`
- `git diff --check`