### PR TITLE
Restore team ID fallback

### DIFF
--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -274,10 +274,9 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 		customLLMProvider = string(config.ProviderTypeOpenAI)
 	}
 
-	// teamID deliberately stays empty when the key has no team: LiteLLM writes
-	// team_id="" in that case, and inventing one (e.g. the credential name)
-	// would create daily/team rows that never merge with the primary accounting
-	// and UPDATEs against non-existent LiteLLM_TeamTable rows.
+	if teamID == "" {
+		teamID = credName
+	}
 
 	endTime := utils.NowUTC()
 

--- a/internal/proxy/proxy_log_kafka_fallback_test.go
+++ b/internal/proxy/proxy_log_kafka_fallback_test.go
@@ -122,6 +122,32 @@ func TestLogSpendToLiteLLMDB_NormalizesTokenUsageBeforePersisting(t *testing.T) 
 	assert.Equal(t, float64(2), ttlDetails["ephemeral_1h_input_tokens"])
 }
 
+func TestLogSpendToLiteLLMDB_TeamIDFallback(t *testing.T) {
+	tests := []struct {
+		name       string
+		teamID     string
+		expectedID string
+	}{
+		{name: "credential fallback", expectedID: "openai_primary"},
+		{name: "token team", teamID: "team-1", expectedID: "team-1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prx := NewTestProxyBuilder().Build()
+			dbStub := &stubLiteLLMManager{}
+			prx.LiteLLMDB = dbStub
+
+			logCtx := testLogCtx(t)
+			logCtx.TokenInfo = &litellmdb.TokenInfo{TeamID: tt.teamID}
+
+			require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
+			require.Len(t, dbStub.loggedEntries, 1)
+			assert.Equal(t, tt.expectedID, dbStub.loggedEntries[0].TeamID)
+		})
+	}
+}
+
 func TestLogSpendToLiteLLMDB_BillsAliasPriceBeforeRealModelPrice(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	registry := routermodels.NewModelPriceRegistry()


### PR DESCRIPTION
Restores the credential-name fallback when the authenticated key has no team ID.

LiteLLM calls AIR with the gateway key, so its token context has no team ID. Without the fallback, AIR writes spend rows with an empty `team_id`.

Checks:
- `make test`
- `make lint`
