### PR TITLE
Pass Gemini image config

### DIFF
--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -40,6 +40,12 @@ type OpenAIRequest struct {
 	Verbosity            string                 `json:"verbosity,omitempty"`
 	Prediction           interface{}            `json:"prediction,omitempty"`
 	WebSearchOptions     interface{}            `json:"web_search_options,omitempty"`
+	ImageConfig          map[string]interface{} `json:"imageConfig,omitempty"`
+	ImageConfigSnake     map[string]interface{} `json:"image_config,omitempty"`
+	AspectRatio          string                 `json:"aspectRatio,omitempty"`
+	AspectRatioSnake     string                 `json:"aspect_ratio,omitempty"`
+	ImageSize            string                 `json:"imageSize,omitempty"`
+	ImageSizeSnake       string                 `json:"image_size,omitempty"`
 	ExtraBody            map[string]interface{} `json:"extra_body,omitempty"`
 }
 

--- a/internal/converter/vertex/genconfig.go
+++ b/internal/converter/vertex/genconfig.go
@@ -16,7 +16,8 @@ func buildGenerationConfig(req *openai.OpenAIRequest, model string) *VertexGener
 		req.FrequencyPenalty != nil || req.PresencePenalty != nil || req.Stop != nil ||
 		len(req.Modalities) > 0 || req.ReasoningEffort != "" || req.ResponseFormat != nil ||
 		req.Logprobs != nil || req.TopLogprobs != nil ||
-		req.Thinking != nil || req.ThinkingBudget != nil || req.ThinkingLevel != ""
+		req.Thinking != nil || req.ThinkingBudget != nil || req.ThinkingLevel != "" ||
+		hasTopLevelImageConfig(req)
 
 	if !hasParams {
 		return nil
@@ -100,6 +101,9 @@ func buildGenerationConfig(req *openai.OpenAIRequest, model string) *VertexGener
 	// ExtraBody overrides
 	if req.ExtraBody != nil {
 		cfg.ImageConfig = applyExtraBodyToConfig(cfg.GenerationConfig, req.ExtraBody, req.Model)
+	}
+	if imageConfig := parseTopLevelImageConfig(req); imageConfig != nil {
+		cfg.ImageConfig = imageConfig
 	}
 
 	// Deduplicate ResponseModalities (modalities may be added from multiple sources:
@@ -273,6 +277,35 @@ func parseImageConfig(value interface{}) *genai.ImageConfig {
 		AspectRatio: aspectRatio,
 		ImageSize:   imageSize,
 	}
+}
+
+func hasTopLevelImageConfig(req *openai.OpenAIRequest) bool {
+	return len(req.ImageConfig) > 0 || len(req.ImageConfigSnake) > 0 ||
+		req.AspectRatio != "" || req.AspectRatioSnake != "" ||
+		req.ImageSize != "" || req.ImageSizeSnake != ""
+}
+
+func parseTopLevelImageConfig(req *openai.OpenAIRequest) *genai.ImageConfig {
+	params := make(map[string]interface{})
+	for key, value := range req.ImageConfig {
+		params[key] = value
+	}
+	for key, value := range req.ImageConfigSnake {
+		params[key] = value
+	}
+	if req.AspectRatio != "" {
+		params["aspectRatio"] = req.AspectRatio
+	}
+	if req.AspectRatioSnake != "" {
+		params["aspect_ratio"] = req.AspectRatioSnake
+	}
+	if req.ImageSize != "" {
+		params["imageSize"] = req.ImageSize
+	}
+	if req.ImageSizeSnake != "" {
+		params["image_size"] = req.ImageSizeSnake
+	}
+	return parseImageConfig(params)
 }
 
 // mapAudioParam converts OpenAI audio param to genai.SpeechConfig (Phase 4).

--- a/internal/converter/vertex/genconfig_test.go
+++ b/internal/converter/vertex/genconfig_test.go
@@ -194,6 +194,66 @@ func TestApplyExtraBodyToConfig(t *testing.T) {
 	})
 }
 
+func TestBuildGenerationConfigTopLevelImageConfig(t *testing.T) {
+	t.Run("with snake case image_config", func(t *testing.T) {
+		req := &openai.OpenAIRequest{
+			Model: "gemini-3.1-flash-image",
+			ImageConfigSnake: map[string]interface{}{
+				"aspect_ratio": "3:4",
+				"image_size":   "2K",
+			},
+		}
+
+		cfg := buildGenerationConfig(req, "gemini-3.1-flash-image")
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.ImageConfig)
+		assert.Equal(t, "3:4", cfg.ImageConfig.AspectRatio)
+		assert.Equal(t, "2K", cfg.ImageConfig.ImageSize)
+	})
+
+	t.Run("top-level scalar fields override image_config", func(t *testing.T) {
+		req := &openai.OpenAIRequest{
+			Model: "gemini-3.1-flash-image",
+			ImageConfigSnake: map[string]interface{}{
+				"aspect_ratio": "1:1",
+				"image_size":   "1K",
+			},
+			AspectRatioSnake: "3:4",
+			ImageSizeSnake:   "2K",
+		}
+
+		cfg := buildGenerationConfig(req, "gemini-3.1-flash-image")
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.ImageConfig)
+		assert.Equal(t, "3:4", cfg.ImageConfig.AspectRatio)
+		assert.Equal(t, "2K", cfg.ImageConfig.ImageSize)
+	})
+
+	t.Run("top-level image_config overrides extra_body image_config", func(t *testing.T) {
+		req := &openai.OpenAIRequest{
+			Model: "gemini-3.1-flash-image",
+			ExtraBody: map[string]interface{}{
+				"generation_config": map[string]interface{}{
+					"image_config": map[string]interface{}{
+						"aspect_ratio": "1:1",
+						"image_size":   "1K",
+					},
+				},
+			},
+			ImageConfigSnake: map[string]interface{}{
+				"aspect_ratio": "3:4",
+				"image_size":   "2K",
+			},
+		}
+
+		cfg := buildGenerationConfig(req, "gemini-3.1-flash-image")
+		require.NotNil(t, cfg)
+		require.NotNil(t, cfg.ImageConfig)
+		assert.Equal(t, "3:4", cfg.ImageConfig.AspectRatio)
+		assert.Equal(t, "2K", cfg.ImageConfig.ImageSize)
+	})
+}
+
 func TestMapAudioParam(t *testing.T) {
 	t.Run("nil param returns nil", func(t *testing.T) {
 		result := mapAudioParam(nil)

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -289,6 +289,9 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 	if err := applyGeminiImageSize(genConfig, providerModel, fields["size"]); err != nil {
 		return nil, err
 	}
+	if err := applyGeminiImageConfigFields(genConfig, fields); err != nil {
+		return nil, err
+	}
 
 	chatReq := openai.OpenAIRequest{
 		Model: model,
@@ -428,6 +431,61 @@ func parseImageEditFloat(raw, name string) (float64, error) {
 		return 0, fmt.Errorf("invalid image edit %s %q", name, raw)
 	}
 	return value, nil
+}
+
+func applyGeminiImageConfigFields(genConfig map[string]interface{}, fields map[string]string) error {
+	imageConfig := map[string]interface{}{}
+	if existing, ok := genConfig["image_config"].(map[string]interface{}); ok {
+		for key, value := range existing {
+			imageConfig[key] = value
+		}
+	}
+
+	for _, name := range []string{"image_config", "imageConfig"} {
+		raw := strings.TrimSpace(fields[name])
+		if raw == "" {
+			continue
+		}
+		var parsed map[string]interface{}
+		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+			return fmt.Errorf("invalid image edit %s %q", name, raw)
+		}
+		for key, value := range parsed {
+			imageConfig[key] = value
+		}
+	}
+
+	if aspectRatio := firstNonEmptyField(fields, "aspect_ratio", "aspectRatio"); aspectRatio != "" {
+		imageConfig["aspectRatio"] = aspectRatio
+		delete(imageConfig, "aspect_ratio")
+	}
+	if imageSize := firstNonEmptyField(fields, "image_size", "imageSize"); imageSize != "" {
+		imageConfig["imageSize"] = imageSize
+		delete(imageConfig, "image_size")
+	}
+
+	if aspectRatio, ok := imageConfig["aspect_ratio"].(string); ok && aspectRatio != "" {
+		imageConfig["aspectRatio"] = aspectRatio
+		delete(imageConfig, "aspect_ratio")
+	}
+	if imageSize, ok := imageConfig["image_size"].(string); ok && imageSize != "" {
+		imageConfig["imageSize"] = imageSize
+		delete(imageConfig, "image_size")
+	}
+
+	if len(imageConfig) > 0 {
+		genConfig["image_config"] = imageConfig
+	}
+	return nil
+}
+
+func firstNonEmptyField(fields map[string]string, names ...string) string {
+	for _, name := range names {
+		if value := strings.TrimSpace(fields[name]); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func readMultipartPartLimit(part *multipart.Part, maxBytes int64) ([]byte, error) {

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -348,6 +348,46 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		assert.Equal(t, float64(1), *chatReq.TopP)
 	})
 
+	t.Run("multipart edit preserves explicit image config fields", func(t *testing.T) {
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", map[string]string{
+			"image_config": `{"aspect_ratio":"3:4","image_size":"2K"}`,
+		})
+		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		genConfig := chatReq.ExtraBody["generation_config"].(map[string]interface{})
+		imageConfig := genConfig["image_config"].(map[string]interface{})
+		assert.Equal(t, "3:4", imageConfig["aspectRatio"])
+		assert.Equal(t, "2K", imageConfig["imageSize"])
+	})
+
+	t.Run("multipart edit explicit image config fields override size", func(t *testing.T) {
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", map[string]string{
+			"aspect_ratio": "3:4",
+			"image_size":   "2K",
+		})
+		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+		require.NoError(t, err)
+
+		var chatReq openai.OpenAIRequest
+		require.NoError(t, json.Unmarshal(result, &chatReq))
+		genConfig := chatReq.ExtraBody["generation_config"].(map[string]interface{})
+		imageConfig := genConfig["image_config"].(map[string]interface{})
+		assert.Equal(t, "3:4", imageConfig["aspectRatio"])
+		assert.Equal(t, "2K", imageConfig["imageSize"])
+	})
+
+	t.Run("multipart edit rejects invalid image config json", func(t *testing.T) {
+		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", map[string]string{
+			"image_config": `{"aspect_ratio":`,
+		})
+		_, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid image edit image_config")
+	})
+
 	t.Run("omitted sampling parameters remain unset", func(t *testing.T) {
 		body, contentType := buildMultipart(t, "gemini-3.1-flash-image-preview", "1024x1024", nil)
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)

--- a/internal/converter/vertex/request_test.go
+++ b/internal/converter/vertex/request_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
+	"github.com/stretchr/testify/require"
 )
 
 // TestOpenAIToVertex_ToolRoleMessage_UsesNameField verifies that when a tool-role
@@ -66,6 +67,37 @@ func TestOpenAIToVertex_ToolRoleMessage_UsesNameField(t *testing.T) {
 	} else if temp != float64(22) {
 		t.Fatalf("expected temperature = 22, got %v", temp)
 	}
+}
+
+func TestOpenAIToVertex_TopLevelImageConfig(t *testing.T) {
+	req := openai.OpenAIRequest{
+		Model: "gemini-3.1-flash-image",
+		Messages: []openai.OpenAIMessage{
+			{
+				Role: "user",
+				Content: []interface{}{
+					map[string]interface{}{"type": "text", "text": "edit"},
+				},
+			},
+		},
+		ImageConfigSnake: map[string]interface{}{
+			"aspect_ratio": "3:4",
+			"image_size":   "2K",
+		},
+	}
+
+	body, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	resultBytes, err := OpenAIToVertex(body, false, false, "gemini-3.1-flash-image", "application/json")
+	require.NoError(t, err)
+
+	var vertexReq VertexRequest
+	require.NoError(t, json.Unmarshal(resultBytes, &vertexReq))
+	require.NotNil(t, vertexReq.GenerationConfig)
+	require.NotNil(t, vertexReq.GenerationConfig.ImageConfig)
+	require.Equal(t, "3:4", vertexReq.GenerationConfig.ImageConfig.AspectRatio)
+	require.Equal(t, "2K", vertexReq.GenerationConfig.ImageConfig.ImageSize)
 }
 
 // TestOpenAIToVertex_ToolRoleMessage_EmptyName_FallbackToToolResult verifies

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -712,6 +712,82 @@ func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+func TestProxyRequest_MultipartImageEditWithFourImagesAndImageConfig(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+
+		var bodyMap map[string]interface{}
+		err := json.NewDecoder(r.Body).Decode(&bodyMap)
+		assert.NoError(t, err)
+
+		contents, ok := bodyMap["contents"].([]interface{})
+		assert.True(t, ok)
+		assert.Len(t, contents, 1)
+		content, ok := contents[0].(map[string]interface{})
+		assert.True(t, ok)
+		parts, ok := content["parts"].([]interface{})
+		assert.True(t, ok)
+		assert.Len(t, parts, 5)
+
+		inlineDataCount := 0
+		for _, partValue := range parts {
+			part, ok := partValue.(map[string]interface{})
+			assert.True(t, ok)
+			if _, exists := part["inlineData"]; exists {
+				inlineDataCount++
+			}
+		}
+		assert.Equal(t, 4, inlineDataCount)
+
+		generationConfig, ok := bodyMap["generationConfig"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, float64(42), generationConfig["seed"])
+		assert.InDelta(t, 0.0, generationConfig["temperature"], 1e-6)
+		assert.InDelta(t, 0.0, generationConfig["topP"], 1e-6)
+
+		imageConfig, ok := generationConfig["imageConfig"].(map[string]interface{})
+		assert.True(t, ok)
+		assert.Equal(t, "3:4", imageConfig["aspectRatio"])
+		assert.Equal(t, "2K", imageConfig["imageSize"])
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"candidates":[{"content":{"parts":[{"inlineData":{"data":"aW1n","mimeType":"image/png"}}],"role":"model"}}]}`))
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeGemini, mockServer.URL, "upstream-key-1").
+		Build()
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	assert.NoError(t, writer.WriteField("model", "gemini-3.1-flash-image-preview"))
+	assert.NoError(t, writer.WriteField("prompt", "Edit these images"))
+	assert.NoError(t, writer.WriteField("seed", "42"))
+	assert.NoError(t, writer.WriteField("temperature", "0"))
+	assert.NoError(t, writer.WriteField("top_p", "0"))
+	assert.NoError(t, writer.WriteField("image_config", `{"aspect_ratio":"3:4","image_size":"2K"}`))
+	for i := 0; i < 4; i++ {
+		part, err := writer.CreatePart(textproto.MIMEHeader{
+			"Content-Disposition": []string{`form-data; name="image[]"; filename="input.png"`},
+			"Content-Type":        []string{"image/png"},
+		})
+		assert.NoError(t, err)
+		_, err = part.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n', byte(i)})
+		assert.NoError(t, err)
+	}
+	assert.NoError(t, writer.Close())
+
+	req := httptest.NewRequest("POST", "/v1/images/edits", &buf)
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestProxyRequest_ImageGenerationSamplingParametersConvertedToJSON(t *testing.T) {
 	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))


### PR DESCRIPTION
## Changes

Pass Gemini image config through image edit multipart requests

Pass top level Gemini image config through chat requests

Reject invalid image_config JSON in image edit multipart requests

## Tests

go test ./internal/converter/vertex ./internal/converter ./internal/converter/openai ./internal/proxy
