### PR TITLE
add messages api

### DIFF
--- a/docs/getting-started/api.md
+++ b/docs/getting-started/api.md
@@ -46,6 +46,24 @@ response = client.chat.completions.create(
 print(response.choices[0].message.content)
 ```
 
+## Anthropic Messages API
+
+`POST /v1/messages` accepts Anthropic Messages requests and adapts them to the router's Chat Completions pipeline. Authentication, model routing, balancing, fallbacks, and usage accounting are the same as for `/v1/chat/completions`.
+
+```bash
+curl -X POST http://localhost:8080/v1/messages \
+  -H "x-api-key: sk-your-master-key-here" \
+  -H "anthropic-version: 2023-06-01" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-20250514",
+    "max_tokens": 1024,
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+Set `"stream": true` to receive Anthropic-compatible `message_start`, content block, `message_delta`, and `message_stop` SSE events. Both `x-api-key` and `Authorization: Bearer ...` authentication are supported.
+
 ## Responses API
 
 The router supports the [OpenAI Responses API](../advanced/responses.md) with native provider integration for Anthropic, Comet API, Vertex AI, and AWS Bedrock.

--- a/internal/converter/anthropic/messages.go
+++ b/internal/converter/anthropic/messages.go
@@ -193,6 +193,18 @@ func convertOpenAIMessagesToAnthropic(openAIMessages []openai.OpenAIMessage) (in
 
 		case "assistant":
 			var blocks []ContentBlock
+			for _, thinking := range msg.ThinkingBlocks {
+				if thinking.Type != "thinking" && thinking.Type != "redacted_thinking" {
+					continue
+				}
+				blocks = append(blocks, ContentBlock{
+					Type:         thinking.Type,
+					Thinking:     thinking.Thinking,
+					Signature:    thinking.Signature,
+					Data:         thinking.Data,
+					CacheControl: thinking.CacheControl,
+				})
+			}
 			if textBlocks := convertOpenAIContentToAnthropic(msg.Content); len(textBlocks) > 0 {
 				blocks = append(blocks, textBlocks...)
 			}

--- a/internal/converter/anthropic/messages_api.go
+++ b/internal/converter/anthropic/messages_api.go
@@ -1,0 +1,778 @@
+package anthropic
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
+)
+
+const maxOpenAIToolNameLength = 64
+
+var invalidToolUseIDChar = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
+
+type MessagesAdapterMetadata struct {
+	ToolNames map[string]string
+}
+
+func MessagesToChat(body []byte) ([]byte, MessagesAdapterMetadata, error) {
+	var request map[string]interface{}
+	if err := json.Unmarshal(body, &request); err != nil {
+		return nil, MessagesAdapterMetadata{}, fmt.Errorf("failed to parse Messages request: %w", err)
+	}
+
+	model, _ := request["model"].(string)
+	if model == "" {
+		return nil, MessagesAdapterMetadata{}, fmt.Errorf("model is required")
+	}
+	maxTokens, ok := request["max_tokens"].(float64)
+	if !ok || maxTokens <= 0 {
+		return nil, MessagesAdapterMetadata{}, fmt.Errorf("max_tokens is required")
+	}
+	rawMessages, ok := request["messages"].([]interface{})
+	if !ok || len(rawMessages) == 0 {
+		return nil, MessagesAdapterMetadata{}, fmt.Errorf("messages is required")
+	}
+
+	messages, err := messagesToChatMessages(rawMessages)
+	if err != nil {
+		return nil, MessagesAdapterMetadata{}, err
+	}
+	if system, ok := request["system"]; ok {
+		if converted := systemToChatContent(system); converted != nil {
+			messages = append([]interface{}{map[string]interface{}{"role": "system", "content": converted}}, messages...)
+		}
+	}
+
+	chat := make(map[string]interface{}, len(request)+1)
+	for key, value := range request {
+		switch key {
+		case "messages", "system", "metadata", "stop_sequences", "tools", "tool_choice", "thinking", "output_format", "output_config":
+		default:
+			chat[key] = value
+		}
+	}
+	chat["model"] = model
+	chat["messages"] = messages
+	if metadata, ok := request["metadata"].(map[string]interface{}); ok {
+		if userID, ok := metadata["user_id"].(string); ok && userID != "" {
+			chat["user"] = userID
+		}
+	}
+	if stop, ok := request["stop_sequences"]; ok {
+		chat["stop"] = stop
+	}
+
+	toolNames := map[string]string{}
+	if tools, ok := request["tools"].([]interface{}); ok && len(tools) > 0 {
+		chat["tools"], toolNames = toolsToChat(tools)
+	}
+	if choice, ok := request["tool_choice"].(map[string]interface{}); ok {
+		chat["tool_choice"] = toolChoiceToChat(choice)
+	}
+	if thinking, ok := request["thinking"].(map[string]interface{}); ok {
+		if isClaudeModel(model) {
+			chat["thinking"] = thinking
+		} else if effort := thinkingToReasoningEffort(thinking); effort != "" {
+			if outputConfig, ok := request["output_config"].(map[string]interface{}); ok && thinking["type"] == "adaptive" {
+				if configured, ok := outputConfig["effort"].(string); ok && configured != "" {
+					effort = configured
+				}
+			}
+			chat["reasoning_effort"] = effort
+		}
+	}
+	if outputFormat := extractOutputFormat(request); outputFormat != nil {
+		chat["response_format"] = outputFormat
+	}
+	if stream, _ := request["stream"].(bool); stream {
+		chat["stream_options"] = map[string]interface{}{"include_usage": true}
+	}
+
+	converted, err := json.Marshal(chat)
+	if err != nil {
+		return nil, MessagesAdapterMetadata{}, fmt.Errorf("failed to encode Chat Completions request: %w", err)
+	}
+	return converted, MessagesAdapterMetadata{ToolNames: toolNames}, nil
+}
+
+func messagesToChatMessages(rawMessages []interface{}) ([]interface{}, error) {
+	converted := make([]interface{}, 0, len(rawMessages))
+	for _, raw := range rawMessages {
+		message, ok := raw.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("invalid message")
+		}
+		role, _ := message["role"].(string)
+		switch role {
+		case "user":
+			converted = append(converted, userMessageToChat(message)...)
+		case "assistant":
+			if assistant := assistantMessageToChat(message); assistant != nil {
+				converted = append(converted, assistant)
+			}
+		default:
+			return nil, fmt.Errorf("unsupported message role %q", role)
+		}
+	}
+	return converted, nil
+}
+
+func userMessageToChat(message map[string]interface{}) []interface{} {
+	content := message["content"]
+	if text, ok := content.(string); ok {
+		return []interface{}{map[string]interface{}{"role": "user", "content": text}}
+	}
+	blocks, _ := content.([]interface{})
+	var userContent []interface{}
+	var toolMessages []interface{}
+	for _, raw := range blocks {
+		block, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch block["type"] {
+		case "text":
+			part := map[string]interface{}{"type": "text", "text": stringValue(block["text"])}
+			copyCacheControl(block, part)
+			userContent = append(userContent, part)
+		case "image", "document":
+			if imageURL := sourceToImageURL(block["source"]); imageURL != "" {
+				part := map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": imageURL}}
+				copyCacheControl(block, part)
+				userContent = append(userContent, part)
+			}
+		case "tool_result":
+			tool := map[string]interface{}{
+				"role":         "tool",
+				"tool_call_id": normalizeToolUseID(stringValue(block["tool_use_id"])),
+				"content":      toolResultContentToChat(block["content"]),
+			}
+			copyCacheControl(block, tool)
+			toolMessages = append(toolMessages, tool)
+		}
+	}
+	if len(userContent) > 0 {
+		toolMessages = append(toolMessages, map[string]interface{}{"role": "user", "content": userContent})
+	}
+	return toolMessages
+}
+
+func assistantMessageToChat(message map[string]interface{}) interface{} {
+	content := message["content"]
+	if text, ok := content.(string); ok {
+		return map[string]interface{}{"role": "assistant", "content": text}
+	}
+	blocks, _ := content.([]interface{})
+	var text strings.Builder
+	var textBlocks []interface{}
+	var toolCalls []interface{}
+	var thinkingBlocks []interface{}
+	hasTextCacheControl := false
+	for _, raw := range blocks {
+		block, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch block["type"] {
+		case "text":
+			text.WriteString(stringValue(block["text"]))
+			part := map[string]interface{}{"type": "text", "text": stringValue(block["text"])}
+			copyCacheControl(block, part)
+			if _, ok := part["cache_control"]; ok {
+				hasTextCacheControl = true
+			}
+			textBlocks = append(textBlocks, part)
+		case "tool_use":
+			name := truncateToolName(stringValue(block["name"]))
+			arguments, _ := json.Marshal(block["input"])
+			call := map[string]interface{}{
+				"id":   normalizeToolUseID(stringValue(block["id"])),
+				"type": "function",
+				"function": map[string]interface{}{
+					"name":      name,
+					"arguments": string(arguments),
+				},
+			}
+			copyCacheControl(block, call)
+			toolCalls = append(toolCalls, call)
+		case "thinking", "redacted_thinking":
+			thinkingBlocks = append(thinkingBlocks, block)
+		}
+	}
+	if len(textBlocks) == 0 && len(toolCalls) == 0 && len(thinkingBlocks) == 0 {
+		return nil
+	}
+	var chatContent interface{} = text.String()
+	if len(textBlocks) == 0 {
+		chatContent = nil
+	} else if hasTextCacheControl {
+		chatContent = textBlocks
+	}
+	result := map[string]interface{}{"role": "assistant", "content": chatContent}
+	if len(toolCalls) > 0 {
+		result["tool_calls"] = toolCalls
+	}
+	if len(thinkingBlocks) > 0 {
+		result["thinking_blocks"] = thinkingBlocks
+	}
+	return result
+}
+
+func systemToChatContent(system interface{}) interface{} {
+	if text, ok := system.(string); ok {
+		if text == "" {
+			return nil
+		}
+		return text
+	}
+	blocks, _ := system.([]interface{})
+	content := make([]interface{}, 0, len(blocks))
+	for _, raw := range blocks {
+		block, ok := raw.(map[string]interface{})
+		if !ok || block["type"] != "text" {
+			continue
+		}
+		part := map[string]interface{}{"type": "text", "text": stringValue(block["text"])}
+		copyCacheControl(block, part)
+		content = append(content, part)
+	}
+	if len(content) == 0 {
+		return nil
+	}
+	return content
+}
+
+func toolsToChat(tools []interface{}) ([]interface{}, map[string]string) {
+	converted := make([]interface{}, 0, len(tools))
+	names := map[string]string{}
+	for index, raw := range tools {
+		tool, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		toolType, _ := tool["type"].(string)
+		if strings.HasPrefix(toolType, "computer_") || strings.HasPrefix(toolType, "bash_") ||
+			strings.HasPrefix(toolType, "text_editor_") || strings.HasPrefix(toolType, "web_search_") {
+			converted = append(converted, tool)
+			continue
+		}
+		name := strings.TrimSpace(stringValue(tool["name"]))
+		if name == "" {
+			name = fmt.Sprintf("litellm_unnamed_tool_%d", index)
+		}
+		truncated := truncateToolName(name)
+		if truncated != name {
+			names[truncated] = name
+		}
+		function := map[string]interface{}{"name": truncated}
+		if schema, ok := tool["input_schema"]; ok {
+			function["parameters"] = schema
+		}
+		if description, ok := tool["description"]; ok {
+			function["description"] = description
+		}
+		convertedTool := map[string]interface{}{"type": "function", "function": function}
+		copyCacheControl(tool, convertedTool)
+		converted = append(converted, convertedTool)
+	}
+	return converted, names
+}
+
+func toolChoiceToChat(choice map[string]interface{}) interface{} {
+	switch choice["type"] {
+	case "any":
+		return "required"
+	case "auto":
+		return "auto"
+	case "none":
+		return "none"
+	case "tool":
+		return map[string]interface{}{
+			"type":     "function",
+			"function": map[string]interface{}{"name": truncateToolName(stringValue(choice["name"]))},
+		}
+	default:
+		return choice
+	}
+}
+
+func sourceToImageURL(raw interface{}) string {
+	source, _ := raw.(map[string]interface{})
+	switch source["type"] {
+	case "base64":
+		data := stringValue(source["data"])
+		if data == "" {
+			return ""
+		}
+		mediaType := stringValue(source["media_type"])
+		if mediaType == "" {
+			mediaType = "image/jpeg"
+		}
+		return "data:" + mediaType + ";base64," + data
+	case "url":
+		return stringValue(source["url"])
+	default:
+		return ""
+	}
+}
+
+func toolResultContentToChat(raw interface{}) interface{} {
+	if raw == nil {
+		return ""
+	}
+	if text, ok := raw.(string); ok {
+		return text
+	}
+	blocks, _ := raw.([]interface{})
+	converted := make([]interface{}, 0, len(blocks))
+	for _, rawBlock := range blocks {
+		if text, ok := rawBlock.(string); ok {
+			converted = append(converted, map[string]interface{}{"type": "text", "text": text})
+			continue
+		}
+		block, ok := rawBlock.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		switch block["type"] {
+		case "text":
+			converted = append(converted, map[string]interface{}{"type": "text", "text": stringValue(block["text"])})
+		case "image", "document":
+			if imageURL := sourceToImageURL(block["source"]); imageURL != "" {
+				converted = append(converted, map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": imageURL}})
+			}
+		}
+	}
+	if len(converted) == 1 {
+		if part, ok := converted[0].(map[string]interface{}); ok && part["type"] == "text" {
+			return part["text"]
+		}
+	}
+	return converted
+}
+
+func copyCacheControl(source, target map[string]interface{}) {
+	if value, ok := source["cache_control"]; ok {
+		target["cache_control"] = value
+	}
+}
+
+func truncateToolName(name string) string {
+	if len(name) <= maxOpenAIToolNameLength {
+		return name
+	}
+	return name[:maxOpenAIToolNameLength]
+}
+
+func isClaudeModel(model string) bool {
+	lower := strings.ToLower(model)
+	return strings.Contains(lower, "anthropic") || strings.Contains(lower, "claude")
+}
+
+func thinkingToReasoningEffort(thinking map[string]interface{}) string {
+	switch thinking["type"] {
+	case "adaptive":
+		return "medium"
+	case "enabled":
+		budget, _ := thinking["budget_tokens"].(float64)
+		switch {
+		case budget >= 4096:
+			return "high"
+		case budget >= 2048:
+			return "medium"
+		case budget >= 1024:
+			return "low"
+		default:
+			return "minimal"
+		}
+	default:
+		return ""
+	}
+}
+
+func extractOutputFormat(request map[string]interface{}) interface{} {
+	output := request["output_format"]
+	if output == nil {
+		if config, ok := request["output_config"].(map[string]interface{}); ok {
+			output = config["format"]
+		}
+	}
+	format, ok := output.(map[string]interface{})
+	if !ok || format["type"] != "json_schema" || format["schema"] == nil {
+		return nil
+	}
+	schema, ok := format["schema"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	makeOpenAISchemaStrict(schema)
+	return map[string]interface{}{
+		"type": "json_schema",
+		"json_schema": map[string]interface{}{
+			"name":   "structured_output",
+			"schema": schema,
+			"strict": true,
+		},
+	}
+}
+
+func makeOpenAISchemaStrict(schema map[string]interface{}) {
+	if schema["type"] == "object" {
+		if properties, ok := schema["properties"].(map[string]interface{}); ok {
+			schema["additionalProperties"] = false
+			required := make([]string, 0, len(properties))
+			for name, raw := range properties {
+				required = append(required, name)
+				if child, ok := raw.(map[string]interface{}); ok {
+					makeOpenAISchemaStrict(child)
+				}
+			}
+			sort.Strings(required)
+			schema["required"] = required
+		}
+	}
+	if item, ok := schema["items"].(map[string]interface{}); ok {
+		makeOpenAISchemaStrict(item)
+	}
+	for _, key := range []string{"anyOf", "oneOf", "allOf"} {
+		alternatives, _ := schema[key].([]interface{})
+		for _, raw := range alternatives {
+			if child, ok := raw.(map[string]interface{}); ok {
+				makeOpenAISchemaStrict(child)
+			}
+		}
+	}
+	for _, key := range []string{"$defs", "definitions"} {
+		definitions, _ := schema[key].(map[string]interface{})
+		for _, raw := range definitions {
+			if child, ok := raw.(map[string]interface{}); ok {
+				makeOpenAISchemaStrict(child)
+			}
+		}
+	}
+}
+
+func ChatToMessages(body []byte, metadata MessagesAdapterMetadata) ([]byte, error) {
+	var response struct {
+		ID      string              `json:"id"`
+		Model   string              `json:"model"`
+		Usage   *openai.OpenAIUsage `json:"usage"`
+		Choices []struct {
+			FinishReason string `json:"finish_reason"`
+			Message      struct {
+				Content          *string                  `json:"content"`
+				ReasoningContent string                   `json:"reasoning_content"`
+				ThinkingBlocks   []map[string]interface{} `json:"thinking_blocks"`
+				ToolCalls        []openai.OpenAIToolCall  `json:"tool_calls"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("failed to parse Chat Completions response: %w", err)
+	}
+	if len(response.Choices) == 0 {
+		return nil, fmt.Errorf("chat completions response has no choices")
+	}
+
+	choice := response.Choices[0]
+	content := make([]interface{}, 0, 1+len(choice.Message.ToolCalls))
+	for _, block := range choice.Message.ThinkingBlocks {
+		switch block["type"] {
+		case "thinking", "redacted_thinking":
+			content = append(content, block)
+		}
+	}
+	if len(choice.Message.ThinkingBlocks) == 0 && choice.Message.ReasoningContent != "" {
+		content = append(content, map[string]interface{}{
+			"type": "thinking", "thinking": choice.Message.ReasoningContent, "signature": nil,
+		})
+	}
+	if choice.Message.Content != nil {
+		content = append(content, map[string]interface{}{"type": "text", "text": *choice.Message.Content})
+	}
+	for _, toolCall := range choice.Message.ToolCalls {
+		var input interface{}
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &input); err != nil {
+			input = map[string]interface{}{}
+		}
+		name := toolCall.Function.Name
+		if original := metadata.ToolNames[name]; original != "" {
+			name = original
+		}
+		content = append(content, map[string]interface{}{
+			"type":  "tool_use",
+			"id":    normalizeToolUseID(toolCall.ID),
+			"name":  name,
+			"input": input,
+		})
+	}
+
+	converted := map[string]interface{}{
+		"id":            response.ID,
+		"type":          "message",
+		"role":          "assistant",
+		"content":       content,
+		"model":         response.Model,
+		"stop_reason":   chatFinishReasonToMessages(choice.FinishReason),
+		"stop_sequence": nil,
+		"usage":         chatUsageToMessages(response.Usage),
+	}
+	return json.Marshal(converted)
+}
+
+func chatUsageToMessages(usage *openai.OpenAIUsage) *AnthropicUsage {
+	if usage == nil {
+		return &AnthropicUsage{}
+	}
+	cacheRead := 0
+	cacheCreation := 0
+	if usage.PromptTokensDetails != nil {
+		cacheRead = usage.PromptTokensDetails.CachedTokens
+		cacheCreation = usage.PromptTokensDetails.CacheCreationTokens
+		if cacheCreation == 0 {
+			cacheCreation = usage.PromptTokensDetails.CacheWriteTokens
+		}
+	}
+	return &AnthropicUsage{
+		InputTokens:              max(usage.PromptTokens-cacheRead-cacheCreation, 0),
+		OutputTokens:             usage.CompletionTokens,
+		CacheReadInputTokens:     cacheRead,
+		CacheCreationInputTokens: cacheCreation,
+	}
+}
+
+func chatFinishReasonToMessages(reason string) string {
+	switch reason {
+	case "length":
+		return "max_tokens"
+	case "tool_calls":
+		return "tool_use"
+	default:
+		return "end_turn"
+	}
+}
+
+func normalizeToolUseID(id string) string {
+	if separator := strings.Index(id, "__thought__"); separator >= 0 {
+		id = id[:separator]
+	}
+	normalized := invalidToolUseIDChar.ReplaceAllString(id, "_")
+	if normalized == "" {
+		return "tool_use_id"
+	}
+	return normalized
+}
+
+type messagesStreamState struct {
+	writer     io.Writer
+	model      string
+	metadata   MessagesAdapterMetadata
+	messageID  string
+	blockIndex int
+	blockType  string
+	toolIndex  int
+	finish     string
+	usage      *openai.OpenAIUsage
+	started    bool
+}
+
+func TransformChatStreamToMessages(reader io.Reader, writer io.Writer, model string, metadata MessagesAdapterMetadata) error {
+	state := messagesStreamState{writer: writer, model: model, metadata: metadata, messageID: "msg_" + uuid.NewString()}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(make([]byte, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data:") {
+			continue
+		}
+		payload := strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		if payload == "" {
+			continue
+		}
+		if payload == "[DONE]" {
+			return state.finishStream()
+		}
+		var chunk openai.OpenAIStreamingChunk
+		if err := json.Unmarshal([]byte(payload), &chunk); err != nil {
+			continue
+		}
+		if chunk.ID != "" {
+			state.messageID = chunk.ID
+		}
+		if chunk.Model != "" {
+			state.model = chunk.Model
+		}
+		if err := state.startMessage(); err != nil {
+			return err
+		}
+		if chunk.Usage != nil {
+			state.usage = chunk.Usage
+		}
+		for _, choice := range chunk.Choices {
+			if choice.Delta.ReasoningContent != "" {
+				if err := state.writeDelta("thinking", -1, "", "", choice.Delta.ReasoningContent); err != nil {
+					return err
+				}
+			}
+			if choice.Delta.Content != "" {
+				if err := state.writeDelta("text", -1, "", "", choice.Delta.Content); err != nil {
+					return err
+				}
+			}
+			for _, call := range choice.Delta.ToolCalls {
+				id := normalizeToolUseID(call.ID)
+				name := ""
+				arguments := ""
+				if call.Function != nil {
+					name = call.Function.Name
+					arguments = call.Function.Arguments
+				}
+				if original := metadata.ToolNames[name]; original != "" {
+					name = original
+				}
+				if err := state.writeDelta("tool_use", call.Index, id, name, arguments); err != nil {
+					return err
+				}
+			}
+			if choice.FinishReason != nil {
+				state.finish = chatFinishReasonToMessages(*choice.FinishReason)
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("chat completions stream scanner: %w", err)
+	}
+	return state.finishStream()
+}
+
+func (s *messagesStreamState) startMessage() error {
+	if s.started {
+		return nil
+	}
+	s.started = true
+	return writeMessagesSSE(s.writer, "message_start", map[string]interface{}{
+		"type": "message_start",
+		"message": map[string]interface{}{
+			"id":            s.messageID,
+			"type":          "message",
+			"role":          "assistant",
+			"content":       []interface{}{},
+			"model":         s.model,
+			"stop_reason":   nil,
+			"stop_sequence": nil,
+			"usage": map[string]interface{}{
+				"input_tokens":                0,
+				"output_tokens":               0,
+				"cache_creation_input_tokens": 0,
+				"cache_read_input_tokens":     0,
+			},
+		},
+	})
+}
+
+func (s *messagesStreamState) writeDelta(blockType string, toolIndex int, id, name, delta string) error {
+	if s.blockType != blockType || blockType == "tool_use" && s.toolIndex != toolIndex {
+		if err := s.stopBlock(); err != nil {
+			return err
+		}
+		s.blockType = blockType
+		s.toolIndex = toolIndex
+		contentBlock := map[string]interface{}{"type": blockType}
+		switch blockType {
+		case "text":
+			contentBlock["text"] = ""
+		case "thinking":
+			contentBlock["thinking"] = ""
+			contentBlock["signature"] = ""
+		case "tool_use":
+			contentBlock["id"] = id
+			contentBlock["name"] = name
+			contentBlock["input"] = map[string]interface{}{}
+		}
+		if err := writeMessagesSSE(s.writer, "content_block_start", map[string]interface{}{
+			"type": "content_block_start", "index": s.blockIndex, "content_block": contentBlock,
+		}); err != nil {
+			return err
+		}
+	}
+	deltaBody := map[string]interface{}{"type": blockType + "_delta"}
+	switch blockType {
+	case "text":
+		deltaBody["type"] = "text_delta"
+		deltaBody["text"] = delta
+	case "thinking":
+		deltaBody["type"] = "thinking_delta"
+		deltaBody["thinking"] = delta
+	case "tool_use":
+		deltaBody["type"] = "input_json_delta"
+		deltaBody["partial_json"] = delta
+	}
+	if delta == "" {
+		return nil
+	}
+	return writeMessagesSSE(s.writer, "content_block_delta", map[string]interface{}{
+		"type": "content_block_delta", "index": s.blockIndex, "delta": deltaBody,
+	})
+}
+
+func (s *messagesStreamState) stopBlock() error {
+	if s.blockType == "" {
+		return nil
+	}
+	if err := writeMessagesSSE(s.writer, "content_block_stop", map[string]interface{}{
+		"type": "content_block_stop", "index": s.blockIndex,
+	}); err != nil {
+		return err
+	}
+	s.blockIndex++
+	s.blockType = ""
+	return nil
+}
+
+func (s *messagesStreamState) finishStream() error {
+	if err := s.startMessage(); err != nil {
+		return err
+	}
+	if s.blockType == "" {
+		if err := s.writeDelta("text", -1, "", "", ""); err != nil {
+			return err
+		}
+	}
+	if err := s.stopBlock(); err != nil {
+		return err
+	}
+	reason := s.finish
+	if reason == "" {
+		reason = "end_turn"
+	}
+	usage := chatUsageToMessages(s.usage)
+	if err := writeMessagesSSE(s.writer, "message_delta", map[string]interface{}{
+		"type":  "message_delta",
+		"delta": map[string]interface{}{"stop_reason": reason, "stop_sequence": nil},
+		"usage": usage,
+	}); err != nil {
+		return err
+	}
+	return writeMessagesSSE(s.writer, "message_stop", map[string]interface{}{"type": "message_stop"})
+}
+
+func writeMessagesSSE(writer io.Writer, event string, value interface{}) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintf(writer, "event: %s\ndata: %s\n\n", event, data)
+	return err
+}
+
+func stringValue(value interface{}) string {
+	text, _ := value.(string)
+	return text
+}

--- a/internal/converter/anthropic/messages_api_test.go
+++ b/internal/converter/anthropic/messages_api_test.go
@@ -1,0 +1,176 @@
+package anthropic
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMessagesToChat(t *testing.T) {
+	longName := strings.Repeat("tool", 20)
+	body := []byte(`{
+		"model":"claude-alias",
+		"max_tokens":512,
+		"system":[{"type":"text","text":"Be concise","cache_control":{"type":"ephemeral"}}],
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"text","text":"Calling "},
+				{"type":"tool_use","id":"tool.1","name":"` + longName + `","input":{"q":"weather"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"tool.1","content":[{"type":"text","text":"sunny"}]},
+				{"type":"text","text":"Continue"},
+				{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aGVsbG8="}}
+			]}
+		],
+		"tools":[{"name":"` + longName + `","description":"Search","input_schema":{"type":"object"}}],
+		"tool_choice":{"type":"tool","name":"` + longName + `"},
+		"stop_sequences":["STOP"],
+		"metadata":{"user_id":"user-1"},
+		"stream":true
+	}`)
+
+	converted, metadata, err := MessagesToChat(body)
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(converted, &got))
+	assert.Equal(t, "claude-alias", got["model"])
+	assert.Equal(t, []interface{}{"STOP"}, got["stop"])
+	assert.Equal(t, "user-1", got["user"])
+	assert.Equal(t, map[string]interface{}{"include_usage": true}, got["stream_options"])
+	require.Len(t, metadata.ToolNames, 1)
+
+	messages := got["messages"].([]interface{})
+	require.Len(t, messages, 4)
+	assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
+	assert.Equal(t, "assistant", messages[1].(map[string]interface{})["role"])
+	assert.Equal(t, "tool", messages[2].(map[string]interface{})["role"])
+	assert.Equal(t, "user", messages[3].(map[string]interface{})["role"])
+
+	tool := got["tools"].([]interface{})[0].(map[string]interface{})
+	truncated := tool["function"].(map[string]interface{})["name"].(string)
+	assert.Len(t, truncated, maxOpenAIToolNameLength)
+	assert.Equal(t, longName, metadata.ToolNames[truncated])
+	assert.Equal(t, truncated, got["tool_choice"].(map[string]interface{})["function"].(map[string]interface{})["name"])
+}
+
+func TestChatToMessages(t *testing.T) {
+	longName := strings.Repeat("tool", 20)
+	truncated := truncateToolName(longName)
+	body := []byte(`{
+		"id":"chatcmpl-1",
+		"model":"model-alias",
+		"choices":[{
+			"index":0,
+			"message":{
+				"role":"assistant",
+				"content":null,
+				"reasoning_content":"thinking",
+				"tool_calls":[{"id":"functions.weather:0","type":"function","function":{"name":"` + truncated + `","arguments":"{\"city\":\"Moscow\"}"}}]
+			},
+			"finish_reason":"tool_calls"
+		}],
+		"usage":{
+			"prompt_tokens":120,
+			"completion_tokens":8,
+			"total_tokens":128,
+			"prompt_tokens_details":{"cached_tokens":20,"cache_creation_tokens":10}
+		}
+	}`)
+
+	converted, err := ChatToMessages(body, MessagesAdapterMetadata{ToolNames: map[string]string{truncated: longName}})
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(converted, &got))
+	assert.Equal(t, "message", got["type"])
+	assert.Equal(t, "assistant", got["role"])
+	assert.Equal(t, "tool_use", got["stop_reason"])
+	assert.Nil(t, got["stop_sequence"])
+	content := got["content"].([]interface{})
+	require.Len(t, content, 2)
+	assert.Equal(t, "thinking", content[0].(map[string]interface{})["type"])
+	tool := content[1].(map[string]interface{})
+	assert.Equal(t, "tool_use", tool["type"])
+	assert.Equal(t, "functions_weather_0", tool["id"])
+	assert.Equal(t, longName, tool["name"])
+	assert.Equal(t, "Moscow", tool["input"].(map[string]interface{})["city"])
+	usage := got["usage"].(map[string]interface{})
+	assert.Equal(t, float64(90), usage["input_tokens"])
+	assert.Equal(t, float64(8), usage["output_tokens"])
+	assert.Equal(t, float64(20), usage["cache_read_input_tokens"])
+	assert.Equal(t, float64(10), usage["cache_creation_input_tokens"])
+}
+
+func TestMessagesToChatPreservesThinkingForAnthropicProvider(t *testing.T) {
+	body := []byte(`{
+		"model":"claude-sonnet",
+		"max_tokens":4096,
+		"thinking":{"type":"enabled","budget_tokens":1024},
+		"messages":[
+			{"role":"assistant","content":[
+				{"type":"thinking","thinking":"reasoning","signature":"signature"},
+				{"type":"tool_use","id":"functions.weather:0","name":"weather","input":{"city":"Moscow"}}
+			]},
+			{"role":"user","content":[
+				{"type":"tool_result","tool_use_id":"functions.weather:0","content":"sunny"}
+			]}
+		]
+	}`)
+
+	chat, _, err := MessagesToChat(body)
+	require.NoError(t, err)
+	roundTrip, err := OpenAIToAnthropic(chat, "claude-sonnet")
+	require.NoError(t, err)
+
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(roundTrip, &got))
+	messages := got["messages"].([]interface{})
+	assistant := messages[0].(map[string]interface{})["content"].([]interface{})
+	assert.Equal(t, "thinking", assistant[0].(map[string]interface{})["type"])
+	assert.Equal(t, "signature", assistant[0].(map[string]interface{})["signature"])
+	assert.Equal(t, "functions_weather_0", assistant[1].(map[string]interface{})["id"])
+	result := messages[1].(map[string]interface{})["content"].([]interface{})[0].(map[string]interface{})
+	assert.Equal(t, "functions_weather_0", result["tool_use_id"])
+}
+
+func TestTransformChatStreamToMessages(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[{"index":0,"delta":{"reasoning_content":"think"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call.1","type":"function","function":{"name":"weather","arguments":""}}]},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"city\":\"Moscow\"}"}}]},"finish_reason":null}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[{"index":0,"delta":{},"finish_reason":"tool_calls"}]}`,
+		"",
+		`data: {"id":"chatcmpl-1","model":"model-alias","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":4,"total_tokens":14}}`,
+		"",
+		"data: [DONE]",
+		"",
+	}, "\n")
+
+	var output bytes.Buffer
+	require.NoError(t, TransformChatStreamToMessages(strings.NewReader(stream), &output, "fallback-model", MessagesAdapterMetadata{}))
+
+	got := output.String()
+	assert.Contains(t, got, "event: message_start")
+	assert.Contains(t, got, `"id":"chatcmpl-1"`)
+	assert.Contains(t, got, `"thinking":"think","type":"thinking_delta"`)
+	assert.Contains(t, got, `"text":"hello","type":"text_delta"`)
+	assert.Contains(t, got, `"id":"call_1","input":{},"name":"weather","type":"tool_use"`)
+	assert.Contains(t, got, `"partial_json":"{\"city\":\"Moscow\"}"`)
+	assert.Contains(t, got, `"stop_reason":"tool_use"`)
+	assert.Contains(t, got, `"input_tokens":10`)
+	assert.Contains(t, got, `"output_tokens":4`)
+	assert.True(t, strings.HasSuffix(got, "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"))
+}

--- a/internal/converter/anthropic/types.go
+++ b/internal/converter/anthropic/types.go
@@ -48,6 +48,7 @@ type ContentBlock struct {
 	// thinking block (in responses)
 	Thinking  string `json:"thinking,omitempty"`
 	Signature string `json:"signature,omitempty"`
+	Data      string `json:"data,omitempty"`
 
 	// prompt caching (requests only)
 	CacheControl interface{} `json:"cache_control,omitempty"`

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -348,8 +348,14 @@ func ExtractTokenUsageWithOptions(body []byte, opts TokenUsageExtractionOptions)
 	}
 
 	type responsesUsageDetails struct {
-		InputTokens        int `json:"input_tokens"`
-		OutputTokens       int `json:"output_tokens"`
+		InputTokens              int `json:"input_tokens"`
+		OutputTokens             int `json:"output_tokens"`
+		CacheReadInputTokens     int `json:"cache_read_input_tokens,omitempty"`
+		CacheCreationInputTokens int `json:"cache_creation_input_tokens,omitempty"`
+		CacheCreation            struct {
+			Ephemeral5mInputTokens int `json:"ephemeral_5m_input_tokens,omitempty"`
+			Ephemeral1hInputTokens int `json:"ephemeral_1h_input_tokens,omitempty"`
+		} `json:"cache_creation,omitempty"`
 		InputTokensDetails struct {
 			CachedTokens              int `json:"cached_tokens,omitempty"`
 			CachedAudioTokens         int `json:"cached_audio_tokens,omitempty"`
@@ -450,6 +456,9 @@ func ExtractTokenUsageWithOptions(body []byte, opts TokenUsageExtractionOptions)
 	if cachedTokens == 0 {
 		cachedTokens = resp.Usage.InputTokensDetails.CachedTokens
 	}
+	if cachedTokens == 0 {
+		cachedTokens = resp.Usage.CacheReadInputTokens
+	}
 	cacheCreationTokens := resp.Usage.PromptTokensDetails.CacheCreationTokens
 	cacheCreation5mTokens := resp.Usage.PromptTokensDetails.CacheCreationTokenDetails.Ephemeral5mInputTokens
 	cacheCreation1hTokens := resp.Usage.PromptTokensDetails.CacheCreationTokenDetails.Ephemeral1hInputTokens
@@ -464,6 +473,13 @@ func ExtractTokenUsageWithOptions(body []byte, opts TokenUsageExtractionOptions)
 	}
 	if cacheCreationTokens == 0 {
 		cacheCreationTokens = resp.Usage.InputTokensDetails.CacheWriteTokens
+	}
+	if cacheCreationTokens == 0 {
+		cacheCreationTokens = resp.Usage.CacheCreationInputTokens
+	}
+	if cacheCreation5mTokens == 0 && cacheCreation1hTokens == 0 {
+		cacheCreation5mTokens = resp.Usage.CacheCreation.Ephemeral5mInputTokens
+		cacheCreation1hTokens = resp.Usage.CacheCreation.Ephemeral1hInputTokens
 	}
 	if cachedAudioTokens == 0 {
 		cachedAudioTokens = resp.Usage.InputTokensDetails.CachedAudioTokens

--- a/internal/converter/converter_test.go
+++ b/internal/converter/converter_test.go
@@ -577,6 +577,22 @@ func TestExtractTokenUsage(t *testing.T) {
 	}
 }
 
+func TestExtractTokenUsage_AnthropicFlatCacheFields(t *testing.T) {
+	body := []byte(`{"usage":{"input_tokens":70,"output_tokens":20,"cache_read_input_tokens":25,"cache_creation_input_tokens":5}}`)
+
+	usage := ExtractTokenUsage(body)
+
+	if usage == nil {
+		t.Fatal("expected Anthropic usage")
+	}
+	if usage.PromptTokens != 70 || usage.CompletionTokens != 20 {
+		t.Fatalf("unexpected token counts: %+v", usage)
+	}
+	if usage.CachedInputTokens != 25 || usage.CacheCreationTokens != 5 {
+		t.Fatalf("unexpected Anthropic cache usage: %+v", usage)
+	}
+}
+
 func TestExtractTokenUsage_CacheCreationDetailsProvideMissingAggregate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -50,13 +50,22 @@ type OpenAIRequest struct {
 }
 
 type OpenAIMessage struct {
-	Role             string        `json:"role"`
-	Content          interface{}   `json:"content"`
-	Name             string        `json:"name,omitempty"`
-	ToolCallID       string        `json:"tool_call_id,omitempty"`
-	ToolCalls        []interface{} `json:"tool_calls,omitempty"`
-	Refusal          string        `json:"refusal,omitempty"`
-	ReasoningContent string        `json:"reasoning_content,omitempty"`
+	Role             string                `json:"role"`
+	Content          interface{}           `json:"content"`
+	Name             string                `json:"name,omitempty"`
+	ToolCallID       string                `json:"tool_call_id,omitempty"`
+	ToolCalls        []interface{}         `json:"tool_calls,omitempty"`
+	ThinkingBlocks   []OpenAIThinkingBlock `json:"thinking_blocks,omitempty"`
+	Refusal          string                `json:"refusal,omitempty"`
+	ReasoningContent string                `json:"reasoning_content,omitempty"`
+}
+
+type OpenAIThinkingBlock struct {
+	Type         string      `json:"type"`
+	Thinking     string      `json:"thinking,omitempty"`
+	Signature    string      `json:"signature,omitempty"`
+	Data         string      `json:"data,omitempty"`
+	CacheControl interface{} `json:"cache_control,omitempty"`
 }
 
 type ContentBlock struct {
@@ -133,6 +142,7 @@ type TokenDetails struct {
 	CachedAudioTokens         int                        `json:"cached_audio_tokens,omitempty"`
 	CacheCreationTokens       int                        `json:"cache_creation_tokens,omitempty"`
 	CacheCreationTokenDetails *CacheCreationTokenDetails `json:"cache_creation_token_details,omitempty"`
+	CacheWriteTokens          int                        `json:"cache_write_tokens,omitempty"`
 	AudioTokens               int                        `json:"audio_tokens,omitempty"`
 }
 

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -279,14 +279,8 @@ func (p *Proxy) prepareRequestForCredential(
 		if err != nil {
 			return req, err
 		}
-		proxyChatBody, _, err := anthropicconv.MessagesToChat(proxyBody)
-		if err != nil {
-			return req, err
-		}
 		req.body = openai.ReplaceBodyParam(realModelID, chatBody)
-		req.proxyBody = proxyChatBody
 		req.path = "/v1/chat/completions"
-		req.proxyPath = req.path
 		req.convertedMessages = true
 		req.messagesMetadata = metadata
 		return req, nil

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -35,11 +35,14 @@ type orchestratedRequest struct {
 	streaming            bool
 	cred                 *config.CredentialConfig
 	isResponsesAPI       bool
+	isMessagesAPI        bool
 	convertedResp        bool
+	convertedMessages    bool
 	passthroughResponses bool // true for codex/OpenAI models: Responses API forwarded as-is (no conversion)
 	nativeResponses      bool // true when using Phase 4 ProviderResponses converter (Vertex/Anthropic)
 	responsesPrevHandled bool
 	responsesMetadata    *responses.ResponsesMetadata // non-nil for Responses API requests
+	messagesMetadata     anthropicconv.MessagesAdapterMetadata
 	stickyCacheEligible  bool
 }
 
@@ -50,8 +53,10 @@ type credentialPreparedRequest struct {
 	realModelID          string
 	path                 string
 	convertedResp        bool
+	convertedMessages    bool
 	passthroughResponses bool
 	nativeResponses      bool
+	messagesMetadata     anthropicconv.MessagesAdapterMetadata
 }
 
 // orchestrateRequest performs auth and credential selection for an incoming request.
@@ -91,6 +96,7 @@ func (p *Proxy) orchestrateRequest(
 
 	// Detect Responses API requests and select credential before conversion.
 	isResponsesAPI := responses.IsResponsesAPI(body) && strings.Contains(r.URL.Path, "/responses")
+	isMessagesAPI := r.URL.Path == "/v1/messages"
 
 	var responsesMetadata *responses.ResponsesMetadata
 	var prevEntry *responsestore.StoredEntry
@@ -122,6 +128,7 @@ func (p *Proxy) orchestrateRequest(
 
 	p.logger.DebugContext(r.Context(), "Responses API detection",
 		"is_responses_api", isResponsesAPI,
+		"is_messages_api", isMessagesAPI,
 		"provider", cred.Type,
 		"model", modelID,
 		"streaming", streaming,
@@ -174,6 +181,12 @@ func (p *Proxy) orchestrateRequest(
 		stickyCacheEligible,
 	)
 	if prepErr != nil {
+		apiName := "request"
+		if isResponsesAPI {
+			apiName = "Responses API request"
+		} else if isMessagesAPI {
+			apiName = "Messages API request"
+		}
 		p.logger.ErrorContext(r.Context(), "Failed to prepare request for credential",
 			"error_code", http.StatusBadRequest,
 			"credential", cred.Name, "provider", string(cred.Type),
@@ -181,8 +194,8 @@ func (p *Proxy) orchestrateRequest(
 			"request_id", logCtx.RequestID)
 		logCtx.Status = "failure"
 		logCtx.HTTPStatus = http.StatusBadRequest
-		logCtx.ErrorMsg = "Failed to convert Responses API request: " + prepErr.Error()
-		WriteErrorBadRequest(w, "Failed to convert Responses API request")
+		logCtx.ErrorMsg = "Failed to convert " + apiName + ": " + prepErr.Error()
+		WriteErrorBadRequest(w, "Failed to convert "+apiName)
 		return nil, false
 	}
 	body = credentialReq.body
@@ -207,11 +220,14 @@ func (p *Proxy) orchestrateRequest(
 		streaming:            streaming,
 		cred:                 cred,
 		isResponsesAPI:       isResponsesAPI,
+		isMessagesAPI:        isMessagesAPI,
 		convertedResp:        credentialReq.convertedResp,
+		convertedMessages:    credentialReq.convertedMessages,
 		passthroughResponses: credentialReq.passthroughResponses,
 		nativeResponses:      credentialReq.nativeResponses,
 		responsesPrevHandled: prevEntryHandled,
 		responsesMetadata:    responsesMetadata,
+		messagesMetadata:     credentialReq.messagesMetadata,
 		stickyCacheEligible:  stickyCacheEligible,
 	}, true
 }
@@ -257,6 +273,23 @@ func (p *Proxy) prepareRequestForCredential(
 		proxyPath:   basePath,
 		realModelID: realModelID,
 		path:        basePath,
+	}
+	if basePath == "/v1/messages" {
+		chatBody, metadata, err := anthropicconv.MessagesToChat(body)
+		if err != nil {
+			return req, err
+		}
+		proxyChatBody, _, err := anthropicconv.MessagesToChat(proxyBody)
+		if err != nil {
+			return req, err
+		}
+		req.body = openai.ReplaceBodyParam(realModelID, chatBody)
+		req.proxyBody = proxyChatBody
+		req.path = "/v1/chat/completions"
+		req.proxyPath = req.path
+		req.convertedMessages = true
+		req.messagesMetadata = metadata
+		return req, nil
 	}
 	if !isResponsesAPI {
 		req.body = openai.ReplaceBodyParam(realModelID, body)

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -221,6 +221,35 @@ func TestPrepareRequestForCredential_ProxyBodyKeepsOriginalParams(t *testing.T) 
 	require.Contains(t, forwarded, "temperature")
 }
 
+func TestPrepareRequestForCredential_MessagesKeepsOriginalProxyRequest(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	cred := config.CredentialConfig{Name: "openai", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "http://openai.local", RPM: 100}
+	req := httptest.NewRequest("POST", "/v1/messages", nil)
+	body := []byte(`{"model":"claude-sonnet","max_tokens":100,"messages":[{"role":"user","content":"hello"}]}`)
+	proxyBody := []byte(`{"model":"claude-alias","max_tokens":100,"messages":[{"role":"user","content":"hello"}]}`)
+
+	prepared, err := prx.prepareRequestForCredential(
+		req,
+		body,
+		proxyBody,
+		"claude-alias",
+		"claude-sonnet",
+		"/v1/messages",
+		false,
+		&cred,
+		false,
+		false,
+		false,
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "/v1/chat/completions", prepared.path)
+	require.Equal(t, "/v1/messages", prepared.proxyPath)
+	require.JSONEq(t, string(proxyBody), string(prepared.proxyBody))
+	require.Contains(t, string(prepared.body), `"model":"claude-sonnet"`)
+	require.True(t, prepared.convertedMessages)
+}
+
 func TestPrepareRequestForCredential_ResponsesRecomputesProviderMode(t *testing.T) {
 	logger := testhelpers.NewTestLogger()
 	openaiCred := config.CredentialConfig{Name: "openai", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "http://openai.local", RPM: 100}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/balancer"
 	"github.com/mixaill76/auto_ai_router/internal/config"
 	"github.com/mixaill76/auto_ai_router/internal/converter"
+	anthropicconv "github.com/mixaill76/auto_ai_router/internal/converter/anthropic"
 	promanutils "github.com/mixaill76/auto_ai_router/internal/converter/proman/utils"
 	"github.com/mixaill76/auto_ai_router/internal/converter/responses"
 	"github.com/mixaill76/auto_ai_router/internal/httputil"
@@ -92,8 +93,10 @@ func (p *Proxy) applyCredentialCompatibilityRouting(
 		prepared.proxyPath = nextReq.proxyPath
 		prepared.realModelID = nextReq.realModelID
 		prepared.convertedResp = nextReq.convertedResp
+		prepared.convertedMessages = nextReq.convertedMessages
 		prepared.passthroughResponses = nextReq.passthroughResponses
 		prepared.nativeResponses = nextReq.nativeResponses
+		prepared.messagesMetadata = nextReq.messagesMetadata
 		logCtx.Credential = nextCred
 		logCtx.RealModelID = prepared.realModelID
 		if span := trace.SpanFromContext(r.Context()); span.IsRecording() {
@@ -993,7 +996,31 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 				"credential", cred.Name, "status", proxyResp.StatusCode)
 			streamCompleted := false
 
-			if prepared.convertedResp {
+			if prepared.convertedMessages && proxyResp.StatusCode >= 200 && proxyResp.StatusCode < 300 {
+				defer func() {
+					if closeErr := proxyResp.StreamBody.Close(); closeErr != nil {
+						p.logger.WarnContext(r.Context(), "Failed to close proxy streaming response body", "error", closeErr)
+					}
+				}()
+				p.copyResponseHeaders(w, proxyResp.Headers, cred, true)
+				setSuccessfulSSEHeaders(w.Header(), proxyResp.StatusCode)
+				if logCtx.IsProxyRequest && logCtx.ActualCredentialName != "" {
+					w.Header().Set("X-Credential-Name", logCtx.ActualCredentialName)
+				}
+				w.WriteHeader(proxyResp.StatusCode)
+				logCtx.PromptTokensEstimate = estimatePromptTokensForModel(body, realModelID)
+				fakeResp := &http.Response{
+					StatusCode: proxyResp.StatusCode,
+					Header:     proxyResp.Headers,
+					Body:       proxyResp.StreamBody,
+				}
+				if err := p.handleMessagesAPIStreaming(w, fakeResp, cred, realModelID, logCtx, prepared.messagesMetadata); err != nil {
+					p.logStreamHandlerError(r.Context(), "Failed to handle proxy Messages API streaming", err,
+						"credential", cred.Name, "model", modelID, "request_id", logCtx.RequestID)
+				} else {
+					streamCompleted = true
+				}
+			} else if prepared.convertedResp {
 				// Proxy streaming + Responses API: need to convert Chat Completions SSE
 				// to Responses API SSE. Wrap StreamBody in http.Response for handleResponsesAPIStreaming.
 				defer func() {
@@ -1092,7 +1119,16 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 		} else {
 			// Save passthrough Responses API response or convert Chat Completions response if needed
-			if prepared.passthroughResponses && proxyResp.StatusCode >= 200 && proxyResp.StatusCode < 300 {
+			if prepared.convertedMessages && proxyResp.StatusCode >= 200 && proxyResp.StatusCode < 300 {
+				messagesBody, convErr := anthropicconv.ChatToMessages(proxyResp.Body, prepared.messagesMetadata)
+				if convErr != nil {
+					p.logger.ErrorContext(r.Context(), "Failed to convert proxy response to Messages API format",
+						"credential", cred.Name, "model", modelID, "error", convErr,
+						"request_id", logCtx.RequestID)
+				} else {
+					proxyResp.Body = messagesBody
+				}
+			} else if prepared.passthroughResponses && proxyResp.StatusCode >= 200 && proxyResp.StatusCode < 300 {
 				// Codex passthrough: body is already in Responses API format — just enrich and save.
 				var respObj responses.Response
 				if err := json.Unmarshal(proxyResp.Body, &respObj); err == nil {
@@ -1277,8 +1313,10 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			prepared.proxyPath = nextReq.proxyPath
 			prepared.realModelID = nextReq.realModelID
 			prepared.convertedResp = nextReq.convertedResp
+			prepared.convertedMessages = nextReq.convertedMessages
 			prepared.passthroughResponses = nextReq.passthroughResponses
 			prepared.nativeResponses = nextReq.nativeResponses
+			prepared.messagesMetadata = nextReq.messagesMetadata
 			logCtx.RealModelID = realModelID
 
 			p.logger.InfoContext(r.Context(), "Retrying with next credential",
@@ -1712,7 +1750,16 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Handle Responses API response body.
-		if prepared.nativeResponses && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if prepared.convertedMessages && resp.StatusCode >= 200 && resp.StatusCode < 300 {
+			messagesBody, convErr := anthropicconv.ChatToMessages(finalResponseBody, prepared.messagesMetadata)
+			if convErr != nil {
+				p.logger.ErrorContext(r.Context(), "Failed to convert to Messages API format",
+					"credential", cred.Name, "model", modelID, "error", convErr,
+					"request_id", logCtx.RequestID)
+			} else {
+				finalResponseBody = messagesBody
+			}
+		} else if prepared.nativeResponses && resp.StatusCode >= 200 && resp.StatusCode < 300 {
 			// Native Responses converter: convert provider response → *responses.Response.
 			nativeResp, convErr := provResponses.ResponseTo([]byte(decodedBody), modelID)
 			if convErr != nil {
@@ -1936,14 +1983,32 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 
 		p.logger.DebugContext(r.Context(), "Streaming handler selection",
 			"is_responses_api", prepared.isResponsesAPI,
+			"is_messages_api", prepared.isMessagesAPI,
 			"converted_resp", prepared.convertedResp,
+			"converted_messages", prepared.convertedMessages,
 			"provider", cred.Type,
 			"model", modelID,
 			"resp_content_type", resp.Header.Get("Content-Type"),
 			"resp_status", resp.StatusCode)
 
 		streamCompleted := false
-		if prepared.nativeResponses {
+		if prepared.convertedMessages {
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				err := p.handleMessagesAPIStreaming(w, resp, cred, modelID, logCtx, prepared.messagesMetadata)
+				if err != nil {
+					p.logStreamHandlerError(r.Context(), "Failed to handle Messages API streaming", err,
+						"credential", cred.Name, "model", modelID, "request_id", logCtx.RequestID)
+				} else {
+					streamCompleted = true
+				}
+			} else {
+				err := p.handleProviderStreaming(w, resp, cred, realModelID, modelID, logCtx)
+				if err != nil {
+					p.logStreamHandlerError(r.Context(), "Failed to handle provider streaming response", err,
+						"credential", cred.Name, "provider", cred.Type, "model", modelID, "request_id", logCtx.RequestID)
+				}
+			}
+		} else if prepared.nativeResponses {
 			// Native Responses converter (Vertex AI, Anthropic): convert provider SSE
 			// directly to Responses API SSE via ProviderResponses.StreamTo().
 			if resp.StatusCode >= 200 && resp.StatusCode < 300 {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1043,6 +1043,11 @@ func TestExtractTokensFromStreamingChunk(t *testing.T) {
 			chunk:    "data: {\"usage\":{\"input_tokens\":100,\"output_tokens\":50,\"total_tokens\":150}}\n\n",
 			expected: 150,
 		},
+		{
+			name:     "messages API flat usage",
+			chunk:    "event: message_delta\ndata: {\"type\":\"message_delta\",\"usage\":{\"input_tokens\":70,\"output_tokens\":20,\"cache_read_input_tokens\":25,\"cache_creation_input_tokens\":5}}\n\n",
+			expected: 120,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/proxy/response_helpers.go
+++ b/internal/proxy/response_helpers.go
@@ -48,6 +48,25 @@ func extractOpenAITotalTokens(payload []byte) int {
 	return openAIResp.Response.Usage.TotalTokens
 }
 
+func extractMessagesTotalTokens(payload []byte) int {
+	var event struct {
+		Type  string `json:"type"`
+		Usage struct {
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.Unmarshal(payload, &event); err != nil || event.Type != "message_delta" {
+		return 0
+	}
+	return event.Usage.InputTokens +
+		event.Usage.OutputTokens +
+		event.Usage.CacheReadInputTokens +
+		event.Usage.CacheCreationInputTokens
+}
+
 func extractTokensFromStreamingChunk(chunk string) int {
 	// Look for usage information in streaming chunks
 	lines := strings.Split(chunk, "\n")
@@ -58,7 +77,11 @@ func extractTokensFromStreamingChunk(chunk string) int {
 				continue
 			}
 
-			tokens := extractOpenAITotalTokens([]byte(jsonData))
+			payload := []byte(jsonData)
+			tokens := extractMessagesTotalTokens(payload)
+			if tokens == 0 {
+				tokens = extractOpenAITotalTokens(payload)
+			}
 			if tokens > 0 {
 				return tokens
 			}

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mixaill76/auto_ai_router/internal/config"
 	"github.com/mixaill76/auto_ai_router/internal/converter"
+	anthropicconv "github.com/mixaill76/auto_ai_router/internal/converter/anthropic"
 	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	promanutils "github.com/mixaill76/auto_ai_router/internal/converter/proman/utils"
 	"github.com/mixaill76/auto_ai_router/internal/converter/responses"
@@ -1286,6 +1287,52 @@ func (p *Proxy) handleResponsesAPIStreaming(
 	}
 
 	return p.handleTransformedStreaming(w, resp, cred.Name, modelID, string(cred.Type), transformer, logCtx)
+}
+
+func (p *Proxy) handleMessagesAPIStreaming(
+	w http.ResponseWriter,
+	resp *http.Response,
+	cred *config.CredentialConfig,
+	modelID string,
+	logCtx *RequestLogContext,
+	metadata anthropicconv.MessagesAdapterMetadata,
+) error {
+	publicModel := clientVisibleResponseModel(logCtx, modelID)
+	converterModelID := modelID
+	if logCtx != nil && logCtx.RealModelID != "" {
+		converterModelID = logCtx.RealModelID
+	}
+	conv := converter.New(cred.Type, converter.RequestMode{
+		ModelID:        converterModelID,
+		DisplayModelID: publicModel,
+		IsStreaming:    true,
+	})
+	transformer := func(reader io.Reader, _ string, writer io.Writer) error {
+		if conv.IsPassthrough() {
+			return anthropicconv.TransformChatStreamToMessages(reader, writer, publicModel, metadata)
+		}
+		chatReader, chatWriter := io.Pipe()
+		var providerErr error
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			providerErr = conv.StreamTo(reader, chatWriter)
+			if providerErr != nil {
+				_ = chatWriter.CloseWithError(providerErr)
+				return
+			}
+			_ = chatWriter.Close()
+		}()
+		err := anthropicconv.TransformChatStreamToMessages(chatReader, writer, publicModel, metadata)
+		_ = chatReader.Close()
+		wg.Wait()
+		if err != nil {
+			return err
+		}
+		return providerErr
+	}
+	return p.handleTransformedStreaming(w, resp, cred.Name, modelID, "messages", transformer, logCtx)
 }
 
 // handleNativeResponsesStreaming handles Responses API streaming via the Phase 4

--- a/internal/proxy/token_estimator.go
+++ b/internal/proxy/token_estimator.go
@@ -428,6 +428,9 @@ func appendDeltaTextForPayload(b *strings.Builder, payload []byte) {
 	if bytes.Contains(payload, []byte(`"choices"`)) {
 		appendChatCompletionDeltaText(b, payload)
 	}
+	if bytes.Contains(payload, []byte(`"content_block_delta"`)) {
+		appendMessagesDeltaText(b, payload)
+	}
 	if bytes.Contains(payload, []byte(`"type"`)) {
 		appendResponsesDeltaText(b, payload)
 	}
@@ -488,6 +491,29 @@ func appendResponsesDeltaText(b *strings.Builder, payload []byte) {
 		"response.custom_tool_call_input.delta",
 		"response.code_interpreter_call_code.delta":
 		appendDeltaValueText(b, event.Delta)
+	}
+}
+
+func appendMessagesDeltaText(b *strings.Builder, payload []byte) {
+	var event struct {
+		Type  string `json:"type"`
+		Delta struct {
+			Type        string `json:"type"`
+			Text        string `json:"text"`
+			Thinking    string `json:"thinking"`
+			PartialJSON string `json:"partial_json"`
+		} `json:"delta"`
+	}
+	if err := goccyjson.Unmarshal(payload, &event); err != nil || event.Type != "content_block_delta" {
+		return
+	}
+	switch event.Delta.Type {
+	case "text_delta":
+		b.WriteString(event.Delta.Text)
+	case "thinking_delta":
+		b.WriteString(event.Delta.Thinking)
+	case "input_json_delta":
+		b.WriteString(event.Delta.PartialJSON)
 	}
 }
 

--- a/internal/proxy/token_estimator_test.go
+++ b/internal/proxy/token_estimator_test.go
@@ -140,6 +140,18 @@ func TestExtractCompletionDeltaText_ResponsesReasoningAndTools(t *testing.T) {
 	assert.Equal(t, "thinksumfnmcpcustomcode", extractCompletionDeltaText(chunk))
 }
 
+func TestExtractCompletionDeltaText_MessagesAPI(t *testing.T) {
+	chunk := []byte(
+		`event: content_block_delta` + "\n" +
+			`data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"hello"}}` + "\n\n" +
+			`event: content_block_delta` + "\n" +
+			`data: {"type":"content_block_delta","delta":{"type":"thinking_delta","thinking":"think"}}` + "\n\n" +
+			`event: content_block_delta` + "\n" +
+			`data: {"type":"content_block_delta","delta":{"type":"input_json_delta","partial_json":"{\"city\":\"Moscow\"}"}}` + "\n\n")
+
+	assert.Equal(t, `hellothink{"city":"Moscow"}`, extractCompletionDeltaText(chunk))
+}
+
 func TestExtractCompletionDeltaText_IgnoresAudioBytes(t *testing.T) {
 	chunk := []byte(`data: {"type":"response.output_audio.delta","delta":"QUJDREVGRw=="}` + "\n\n" +
 		`data: {"type":"response.audio.delta","delta":"QUJDREVGRw=="}` + "\n\n")

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -29,6 +29,7 @@ var proxiedPublicPaths = map[string]struct{}{
 	"/v1/embeddings":         {},
 	"/v1/images/generations": {},
 	"/v1/images/edits":       {},
+	"/v1/messages":           {},
 	"/v1/responses":          {},
 }
 
@@ -183,7 +184,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		// Capture request body for logging (detects streaming requests)
 		reqBody, isStreaming, err := captureRequestBody(req)
 		if err != nil {
-			r.proxy.ProxyRequest(w, req)
+			r.proxyPublicRequest(w, req)
 			return
 		}
 
@@ -191,7 +192,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		rc := newResponseCapture(w)
 
 		// Proxy the request through captured response
-		r.proxy.ProxyRequest(rc, req)
+		r.proxyPublicRequest(rc, req)
 
 		// Log error responses if enabled and status is error (4xx or 5xx).
 		// Skip logging for streaming requests to avoid memory overhead with large responses.
@@ -204,7 +205,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 		}
 	} else {
-		r.proxy.ProxyRequest(w, req)
+		r.proxyPublicRequest(w, req)
 	}
 }
 

--- a/internal/router/router_messages.go
+++ b/internal/router/router_messages.go
@@ -1,0 +1,115 @@
+package router
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+)
+
+type messagesErrorWriter struct {
+	http.ResponseWriter
+	body      bytes.Buffer
+	status    int
+	buffering bool
+}
+
+func (w *messagesErrorWriter) WriteHeader(status int) {
+	if status >= http.StatusBadRequest {
+		w.status = status
+		w.buffering = true
+		return
+	}
+	w.status = status
+	w.ResponseWriter.WriteHeader(status)
+}
+
+func (w *messagesErrorWriter) Write(body []byte) (int, error) {
+	if w.status == 0 {
+		w.WriteHeader(http.StatusOK)
+	}
+	if w.buffering {
+		return w.body.Write(body)
+	}
+	return w.ResponseWriter.Write(body)
+}
+
+func (w *messagesErrorWriter) Flush() {
+	if w.buffering {
+		return
+	}
+	if flusher, ok := w.ResponseWriter.(http.Flusher); ok {
+		flusher.Flush()
+	}
+}
+
+func (w *messagesErrorWriter) Unwrap() http.ResponseWriter {
+	return w.ResponseWriter
+}
+
+func (w *messagesErrorWriter) finalize() {
+	if !w.buffering {
+		return
+	}
+	message := http.StatusText(w.status)
+	var response struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+		Detail string `json:"detail"`
+	}
+	if json.Unmarshal(w.body.Bytes(), &response) == nil {
+		if response.Error.Message != "" {
+			message = response.Error.Message
+		} else if response.Detail != "" {
+			message = response.Detail
+		}
+	} else if w.body.Len() > 0 {
+		message = w.body.String()
+	}
+	body, _ := json.Marshal(map[string]interface{}{
+		"type": "error",
+		"error": map[string]interface{}{
+			"type":    messagesErrorType(w.status),
+			"message": message,
+		},
+	})
+	header := w.Header()
+	header.Del("Content-Encoding")
+	header.Set("Content-Type", "application/json")
+	header.Set("Content-Length", strconv.Itoa(len(body)))
+	w.ResponseWriter.WriteHeader(w.status)
+	_, _ = w.ResponseWriter.Write(body)
+}
+
+func messagesErrorType(status int) string {
+	switch status {
+	case http.StatusBadRequest:
+		return "invalid_request_error"
+	case http.StatusUnauthorized:
+		return "authentication_error"
+	case http.StatusForbidden:
+		return "permission_error"
+	case http.StatusNotFound:
+		return "not_found_error"
+	case http.StatusRequestEntityTooLarge:
+		return "request_too_large"
+	case http.StatusTooManyRequests:
+		return "rate_limit_error"
+	case 529:
+		return "overloaded_error"
+	default:
+		return "api_error"
+	}
+}
+
+func (r *Router) proxyPublicRequest(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path != "/v1/messages" {
+		r.proxy.ProxyRequest(w, req)
+		return
+	}
+	writer := &messagesErrorWriter{ResponseWriter: w}
+	req.Header.Set("Accept-Encoding", "identity")
+	r.proxy.ProxyRequest(writer, req)
+	writer.finalize()
+}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -435,6 +435,110 @@ func TestServeHTTP_ProxyRequest(t *testing.T) {
 	}
 }
 
+func TestServeHTTP_Messages(t *testing.T) {
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		var body map[string]interface{}
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		messages := body["messages"].([]interface{})
+		require.Len(t, messages, 2)
+		assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
+		assert.Equal(t, "user", messages[1].(map[string]interface{})["role"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{
+			"id":"chatcmpl-1",
+			"object":"chat.completion",
+			"created":1,
+			"model":"test-model",
+			"choices":[{"index":0,"message":{"role":"assistant","content":"hello"},"finish_reason":"stop"}],
+			"usage":{"prompt_tokens":5,"completion_tokens":2,"total_tokens":7}
+		}`)
+	}))
+	defer upstream.Close()
+
+	prx := createProxyWithMockServer(upstream.URL)
+	router := New(prx, nil, testhelpers.NewTestMonitoringConfig("/health", false, ""), testhelpers.NewTestLogger(), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"test-model",
+		"max_tokens":64,
+		"system":"Be concise",
+		"messages":[{"role":"user","content":"hi"}]
+	}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	result := httptest.NewRecorder()
+
+	router.ServeHTTP(result, req)
+
+	require.Equal(t, http.StatusOK, result.Code)
+	assert.Equal(t, "application/json", result.Header().Get("Content-Type"))
+	var response map[string]interface{}
+	require.NoError(t, json.Unmarshal(result.Body.Bytes(), &response))
+	assert.Equal(t, "message", response["type"])
+	assert.Equal(t, "assistant", response["role"])
+	assert.Equal(t, "end_turn", response["stop_reason"])
+	assert.Equal(t, "hello", response["content"].([]interface{})[0].(map[string]interface{})["text"])
+}
+
+func TestServeHTTP_MessagesStreaming(t *testing.T) {
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher := w.(http.Flusher)
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"model\":\"test-model\",\"choices\":[{\"index\":0,\"delta\":{\"role\":\"assistant\"},\"finish_reason\":null}]}\n\n")
+		flusher.Flush()
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"model\":\"test-model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"hello\"},\"finish_reason\":null}]}\n\n")
+		flusher.Flush()
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"model\":\"test-model\",\"choices\":[{\"index\":0,\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n")
+		_, _ = io.WriteString(w, "data: {\"id\":\"chatcmpl-1\",\"model\":\"test-model\",\"choices\":[],\"usage\":{\"prompt_tokens\":5,\"completion_tokens\":2,\"total_tokens\":7}}\n\n")
+		_, _ = io.WriteString(w, "data: [DONE]\n\n")
+		flusher.Flush()
+	}))
+	defer upstream.Close()
+
+	prx := createProxyWithMockServer(upstream.URL)
+	router := New(prx, nil, testhelpers.NewTestMonitoringConfig("/health", false, ""), testhelpers.NewTestLogger(), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"test-model",
+		"max_tokens":64,
+		"stream":true,
+		"messages":[{"role":"user","content":"hi"}]
+	}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	result := httptest.NewRecorder()
+
+	router.ServeHTTP(result, req)
+
+	require.Equal(t, http.StatusOK, result.Code)
+	assert.Contains(t, result.Header().Get("Content-Type"), "text/event-stream")
+	assert.Contains(t, result.Body.String(), "event: message_start")
+	assert.Contains(t, result.Body.String(), `"text":"hello","type":"text_delta"`)
+	assert.Contains(t, result.Body.String(), `"stop_reason":"end_turn"`)
+	assert.Contains(t, result.Body.String(), "event: message_stop")
+}
+
+func TestServeHTTP_MessagesUsesAnthropicErrorShape(t *testing.T) {
+	prx := createTestProxy()
+	router := New(prx, nil, testhelpers.NewTestMonitoringConfig("/health", false, ""), testhelpers.NewTestLogger(), nil)
+	req := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{
+		"model":"test-model",
+		"max_tokens":64,
+		"messages":[{"role":"user","content":"hi"}]
+	}`))
+	req.Header.Set("Content-Type", "application/json")
+	result := httptest.NewRecorder()
+
+	router.ServeHTTP(result, req)
+
+	require.Equal(t, http.StatusUnauthorized, result.Code)
+	assert.JSONEq(t, `{
+		"type":"error",
+		"error":{"type":"authentication_error","message":"Missing Authorization header"}
+	}`, result.Body.String())
+}
+
 func TestServeHTTP_NotFound(t *testing.T) {
 	prx := createTestProxy()
 	router := New(prx, nil, testhelpers.NewTestMonitoringConfig("/health", false, ""), testhelpers.NewTestLogger(), nil)
@@ -776,13 +880,12 @@ func TestServeHTTPRejectsUnsupportedMethodsBeforeAuth(t *testing.T) {
 	assert.Equal(t, http.StatusMethodNotAllowed, modelsResult.Code)
 	assert.Equal(t, http.MethodGet, modelsResult.Header().Get("Allow"))
 
-	// Native Anthropic Messages is intentionally outside the configured public
-	// surface; adding CORS must not make it look supported.
 	messagesReq := httptest.NewRequest(http.MethodOptions, "/v1/messages", nil)
 	messagesReq.Header.Set("Origin", "https://client.example.invalid")
 	messagesResult := httptest.NewRecorder()
 	router.ServeHTTP(messagesResult, messagesReq)
-	assert.Equal(t, http.StatusNotFound, messagesResult.Code)
+	assert.Equal(t, http.StatusMethodNotAllowed, messagesResult.Code)
+	assert.Equal(t, http.MethodPost, messagesResult.Header().Get("Allow"))
 	assert.Empty(t, messagesResult.Header().Get("Access-Control-Allow-Origin"))
 }
 


### PR DESCRIPTION
Adds an Anthropic-compatible `POST /v1/messages` endpoint over the existing Chat Completions pipeline.

Converts Messages requests, non-streaming responses, streaming SSE events, tools, thinking blocks, usage, and errors while preserving existing routing, fallbacks, authentication, and accounting.

Checks:
- `go test ./internal/...`
- `make lint`
