### PR TITLE
fix(litellmdb): align key/user budget boundary with LiteLLM 1.90.0

### DIFF
--- a/internal/litellmdb/auth/auth_test.go
+++ b/internal/litellmdb/auth/auth_test.go
@@ -130,10 +130,10 @@ func TestTokenInfo_IsBudgetExceeded(t *testing.T) {
 		assert.False(t, info.IsBudgetExceeded())
 	})
 
-	t.Run("spend == max_budget - not exceeded (embedded uses >)", func(t *testing.T) {
+	t.Run("spend == max_budget - exceeded (LiteLLM 1.90.0 key check uses >=)", func(t *testing.T) {
 		maxBudget := 100.0
 		info := &models.TokenInfo{Spend: 100, MaxBudget: &maxBudget}
-		assert.False(t, info.IsBudgetExceeded())
+		assert.True(t, info.IsBudgetExceeded())
 	})
 
 	t.Run("spend > max_budget - exceeded", func(t *testing.T) {

--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -323,12 +323,14 @@ func (t *TokenInfo) IsExpired() bool {
 	return utils.NowUTC().After(*t.Expires)
 }
 
-// IsBudgetExceeded checks if token budget is exceeded (embedded, use >)
+// IsBudgetExceeded checks if token budget is exceeded.
+// LiteLLM 1.90.0 rejects at the boundary for keys: `spend >= max_budget`
+// (auth_checks.py, GHSA-2rv4-xv66-fpjg defense-in-depth). Match that exactly.
 func (t *TokenInfo) IsBudgetExceeded() bool {
 	if t.MaxBudget == nil {
 		return false
 	}
-	return t.Spend > *t.MaxBudget
+	return t.Spend >= *t.MaxBudget
 }
 
 // ModelAccessScopes returns the ordered set of allowlists applicable to this
@@ -399,7 +401,9 @@ func (t *TokenInfo) IsModelAllowed(model string) bool {
 	return t.IsModelAllowedBy(model, exactModelScopeMatch)
 }
 
-// checkUserBudget checks user budget (personal key only - embedded, use >)
+// checkUserBudget checks user budget (personal key only).
+// LiteLLM 1.90.0 uses `user_spend >= user_budget` (auth_checks.py
+// _user_max_budget_check), so reaching the budget rejects.
 func (t *TokenInfo) checkUserBudget() bool {
 	// Only check user budget for personal keys (no team)
 	if t.TeamID != "" {
@@ -408,10 +412,12 @@ func (t *TokenInfo) checkUserBudget() bool {
 	if t.UserMaxBudget == nil || t.UserSpend == nil {
 		return false
 	}
-	return *t.UserSpend > *t.UserMaxBudget
+	return *t.UserSpend >= *t.UserMaxBudget
 }
 
-// checkTeamBudget checks team budget (embedded, use >)
+// checkTeamBudget checks team budget.
+// LiteLLM 1.90.0 uses `spend > team.max_budget` (auth_checks.py) — a deliberately
+// different boundary from key/user: reaching the team budget exactly is allowed.
 func (t *TokenInfo) checkTeamBudget() bool {
 	if t.TeamMaxBudget == nil || t.TeamSpend == nil {
 		return false

--- a/internal/litellmdb/models/models_test.go
+++ b/internal/litellmdb/models/models_test.go
@@ -156,6 +156,10 @@ func TestTokenInfo_IsBudgetExceeded_SpendLessThanMax(t *testing.T) {
 	assert.False(t, token.IsBudgetExceeded())
 }
 
+// LiteLLM 1.90.0 rejects the request when key spend reaches the budget
+// (litellm/proxy/auth/auth_checks.py: `spend >= valid_token.max_budget`,
+// the GHSA-2rv4-xv66-fpjg defense-in-depth check). AIR must match that
+// boundary for the key/token level.
 func TestTokenInfo_IsBudgetExceeded_SpendEqualToMax(t *testing.T) {
 	maxBudget := 100.0
 	token := &TokenInfo{
@@ -163,7 +167,7 @@ func TestTokenInfo_IsBudgetExceeded_SpendEqualToMax(t *testing.T) {
 		MaxBudget: &maxBudget,
 	}
 
-	assert.False(t, token.IsBudgetExceeded())
+	assert.True(t, token.IsBudgetExceeded())
 }
 
 func TestTokenInfo_IsBudgetExceeded_SpendGreaterThanMax(t *testing.T) {
@@ -277,6 +281,21 @@ func TestTokenInfo_checkUserBudget_PersonalKey(t *testing.T) {
 	assert.True(t, token.checkUserBudget())
 }
 
+// LiteLLM 1.90.0 user budget check is `user_spend >= user_budget`
+// (auth_checks.py `_user_max_budget_check`). Reaching the budget must reject.
+func TestTokenInfo_checkUserBudget_SpendEqualToMax(t *testing.T) {
+	userBudget := 100.0
+	userSpend := 100.0
+	token := &TokenInfo{
+		UserID:        "user1",
+		TeamID:        "",
+		UserMaxBudget: &userBudget,
+		UserSpend:     &userSpend,
+	}
+
+	assert.True(t, token.checkUserBudget())
+}
+
 func TestTokenInfo_checkUserBudget_NotPersonalKey(t *testing.T) {
 	userBudget := 100.0
 	userSpend := 150.0
@@ -315,6 +334,20 @@ func TestTokenInfo_checkTeamBudget_ExceededEmbedded(t *testing.T) {
 func TestTokenInfo_checkTeamBudget_NotExceeded(t *testing.T) {
 	teamBudget := 100.0
 	teamSpend := 50.0
+	token := &TokenInfo{
+		TeamMaxBudget: &teamBudget,
+		TeamSpend:     &teamSpend,
+	}
+
+	assert.False(t, token.checkTeamBudget())
+}
+
+// LiteLLM 1.90.0 team budget check is `spend > team.max_budget` (auth_checks.py),
+// a deliberately different boundary from the key/user (`>=`) levels: reaching the
+// team budget exactly is still allowed. Lock this in so it is not "unified" away.
+func TestTokenInfo_checkTeamBudget_SpendEqualToMax(t *testing.T) {
+	teamBudget := 100.0
+	teamSpend := 100.0
 	token := &TokenInfo{
 		TeamMaxBudget: &teamBudget,
 		TeamSpend:     &teamSpend,


### PR DESCRIPTION
Discovered while validating the AIR migration candidate against a green
migration stand.

## Problem
Key and user budget checks used `spend > max_budget`, while LiteLLM 1.90.0
rejects at the boundary with `spend >= max_budget` (`litellm/proxy/auth/auth_checks.py`
— the GHSA-2rv4-xv66-fpjg key check and `_user_max_budget_check`). Reaching the
budget exactly leaked one extra request per key/user versus production.

## Fix
Align each level with LiteLLM's actual per-level operator:
- key / user: `>` → `>=`
- team: stays `>` (LiteLLM deliberately uses a looser boundary there)
- team-member / org / org-member: already `>=`

Boundary tests now lock in each level's operator so they are not "unified" away.
`go test ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)