### PR TITLE
Gate model ACL checks

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -12,7 +12,7 @@ server:
   stdout_logs_enabled: true  # Write logs to stdout (default: true); set false to ship logs only via OTEL
   master_key: "sk-your-master-key-here"  # Required: Master key for authentication
   default_models_rpm: -1  # Default RPM limit for models (-1 for unlimited, default: -1)
-  strict_all_team_models_acl: false  # Deny all-team-models keys that have no team
+  strict_all_team_models_acl: false  # Enforce key/team/user model ACLs (default: false)
   model_prices_link: ""  # Optional: URL or file path to model prices JSON (supports os.environ/VAR_NAME)
   response_headers:
     mode: passthrough  # Use allowlist to expose only standard response metadata

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -467,8 +467,8 @@ type ServerConfig struct {
 	ModelPricesLink            string                `yaml:"model_prices_link,omitempty"`       // URL or file path to model prices JSON - supports os.environ/VAR_NAME
 	ShutdownDelay              time.Duration         `yaml:"shutdown_delay"`                    // Delay between readiness=false and server.Shutdown (default: 5s)
 	DrainUpstreamOnAbort       bool                  `yaml:"drain_upstream_on_abort"`           // When true, keep reading upstream after client disconnect to capture real usage chunk (default: false — estimate from delta text)
-	StrictAllTeamModelsACL     bool                  `yaml:"strict_all_team_models_acl"`
-	ProxyHealthTimeout         time.Duration         `yaml:"proxy_health_timeout"` // Timeout for fetching /health from remote proxy credentials (default: 15s)
+	StrictAllTeamModelsACL     bool                  `yaml:"strict_all_team_models_acl"`        // Enforce key/team/user model ACLs (default: false)
+	ProxyHealthTimeout         time.Duration         `yaml:"proxy_health_timeout"`              // Timeout for fetching /health from remote proxy credentials (default: 15s)
 	ResponseHeaders            ResponseHeadersConfig `yaml:"response_headers"`
 }
 

--- a/internal/proxy/client_auth_test.go
+++ b/internal/proxy/client_auth_test.go
@@ -360,6 +360,7 @@ func TestExplicitClientModelSurfacePreservesRestrictedACLPrecedenceForUnknownMod
 		},
 	}}
 	prx := newClientAuthTestProxy(t, db, provider.URL, config.ProviderTypeOpenAI, "provider-key")
+	prx.strictAllTeamModelsACL = true
 	prx.modelManager.SetClientModelIDs([]string{"public/chat", "public/embed"})
 
 	request := func(key string) *httptest.ResponseRecorder {
@@ -565,6 +566,7 @@ func TestInferenceModelACLIntersectsParentScopesBeforeAliasResolution(t *testing
 		},
 	}}
 	prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
+	prx.strictAllTeamModelsACL = true
 
 	allowed := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
 		`{"model":"public/chat","messages":[{"role":"user","content":"hello"}]}`,
@@ -619,45 +621,83 @@ func TestInferenceModelACLIntersectsParentScopesBeforeAliasResolution(t *testing
 	assert.Equal(t, 1, upstreamCalls, "a disallowed model must be rejected before provider dispatch")
 }
 
-func TestInferenceAllTeamModelsWithoutTeamPolicy(t *testing.T) {
+func TestInferenceModelACLPolicy(t *testing.T) {
 	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_, _ = w.Write([]byte(`{"id":"chatcmpl-auth","object":"chat.completion","created":1,"model":"backend-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
 	}))
 	defer upstream.Close()
 
-	for _, tt := range []struct {
-		name       string
-		strict     bool
-		wantStatus int
+	for _, tokenCase := range []struct {
+		name string
+		info *dbmodels.TokenInfo
 	}{
-		{name: "compatibility", wantStatus: http.StatusOK},
-		{name: "strict", strict: true, wantStatus: http.StatusForbidden},
+		{
+			name: "all-team-models without team",
+			info: &dbmodels.TokenInfo{Models: []string{dbmodels.AllTeamModels}},
+		},
+		{
+			name: "explicit key model mismatch",
+			info: &dbmodels.TokenInfo{Models: []string{"other-model"}},
+		},
+		{
+			name: "dangling team",
+			info: &dbmodels.TokenInfo{
+				Models:       []string{"backend-chat"},
+				TeamID:       "deleted-team",
+				TeamDangling: true,
+			},
+		},
+		{
+			name: "team model mismatch",
+			info: &dbmodels.TokenInfo{
+				Models:     []string{"backend-chat"},
+				TeamID:     "team",
+				TeamModels: []string{"other-model"},
+			},
+		},
+		{
+			name: "personal user no-default-models",
+			info: &dbmodels.TokenInfo{
+				Models:     []string{"backend-chat"},
+				UserID:     "user",
+				UserModels: []string{dbmodels.NoDefaultModels},
+			},
+		},
 	} {
-		t.Run(tt.name, func(t *testing.T) {
-			db := &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
-				"gateway-key": {
-					Token:  "gateway-hash",
-					Models: []string{dbmodels.AllTeamModels},
-				},
-			}}
-			prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
-			prx.strictAllTeamModelsACL = tt.strict
-			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
-				`{"model":"backend-chat","messages":[{"role":"user","content":"hello"}]}`,
-			))
-			req.Header.Set("Authorization", "Bearer gateway-key")
-			req.Header.Set("Content-Type", "application/json")
-			writer := httptest.NewRecorder()
+		t.Run(tokenCase.name, func(t *testing.T) {
+			for _, policy := range []struct {
+				name       string
+				strict     bool
+				wantStatus int
+			}{
+				{name: "compatibility", wantStatus: http.StatusOK},
+				{name: "strict", strict: true, wantStatus: http.StatusForbidden},
+			} {
+				t.Run(policy.name, func(t *testing.T) {
+					tokenCase.info.Token = "gateway-hash"
+					db := &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+						"gateway-key": tokenCase.info,
+					}}
+					prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
+					prx.strictAllTeamModelsACL = policy.strict
+					req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+						`{"model":"backend-chat","messages":[{"role":"user","content":"hello"}]}`,
+					))
+					req.Header.Set("Authorization", "Bearer gateway-key")
+					req.Header.Set("Content-Type", "application/json")
+					writer := httptest.NewRecorder()
 
-			prx.ProxyRequest(writer, req)
+					prx.ProxyRequest(writer, req)
 
-			assert.Equal(t, tt.wantStatus, writer.Code)
+					assert.Equal(t, policy.wantStatus, writer.Code)
+				})
+			}
 		})
 	}
 }
 
-func TestInferenceRejectsBlockedParentsAndNoDefaultPersonalUserBeforeProvider(t *testing.T) {
+func TestInferenceRejectsBlockedParentBeforeProvider(t *testing.T) {
 	var upstreamCalls int
 	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		upstreamCalls++
@@ -675,29 +715,19 @@ func TestInferenceRejectsBlockedParentsAndNoDefaultPersonalUserBeforeProvider(t 
 			TeamModels:  []string{"public/chat"},
 			TeamBlocked: &blocked,
 		},
-		"no-default-user": {
-			Token:      "no-default-user-hash",
-			Models:     []string{"public/chat"},
-			UserID:     "personal-user",
-			UserModels: []string{dbmodels.NoDefaultModels, "public/chat"},
-		},
 	}}
 	prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
 
-	for _, key := range []string{"blocked-team", "no-default-user"} {
-		t.Run(key, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
-				`{"model":"public/chat","messages":[{"role":"user","content":"hello"}]}`,
-			))
-			req.Header.Set("Authorization", "Bearer "+key)
-			req.Header.Set("Content-Type", "application/json")
-			writer := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"public/chat","messages":[{"role":"user","content":"hello"}]}`,
+	))
+	req.Header.Set("Authorization", "Bearer blocked-team")
+	req.Header.Set("Content-Type", "application/json")
+	writer := httptest.NewRecorder()
 
-			prx.ProxyRequest(writer, req)
+	prx.ProxyRequest(writer, req)
 
-			assertAuthErrorShape(t, writer, http.StatusForbidden)
-		})
-	}
+	assertAuthErrorShape(t, writer, http.StatusForbidden)
 	assert.Equal(t, 0, upstreamCalls)
 }
 
@@ -723,6 +753,7 @@ func TestInferenceModelACLWildcardTreatsOnlyStarAsSyntax(t *testing.T) {
 		},
 	}}
 	prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
+	prx.strictAllTeamModelsACL = true
 
 	request := func(key string) *httptest.ResponseRecorder {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
@@ -742,6 +773,7 @@ func TestInferenceModelACLWildcardTreatsOnlyStarAsSyntax(t *testing.T) {
 
 func TestInferenceModelACLRejectsBeforeRoutingAcrossPublicEndpoints(t *testing.T) {
 	prx := newClientAuthTestProxy(t, nil, "http://example.invalid", config.ProviderTypeOpenAI, "provider-key")
+	prx.strictAllTeamModelsACL = true
 	type requestFixture struct {
 		path        string
 		contentType string

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -404,7 +404,7 @@ func (p *Proxy) AuthenticateClientRequestScoped(w http.ResponseWriter, r *http.R
 }
 
 func (p *Proxy) IsModelAllowedForToken(tokenInfo *models.TokenInfo, model string) bool {
-	if tokenInfo == nil {
+	if tokenInfo == nil || !p.strictAllTeamModelsACL {
 		return true
 	}
 	var matcher models.ModelScopeMatcher
@@ -412,7 +412,7 @@ func (p *Proxy) IsModelAllowedForToken(tokenInfo *models.TokenInfo, model string
 		matcher = p.modelManager.IsModelIDAllowedByScope
 	}
 	return tokenInfo.IsModelAllowedByPolicy(model, matcher, models.ModelAccessPolicy{
-		StrictAllTeamModelsACL: p.strictAllTeamModelsACL,
+		StrictAllTeamModelsACL: true,
 	})
 }
 

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -76,8 +76,11 @@ func newIPv4Server(t *testing.T, handler http.Handler) *httptest.Server {
 	return server
 }
 
-// createTestProxy creates a test proxy instance
 func createTestProxy() *proxy.Proxy {
+	return createTestProxyWithStrictACL(false)
+}
+
+func createTestProxyWithStrictACL(strictAllTeamModelsACL bool) *proxy.Proxy {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	f2b := fail2ban.New(3, 0, []int{401, 403, 500})
 	rl := ratelimit.New()
@@ -96,20 +99,21 @@ func createTestProxy() *proxy.Proxy {
 	tokenManager := auth.NewVertexTokenManager(logger)
 
 	return proxy.New(&proxy.Config{
-		Balancer:            bal,
-		Logger:              logger,
-		MaxBodySizeMB:       10,
-		RequestTimeout:      30 * time.Second,
-		MaxIdleConns:        200,
-		MaxIdleConnsPerHost: 20,
-		IdleConnTimeout:     120 * time.Second,
-		Metrics:             metrics,
-		MasterKey:           "test-master-key",
-		RateLimiter:         rl,
-		TokenManager:        tokenManager,
-		ModelManager:        createTestModelManager(),
-		Version:             "test-version",
-		Commit:              "test-commit",
+		Balancer:               bal,
+		Logger:                 logger,
+		MaxBodySizeMB:          10,
+		RequestTimeout:         30 * time.Second,
+		MaxIdleConns:           200,
+		MaxIdleConnsPerHost:    20,
+		IdleConnTimeout:        120 * time.Second,
+		Metrics:                metrics,
+		MasterKey:              "test-master-key",
+		RateLimiter:            rl,
+		TokenManager:           tokenManager,
+		ModelManager:           createTestModelManager(),
+		Version:                "test-version",
+		Commit:                 "test-commit",
+		StrictAllTeamModelsACL: strictAllTeamModelsACL,
 	})
 }
 
@@ -546,7 +550,7 @@ func TestHandleModels(t *testing.T) {
 	// Models list might be empty if not fetched, which is OK
 }
 
-func TestServeHTTPV1ModelsRequiresAuthAndFiltersPublicCatalog(t *testing.T) {
+func TestServeHTTPV1ModelsAuthAndModelACLPolicy(t *testing.T) {
 	logger := testhelpers.NewTestLogger()
 	modelManager := models.New(logger, 100, []config.ModelRPMConfig{
 		{Name: "z-backend", RPM: 100},
@@ -561,7 +565,7 @@ func TestServeHTTPV1ModelsRequiresAuthAndFiltersPublicCatalog(t *testing.T) {
 	catalogCredentials := []config.CredentialConfig{{Name: "catalog", Type: config.ProviderTypeOpenAI}}
 	modelManager.SetCredentials(catalogCredentials)
 	modelManager.LoadModelsFromConfig(catalogCredentials)
-	prx := createTestProxy()
+	prx := createTestProxyWithStrictACL(true)
 	blocked := true
 	prx.LiteLLMDB = &routerAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
 		"unrestricted-key": {Token: "unrestricted-hash"},
@@ -583,6 +587,12 @@ func TestServeHTTPV1ModelsRequiresAuthAndFiltersPublicCatalog(t *testing.T) {
 			Models:     []string{"openai/a-public"},
 			UserID:     "personal-user",
 			UserModels: []string{dbmodels.NoDefaultModels, "openai/a-public"},
+		},
+		"dangling-team-key": {
+			Token:        "dangling-team-hash",
+			Models:       []string{"openai/a-public"},
+			TeamID:       "deleted-team",
+			TeamDangling: true,
 		},
 		"wildcard-key": {
 			Token:  "wildcard-hash",
@@ -634,6 +644,10 @@ func TestServeHTTPV1ModelsRequiresAuthAndFiltersPublicCatalog(t *testing.T) {
 	require.Equal(t, http.StatusOK, noDefault.Code)
 	assert.Empty(t, modelIDs(t, noDefault))
 
+	danglingTeam := request(map[string]string{"Authorization": "Bearer dangling-team-key"})
+	require.Equal(t, http.StatusOK, danglingTeam.Code)
+	assert.Empty(t, modelIDs(t, danglingTeam))
+
 	wildcard := request(map[string]string{"Authorization": "Bearer wildcard-key"})
 	require.Equal(t, http.StatusOK, wildcard.Code)
 	assert.Equal(t, []string{"openai/a-public"}, modelIDs(t, wildcard),
@@ -670,6 +684,36 @@ func TestServeHTTPV1ModelsRequiresAuthAndFiltersPublicCatalog(t *testing.T) {
 		[]string{"openai/a-public", "openai/z-public"},
 		modelIDs(t, unrestrictedGroups),
 	)
+
+	compatibilityProxy := createTestProxy()
+	compatibilityProxy.LiteLLMDB = prx.LiteLLMDB
+	compatibilityRouter := New(
+		compatibilityProxy,
+		modelManager,
+		testhelpers.NewTestMonitoringConfig("/health", false, ""),
+		logger,
+		nil,
+	)
+	compatibilityRequest := func(key string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+		req.Header.Set("Authorization", "Bearer "+key)
+		w := httptest.NewRecorder()
+		compatibilityRouter.ServeHTTP(w, req)
+		return w
+	}
+	allModels := []string{"openai/a-public", "openai/z-public"}
+	for _, key := range []string{
+		"restricted-key",
+		"no-default-user-key",
+		"dangling-team-key",
+		"wildcard-key",
+		"regex-looking-key",
+	} {
+		response := compatibilityRequest(key)
+		require.Equal(t, http.StatusOK, response.Code)
+		assert.Equal(t, allModels, modelIDs(t, response))
+	}
+	assert.Equal(t, http.StatusForbidden, compatibilityRequest("blocked-team-key").Code)
 }
 
 func TestServeHTTPPublicPreflightDoesNotEnableWildcardCORS(t *testing.T) {


### PR DESCRIPTION
Disables all key/team/user model ACL checks unless strict_all_team_models_acl is true.

Tests: go test ./...
Lint: existing SA5011 in internal/converter/converter_test.go