### PR TITLE
Gate orphan all-team-models ACL

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -253,6 +253,7 @@ func main() {
 		SessionStickyAutoCacheCtrl: cfg.Server.SessionStickyAutoCacheCtrl,
 		SessionStoreTTL:            time.Duration(cfg.Server.SessionStickyTTL) * time.Minute,
 		DrainUpstreamOnAbort:       cfg.Server.DrainUpstreamOnAbort,
+		StrictAllTeamModelsACL:     cfg.Server.StrictAllTeamModelsACL,
 		ResponseHeaderMode:         cfg.Server.ResponseHeaders.Mode,
 
 		BudgetReserver:                   budgetReserver,

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,6 +12,7 @@ server:
   stdout_logs_enabled: true  # Write logs to stdout (default: true); set false to ship logs only via OTEL
   master_key: "sk-your-master-key-here"  # Required: Master key for authentication
   default_models_rpm: -1  # Default RPM limit for models (-1 for unlimited, default: -1)
+  strict_all_team_models_acl: false  # Deny all-team-models keys that have no team
   model_prices_link: ""  # Optional: URL or file path to model prices JSON (supports os.environ/VAR_NAME)
   response_headers:
     mode: passthrough  # Use allowlist to expose only standard response metadata

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -467,7 +467,8 @@ type ServerConfig struct {
 	ModelPricesLink            string                `yaml:"model_prices_link,omitempty"`       // URL or file path to model prices JSON - supports os.environ/VAR_NAME
 	ShutdownDelay              time.Duration         `yaml:"shutdown_delay"`                    // Delay between readiness=false and server.Shutdown (default: 5s)
 	DrainUpstreamOnAbort       bool                  `yaml:"drain_upstream_on_abort"`           // When true, keep reading upstream after client disconnect to capture real usage chunk (default: false — estimate from delta text)
-	ProxyHealthTimeout         time.Duration         `yaml:"proxy_health_timeout"`              // Timeout for fetching /health from remote proxy credentials (default: 15s)
+	StrictAllTeamModelsACL     bool                  `yaml:"strict_all_team_models_acl"`
+	ProxyHealthTimeout         time.Duration         `yaml:"proxy_health_timeout"` // Timeout for fetching /health from remote proxy credentials (default: 15s)
 	ResponseHeaders            ResponseHeadersConfig `yaml:"response_headers"`
 }
 
@@ -549,6 +550,7 @@ func (s *ServerConfig) UnmarshalYAML(value *yaml.Node) error {
 		ModelPricesLink            string                `yaml:"model_prices_link,omitempty"`
 		ShutdownDelay              string                `yaml:"shutdown_delay"`
 		DrainUpstreamOnAbort       string                `yaml:"drain_upstream_on_abort"`
+		StrictAllTeamModelsACL     string                `yaml:"strict_all_team_models_acl"`
 		ProxyHealthTimeout         string                `yaml:"proxy_health_timeout"`
 		ResponseHeaders            ResponseHeadersConfig `yaml:"response_headers"`
 	}
@@ -624,6 +626,9 @@ func (s *ServerConfig) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	if s.DrainUpstreamOnAbort, err = parseField(temp.DrainUpstreamOnAbort, false, strconv.ParseBool, "drain_upstream_on_abort"); err != nil {
+		return err
+	}
+	if s.StrictAllTeamModelsACL, err = parseField(temp.StrictAllTeamModelsACL, false, strconv.ParseBool, "strict_all_team_models_acl"); err != nil {
 		return err
 	}
 	if s.ProxyHealthTimeout, err = parseField(temp.ProxyHealthTimeout, 15*time.Second, time.ParseDuration, "proxy_health_timeout"); err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1401,6 +1401,16 @@ monitoring:
 	assert.Equal(t, 15, cfg.Server.SessionStickyTTL)
 }
 
+func TestServerConfigStrictAllTeamModelsACL(t *testing.T) {
+	var defaults ServerConfig
+	require.NoError(t, yaml.Unmarshal([]byte("{}"), &defaults))
+	assert.False(t, defaults.StrictAllTeamModelsACL)
+
+	var strict ServerConfig
+	require.NoError(t, yaml.Unmarshal([]byte("strict_all_team_models_acl: true"), &strict))
+	assert.True(t, strict.StrictAllTeamModelsACL)
+}
+
 func TestLoad_ModelAlias(t *testing.T) {
 	tmpDir := t.TempDir()
 	configPath := filepath.Join(tmpDir, "config.yaml")

--- a/internal/litellmdb/auth/auth_test.go
+++ b/internal/litellmdb/auth/auth_test.go
@@ -169,11 +169,9 @@ func TestTokenInfo_IsModelAllowed(t *testing.T) {
 		assert.True(t, info.IsModelAllowed("claude-3"))
 	})
 
-	t.Run("all-team-models sentinel with no team - fail closed", func(t *testing.T) {
-		// LiteLLM fails closed when all-team-models is used without a team;
-		// the fail-open behavior from PR #82 is intentionally not carried over.
+	t.Run("all-team-models sentinel with no team - unrestricted", func(t *testing.T) {
 		info := &models.TokenInfo{Models: []string{"all-team-models"}, TeamID: ""}
-		assert.False(t, info.IsModelAllowed("gpt-4"))
+		assert.True(t, info.IsModelAllowed("gpt-4"))
 	})
 
 	t.Run("all-team-models sentinel - resolves against team allow-list", func(t *testing.T) {

--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -236,6 +236,10 @@ type ModelAccessScope struct {
 // directional request-alias expansion without coupling DB models to routing.
 type ModelScopeMatcher func(model string, allowedModels []string) bool
 
+type ModelAccessPolicy struct {
+	StrictAllTeamModelsACL bool
+}
+
 func clonePointer[T any](value *T) *T {
 	if value == nil {
 		return nil
@@ -334,13 +338,17 @@ func (t *TokenInfo) IsBudgetExceeded() bool {
 
 // ModelAccessScopes returns the independently enforced model allowlists.
 func (t *TokenInfo) ModelAccessScopes() []ModelAccessScope {
+	return t.ModelAccessScopesWithPolicy(ModelAccessPolicy{})
+}
+
+func (t *TokenInfo) ModelAccessScopesWithPolicy(policy ModelAccessPolicy) []ModelAccessScope {
 	keyModels := t.Models
 	for _, model := range t.Models {
 		if model == AllTeamModels {
-			// LiteLLM fails closed when all-team-models is used without a team.
-			// With a team it replaces, rather than extends, the key allowlist.
 			if t.TeamID != "" {
 				keyModels = t.TeamModels
+			} else if !policy.StrictAllTeamModelsACL {
+				keyModels = nil
 			}
 			break
 		}
@@ -402,10 +410,18 @@ func modelScopePatternMatches(pattern, model string) bool {
 
 // IsModelAllowedBy checks every applicable model scope with matcher.
 func (t *TokenInfo) IsModelAllowedBy(model string, matcher ModelScopeMatcher) bool {
+	return t.IsModelAllowedByPolicy(model, matcher, ModelAccessPolicy{})
+}
+
+func (t *TokenInfo) IsModelAllowedByPolicy(
+	model string,
+	matcher ModelScopeMatcher,
+	policy ModelAccessPolicy,
+) bool {
 	if matcher == nil {
 		matcher = exactModelScopeMatch
 	}
-	for _, scope := range t.ModelAccessScopes() {
+	for _, scope := range t.ModelAccessScopesWithPolicy(policy) {
 		if scope.DenyAll || !matcher(model, scope.Models) {
 			return false
 		}

--- a/internal/litellmdb/models/models_test.go
+++ b/internal/litellmdb/models/models_test.go
@@ -274,8 +274,13 @@ func TestTokenInfo_IsModelAllowed_AllTeamModelsInheritsTeamScope(t *testing.T) {
 	assert.True(t, token.IsModelAllowed("public/chat"))
 	assert.False(t, token.IsModelAllowed("public/embed"))
 
-	broken := &TokenInfo{Models: []string{AllTeamModels}}
-	assert.False(t, broken.IsModelAllowed("public/chat"), "all-team-models without a team must fail closed")
+	orphan := &TokenInfo{Models: []string{AllTeamModels}}
+	assert.True(t, orphan.IsModelAllowed("public/chat"))
+	assert.False(t, orphan.IsModelAllowedByPolicy(
+		"public/chat",
+		nil,
+		ModelAccessPolicy{StrictAllTeamModelsACL: true},
+	))
 }
 
 // A token whose team_id references a deleted LiteLLM_TeamTable row gets an

--- a/internal/proxy/client_auth_test.go
+++ b/internal/proxy/client_auth_test.go
@@ -619,6 +619,44 @@ func TestInferenceModelACLIntersectsParentScopesBeforeAliasResolution(t *testing
 	assert.Equal(t, 1, upstreamCalls, "a disallowed model must be rejected before provider dispatch")
 }
 
+func TestInferenceAllTeamModelsWithoutTeamPolicy(t *testing.T) {
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-auth","object":"chat.completion","created":1,"model":"backend-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	for _, tt := range []struct {
+		name       string
+		strict     bool
+		wantStatus int
+	}{
+		{name: "compatibility", wantStatus: http.StatusOK},
+		{name: "strict", strict: true, wantStatus: http.StatusForbidden},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			db := &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+				"gateway-key": {
+					Token:  "gateway-hash",
+					Models: []string{dbmodels.AllTeamModels},
+				},
+			}}
+			prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
+			prx.strictAllTeamModelsACL = tt.strict
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+				`{"model":"backend-chat","messages":[{"role":"user","content":"hello"}]}`,
+			))
+			req.Header.Set("Authorization", "Bearer gateway-key")
+			req.Header.Set("Content-Type", "application/json")
+			writer := httptest.NewRecorder()
+
+			prx.ProxyRequest(writer, req)
+
+			assert.Equal(t, tt.wantStatus, writer.Code)
+		})
+	}
+}
+
 func TestInferenceRejectsBlockedParentsAndNoDefaultPersonalUserBeforeProvider(t *testing.T) {
 	var upstreamCalls int
 	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -403,6 +403,19 @@ func (p *Proxy) AuthenticateClientRequestScoped(w http.ResponseWriter, r *http.R
 	return logCtx.TokenInfo, logCtx.Scope, true
 }
 
+func (p *Proxy) IsModelAllowedForToken(tokenInfo *models.TokenInfo, model string) bool {
+	if tokenInfo == nil {
+		return true
+	}
+	var matcher models.ModelScopeMatcher
+	if p.modelManager != nil {
+		matcher = p.modelManager.IsModelIDAllowedByScope
+	}
+	return tokenInfo.IsModelAllowedByPolicy(model, matcher, models.ModelAccessPolicy{
+		StrictAllTeamModelsACL: p.strictAllTeamModelsACL,
+	})
+}
+
 func (p *Proxy) authenticateRequest(
 	w http.ResponseWriter,
 	r *http.Request,
@@ -535,14 +548,7 @@ func (p *Proxy) readRequestBodyAndSelectModel(
 	// LiteLLM -> AIR hop authenticated with AIR's master key, but ordinary keys
 	// cannot discover or invoke them even when their DB model ACL is empty.
 	trustedInternalModelID := p.isMasterKey(logCtx.Token)
-	// Token model scopes contain client-visible model IDs. Enforce the scope
-	// before route-surface lookup or alias rewrites. LiteLLM reports a restricted
-	// key's unknown/disallowed model as an authorization failure; unrestricted
-	// keys continue to the product-surface check and receive a not-found error.
-	modelAllowed := logCtx.TokenInfo == nil || logCtx.TokenInfo.IsModelAllowed(modelID)
-	if logCtx.TokenInfo != nil && p.modelManager != nil {
-		modelAllowed = logCtx.TokenInfo.IsModelAllowedBy(modelID, p.modelManager.IsModelIDAllowedByScope)
-	}
+	modelAllowed := p.IsModelAllowedForToken(logCtx.TokenInfo, modelID)
 	if !modelAllowed {
 		p.logger.WarnContext(r.Context(), "Model is not allowed for token",
 			"error_code", http.StatusForbidden,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -311,6 +311,7 @@ type Config struct {
 	SessionStoreTTL            time.Duration
 	RouterID                   string // Human-readable name for this router (shown in /trace); defaults to hostname
 	DrainUpstreamOnAbort       bool   // When true, keep reading upstream after client disconnect to get real usage (default: false)
+	StrictAllTeamModelsACL     bool
 	ResponseHeaderMode         config.ResponseHeaderMode
 
 	BudgetReserver                   *budget.Reserver      // Atomic Redis budget reservation (nil if Redis disabled — feature is a no-op)
@@ -343,6 +344,7 @@ type Proxy struct {
 	sessionStore                     *SessionStore              // Optional: session-sticky credential routing
 	stickyAutoCacheCtrl              bool                       // Auto-inject Anthropic cache_control when session is active
 	drainUpstreamOnAbort             bool                       // Keep reading upstream after client disconnect to get real usage chunk
+	strictAllTeamModelsACL           bool
 	responseHeaderMode               config.ResponseHeaderMode
 	bedrockDailyQuota                *bedrockDailyQuotaTracker
 	budgetReserver                   *budget.Reserver
@@ -413,6 +415,7 @@ func New(cfg *Config) *Proxy {
 		sessionStore:                     sessionStore,
 		stickyAutoCacheCtrl:              cfg.SessionStickyAutoCacheCtrl,
 		drainUpstreamOnAbort:             cfg.DrainUpstreamOnAbort,
+		strictAllTeamModelsACL:           cfg.StrictAllTeamModelsACL,
 		responseHeaderMode:               cfg.ResponseHeaderMode,
 		bedrockDailyQuota:                newBedrockDailyQuotaTracker(),
 		budgetReserver:                   cfg.BudgetReserver,

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -228,11 +228,7 @@ func (r *Router) handleModels(w http.ResponseWriter, req *http.Request) {
 	if tokenInfo != nil {
 		filtered := make([]models.Model, 0, len(modelsResp.Data))
 		for _, model := range modelsResp.Data {
-			allowed := tokenInfo.IsModelAllowed(model.ID)
-			if r.modelManager != nil {
-				allowed = tokenInfo.IsModelAllowedBy(model.ID, r.modelManager.IsModelIDAllowedByScope)
-			}
-			if allowed {
+			if r.proxy.IsModelAllowedForToken(tokenInfo, model.ID) {
 				filtered = append(filtered, model)
 			}
 		}


### PR DESCRIPTION
Adds `server.strict_all_team_models_acl` (default `false`). Keys with `all-team-models` and no team remain unrestricted unless strict mode is enabled.

Checks: `go test ./...`; changed-code lint: 0 issues. Full `make lint` is blocked by existing SA5011 findings in `internal/converter/converter_test.go`.