### PR TITLE
Fix accepted model aliases

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -590,6 +590,9 @@ func initializeModelManager(
 	if len(cfg.PublicModelAlias) > 0 {
 		modelManager.SetPublicModelAliases(cfg.PublicModelAlias)
 	}
+	if len(cfg.AcceptedModelAlias) > 0 {
+		modelManager.SetAcceptedModelAliases(cfg.AcceptedModelAlias)
+	}
 
 	// Initialize rate limiters for each model
 	modelsResp := modelManager.GetAllModels()

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/config"
 	"github.com/mixaill76/auto_ai_router/internal/modelupdate"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSplitCredentialModel(t *testing.T) {
@@ -74,4 +75,32 @@ func TestInitializeModelManagerKeepsBackendRateLimitsBehindClientSurface(t *test
 	if assert.Len(t, models.Data, 1) {
 		assert.Equal(t, "public/chat", models.Data[0].ID)
 	}
+}
+
+func TestInitializeModelManagerRegistersAcceptedModelAliases(t *testing.T) {
+	cfg := &config.Config{
+		Server: config.ServerConfig{DefaultModelsRPM: -1},
+		Credentials: []config.CredentialConfig{{
+			Name: "provider", Type: config.ProviderTypeOpenAI, RPM: -1, TPM: -1,
+		}},
+		Models: []config.ModelRPMConfig{{
+			Name: "backend-chat", Credential: "provider", RPM: 7, TPM: 70,
+		}},
+		ModelAlias:         map[string]string{"public/chat": "backend-chat"},
+		ClientModelIDs:     []string{"public/chat"},
+		AcceptedModelAlias: map[string]string{"legacy-chat": "public/chat"},
+	}
+	logger := slog.New(slog.DiscardHandler)
+	_, limiter, bal := initializeBalancer(cfg, logger, nil)
+	manager := initializeModelManager(logger, cfg, limiter, bal)
+
+	assert.True(t, manager.IsClientModelIDRoutable("legacy-chat"))
+	canonical, alias, err := manager.ResolvePublicModelAlias("legacy-chat")
+	require.NoError(t, err)
+	assert.True(t, alias)
+	assert.Equal(t, "public/chat", canonical)
+
+	models := manager.GetClientModels()
+	require.Len(t, models.Data, 1)
+	assert.Equal(t, "public/chat", models.Data[0].ID)
 }

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -190,6 +190,7 @@ type Manager struct {
 	clientModelIDs               map[string]struct{}          // exact advertised canonical client IDs
 	clientModelSurfaceConfigured bool                         // distinguishes an omitted boundary from an explicit empty boundary
 	publicModelAliases           map[string]string            // client alias -> canonical LiteLLM public deployment identity
+	acceptedModelAliases         map[string]string            // accepted client alias -> canonical model, hidden from discovery
 	modelRealNames               map[string]string            // alias name -> real model name (global, no specific credential)
 	modelRealNamesPerCred        map[string]map[string]string // credential -> alias -> real model name (for credential-specific entries)
 	credentialMappingsReady      bool                         // true after static/DB credential mappings have been initialized
@@ -217,6 +218,7 @@ func New(logger *slog.Logger, defaultModelsRPM int, staticModels []config.ModelR
 		modelAliases:                make(map[string]string),
 		clientModelIDs:              make(map[string]struct{}),
 		publicModelAliases:          make(map[string]string),
+		acceptedModelAliases:        make(map[string]string),
 		modelRealNames:              make(map[string]string),
 		modelRealNamesPerCred:       make(map[string]map[string]string),
 		modelPassthroughResponses:   make(map[string]*bool),
@@ -569,11 +571,49 @@ func (m *Manager) SetPublicModelAliases(aliases map[string]string) {
 	m.invalidateAllModelsCachesLocked()
 }
 
+func (m *Manager) SetAcceptedModelAliases(aliases map[string]string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.acceptedModelAliases = make(map[string]string, len(aliases))
+	for alias, target := range aliases {
+		if alias == "" || target == "" || alias == target {
+			m.logger.Warn("Invalid accepted model alias, skipping", "alias", alias, "target", target)
+			continue
+		}
+		m.acceptedModelAliases[alias] = target
+		m.logger.Info("Registered accepted model alias", "alias", alias, "target", target)
+	}
+	m.allModels = nil
+	m.invalidateAllModelsCachesLocked()
+}
+
+func (m *Manager) clientAliasTargetLocked(modelID string) (string, bool, bool) {
+	publicTarget, publicConfigured := m.publicModelAliases[modelID]
+	acceptedTarget, acceptedConfigured := m.acceptedModelAliases[modelID]
+	if publicConfigured && acceptedConfigured && publicTarget != acceptedTarget {
+		return modelID, true, false
+	}
+	if publicConfigured {
+		return publicTarget, true, true
+	}
+	if acceptedConfigured {
+		return acceptedTarget, true, true
+	}
+	return modelID, false, true
+}
+
 func (m *Manager) IsClientModelIDRoutable(modelID string) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if target, aliased := m.publicModelAliases[modelID]; aliased {
-		return m.publicModelAliasTargetActiveLocked(target)
+	if target, aliased, unambiguous := m.clientAliasTargetLocked(modelID); aliased {
+		if !unambiguous || !m.publicModelAliasTargetActiveLocked(target) {
+			return false
+		}
+		if m.clientModelSurfaceConfigured {
+			_, allowed := m.clientModelIDs[target]
+			return allowed
+		}
+		return true
 	}
 	if m.clientModelSurfaceConfigured {
 		if _, allowed := m.clientModelIDs[modelID]; !allowed {
@@ -587,11 +627,11 @@ func (m *Manager) IsClientModelIDRoutable(modelID string) bool {
 func (m *Manager) ResolvePublicModelAlias(modelID string) (string, bool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	target, aliased := m.publicModelAliases[modelID]
+	target, aliased, unambiguous := m.clientAliasTargetLocked(modelID)
 	if !aliased {
 		return modelID, false, nil
 	}
-	if !m.publicModelAliasTargetActiveLocked(target) {
+	if !unambiguous || !m.publicModelAliasTargetActiveLocked(target) {
 		return modelID, false, fmt.Errorf("public model alias %q is not routable", modelID)
 	}
 	return target, true, nil
@@ -765,8 +805,8 @@ func (m *Manager) IsModelIDAllowedByScope(modelID string, allowedModelIDs []stri
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	requestIDs := []string{modelID}
-	if target, isPublicAlias := m.publicModelAliases[modelID]; isPublicAlias {
-		if !m.publicModelAliasTargetActiveLocked(target) {
+	if target, isClientAlias, unambiguous := m.clientAliasTargetLocked(modelID); isClientAlias {
+		if !unambiguous || !m.publicModelAliasTargetActiveLocked(target) {
 			return false
 		}
 		requestIDs = append(requestIDs, target)
@@ -1433,17 +1473,32 @@ func (m *Manager) projectClientModelCatalogLocked(internalModels []Model) []Mode
 			activePublicAliases[alias] = target
 		}
 	}
+	var models []Model
 	if m.clientModelSurfaceConfigured {
-		return projectConfiguredClientModelCatalog(
+		models = projectConfiguredClientModelCatalog(
 			internalModels,
 			m.clientModelIDs,
 			m.modelAliases,
 			activePublicAliases,
 		)
+	} else {
+		models = projectPublicModelCatalog(internalModels, m.modelAliases)
+		models = projectCanonicalPublicAliases(models, activePublicAliases)
 	}
-	models := projectPublicModelCatalog(internalModels, m.modelAliases)
-	models = projectCanonicalPublicAliases(models, activePublicAliases)
-	return models
+	return hideAcceptedModelAliases(models, m.acceptedModelAliases)
+}
+
+func hideAcceptedModelAliases(models []Model, aliases map[string]string) []Model {
+	if len(aliases) == 0 {
+		return models
+	}
+	visible := make([]Model, 0, len(models))
+	for _, model := range models {
+		if _, hidden := aliases[model.ID]; !hidden {
+			visible = append(visible, model)
+		}
+	}
+	return visible
 }
 
 func (m *Manager) invalidateAllModelsCachesLocked() {

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -125,6 +125,26 @@ func TestClientCatalogActivatesPublicAliasThroughCanonicalRouteAlias(t *testing.
 	assert.True(t, manager.IsModelIDAllowedByScope("gpt-4.1", []string{"openai/gpt-4.1"}))
 }
 
+func TestAcceptedModelAliasRoutesWithoutDiscovery(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	credential := config.CredentialConfig{Name: "openai", Type: config.ProviderTypeOpenAI}
+	manager := New(logger, 100, []config.ModelRPMConfig{{
+		Name:       "gpt-4.1",
+		Credential: credential.Name,
+	}})
+	manager.SetModelAliases(map[string]string{"openai/gpt-4.1": "gpt-4.1"})
+	manager.SetClientModelIDs([]string{"openai/gpt-4.1"})
+	manager.SetAcceptedModelAliases(map[string]string{"legacy-gpt-4.1": "openai/gpt-4.1"})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+
+	assert.True(t, manager.IsClientModelIDRoutable("legacy-gpt-4.1"))
+	canonical, alias, err := manager.ResolvePublicModelAlias("legacy-gpt-4.1")
+	assert.NoError(t, err)
+	assert.True(t, alias)
+	assert.Equal(t, "openai/gpt-4.1", canonical)
+	assert.Equal(t, []string{"openai/gpt-4.1"}, responseModelIDs(manager.GetClientModels()))
+}
+
 func TestGetAllModelsWithAccessGroupsScoped_FiltersAliasesByScope(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	manager := New(logger, 100, []config.ModelRPMConfig{

--- a/internal/proxy/client_auth_test.go
+++ b/internal/proxy/client_auth_test.go
@@ -233,6 +233,40 @@ func TestExplicitClientModelSurfaceRejectsBackendBeforeProviderAndSpend(t *testi
 	assert.Equal(t, int32(1), providerCalls.Load(), "master-key internal routing must remain available")
 }
 
+func TestAcceptedModelAliasPreservesRestrictedTokenRouting(t *testing.T) {
+	var providerModel string
+	provider := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		providerModel, _ = body["model"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-accepted","object":"chat.completion","created":1,"model":"backend-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer provider.Close()
+
+	db := &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"restricted-key": {
+			Token:  "restricted-hash",
+			Models: []string{"public/chat"},
+		},
+	}}
+	prx := newClientAuthTestProxy(t, db, provider.URL, config.ProviderTypeOpenAI, "provider-key")
+	prx.modelManager.SetClientModelIDs([]string{"public/chat"})
+	prx.modelManager.SetAcceptedModelAliases(map[string]string{"legacy-chat": "public/chat"})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"legacy-chat","messages":[{"role":"user","content":"hello"}]}`,
+	))
+	req.Header.Set("Authorization", "Bearer restricted-key")
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	prx.ProxyRequest(recorder, req)
+
+	require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+	assert.Equal(t, "backend-chat", providerModel)
+}
+
 func TestExplicitClientModelSurfacePreservesRestrictedACLPrecedenceForUnknownModel(t *testing.T) {
 	var providerCalls atomic.Int32
 	provider := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## Summary
- restore `accepted_model_alias` routing
- preserve model ACLs and keep compatibility aliases out of discovery

## Root cause
`accepted_model_alias` remained in config but was no longer registered in `ModelManager`, so valid production model IDs were rejected before upstream routing.

## Checks
- `go test ./...`
- `make lint`
