### PR TITLE
Add ful grafana

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1069,6 +1069,7 @@ func updateMetrics(
 		cs := credStats[name]
 		metrics.UpdateCredentialRPM(name, cs.RPM)
 		metrics.UpdateCredentialTPM(name, cs.TPM)
+		metrics.UpdateCredentialBanStatus(name, bal.HasAnyBan(name))
 	}
 
 	for _, p := range filteredPairs {

--- a/examples/grafana.json
+++ b/examples/grafana.json
@@ -2564,6 +2564,995 @@
         }
       ],
       "type": "table"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 138 },
+      "id": 900,
+      "panels": [],
+      "title": "Spend Pipeline",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 139 },
+      "id": 901,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_queue_depth{instance=~\"$instance\"})",
+          "legendFormat": "Queue Depth",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Queue Depth",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 139 },
+      "id": 902,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_pending_entries{instance=~\"$instance\"})",
+          "legendFormat": "Pending Entries",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Pending Entries",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 139 },
+      "id": 903,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_pending_aggregation_depth{instance=~\"$instance\"})",
+          "legendFormat": "Pending Aggregation",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Pending Aggregation Depth",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 139 },
+      "id": 904,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_dlq_size{instance=~\"$instance\"})",
+          "legendFormat": "DLQ Size",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend DLQ Size",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 900 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 139 },
+      "id": 905,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(auto_ai_router_spend_aggregation_lag_seconds{instance=~\"$instance\"})",
+          "legendFormat": "Aggregation Lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Aggregation Lag",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "text": "Invalid" },
+                "1": { "color": "green", "text": "Valid" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 139 },
+      "id": 906,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "min(auto_ai_router_spend_comparison_window_valid{instance=~\"$instance\"})",
+          "legendFormat": "Comparison Window",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Comparison Window Valid",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 143 },
+      "id": 907,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_dropped_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Dropped",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_dlq_overflow_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "DLQ Overflow",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_duplicates_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Duplicates",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_collision_unresolved_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Collision Unresolved",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Spend Loss & Duplicate Events",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 143 },
+      "id": 908,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_aggregation_errors_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Aggregation Errors",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_pending_aggregation_overflow_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Pending Aggregation Overflow",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Spend Aggregation Errors & Overflow",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 151 },
+      "id": 909,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (eligibility) (rate(auto_ai_router_spend_comparison_rows_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{eligibility}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Comparison Rows by Eligibility",
+      "type": "timeseries"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 159 },
+      "id": 1000,
+      "panels": [],
+      "title": "Redis & Kafka",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 160 },
+      "id": 1001,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (operation) (rate(auto_ai_router_redis_connection_errors_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Connection Errors by Operation",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 160 },
+      "id": 1002,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_redis_fallback_events_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Fallback Events",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Fallback Events",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 168 },
+      "id": 1003,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_queued_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Queued",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_produced_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Produced",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_dropped_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Dropped",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_errors_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Errors",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Kafka Spend Logger Throughput",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 168 },
+      "id": 1004,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_kafka_spend_logger_dlq_size{instance=~\"$instance\"})",
+          "legendFormat": "DLQ Size",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Spend Logger DLQ Size",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "text": "Unhealthy" },
+                "1": { "color": "green", "text": "Healthy" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 168 },
+      "id": 1005,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "min(auto_ai_router_kafka_spend_logger_healthy{instance=~\"$instance\"})",
+          "legendFormat": "Broker Health",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Spend Logger Broker Health",
+      "type": "stat"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 176 },
+      "id": 1100,
+      "panels": [],
+      "title": "Time to First Token (TTFT)",
+      "type": "row"
+    },
+    {
+      "description": "P50 / P95 / P99 time-to-first-token for streaming responses (request start to first real content delta, not first HTTP byte)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 177 },
+      "id": 1101,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{instance=~\"$instance\",credential=~\"$credential\"}[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{instance=~\"$instance\",credential=~\"$credential\"}[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{instance=~\"$instance\",credential=~\"$credential\"}[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "title": "TTFT Percentiles (Global)",
+      "type": "timeseries"
+    },
+    {
+      "description": "P95 time-to-first-token per endpoint",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 177 },
+      "id": 1102,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{instance=~\"$instance\",credential=~\"$credential\"}[5m])) by (le, endpoint))",
+          "legendFormat": "P95 {{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TTFT P95 by Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "description": "P95 time-to-first-token per credential",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 185 },
+      "id": 1103,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{instance=~\"$instance\",credential=~\"$credential\"}[5m])) by (le, credential))",
+          "legendFormat": "{{credential}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TTFT P95 by Credential",
+      "type": "timeseries"
+    },
+    {
+      "description": "Average time-to-first-token per credential",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 185 },
+      "id": 1104,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (credential) (rate(auto_ai_router_time_to_first_token_seconds_sum{instance=~\"$instance\",credential=~\"$credential\"}[5m])) / sum by (credential) (rate(auto_ai_router_time_to_first_token_seconds_count{instance=~\"$instance\",credential=~\"$credential\"}[5m]))",
+          "legendFormat": "{{credential}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Average TTFT by Credential",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/examples/grafana_k8s.json
+++ b/examples/grafana_k8s.json
@@ -43,7 +43,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 0, "y": 1 },
       "id": 101,
       "options": {
         "colorMode": "value",
@@ -84,7 +84,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 3, "y": 1 },
       "id": 102,
       "options": {
         "colorMode": "value",
@@ -111,6 +111,47 @@
       "fieldConfig": {
         "defaults": {
           "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "#EAB839", "value": 0.02 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 3, "x": 6, "y": 1 },
+      "id": 107,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "((sum(rate(auto_ai_router_aborted_requests_total{service_name=~\"$service\",credential=~\"$credential\",model=~\"$model\"}[5m])) or (0 * sum(rate(auto_ai_router_requests_total{service_name=~\"$service\",credential=~\"$credential\",model=~\"$model\"}[5m])))) / sum(rate(auto_ai_router_requests_total{service_name=~\"$service\",credential=~\"$credential\",model=~\"$model\"}[5m]))) or vector(0)",
+          "legendFormat": "Aborted %",
+          "refId": "A"
+        }
+      ],
+      "title": "Aborted Rate",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -123,7 +164,7 @@
         },
         "overrides": []
       },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 1 },
+      "gridPos": { "h": 4, "w": 3, "x": 9, "y": 1 },
       "id": 103,
       "options": {
         "colorMode": "value",
@@ -589,6 +630,73 @@
         }
       ],
       "title": "Error Rate by Status Code",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "#EAB839", "value": 0.02 },
+              { "color": "red", "value": 0.05 }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
+      "id": 206,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "((sum by (model) (rate(auto_ai_router_aborted_requests_total{service_name=~\"$service\",credential=~\"$credential\",model=~\"$model\"}[5m])) or (0 * sum by (model) (rate(auto_ai_router_requests_total{service_name=~\"$service\",credential=~\"$credential\",model=~\"$model\"}[5m])))) / sum by (model) (rate(auto_ai_router_requests_total{service_name=~\"$service\",credential=~\"$credential\",model=~\"$model\"}[5m])))",
+          "legendFormat": "{{model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Aborted Rate by Model",
       "type": "timeseries"
     },
 
@@ -2456,6 +2564,994 @@
         }
       ],
       "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 138 },
+      "id": 900,
+      "panels": [],
+      "title": "Spend Pipeline",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 139 },
+      "id": 901,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_queue_depth{service_name=~\"$service\"})",
+          "legendFormat": "Queue Depth",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Queue Depth",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 139 },
+      "id": 902,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_pending_entries{service_name=~\"$service\"})",
+          "legendFormat": "Pending Entries",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Pending Entries",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 139 },
+      "id": 903,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_pending_aggregation_depth{service_name=~\"$service\"})",
+          "legendFormat": "Pending Aggregation",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Pending Aggregation Depth",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 139 },
+      "id": 904,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_spend_dlq_size{service_name=~\"$service\"})",
+          "legendFormat": "DLQ Size",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend DLQ Size",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 300 },
+              { "color": "red", "value": 900 }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 139 },
+      "id": 905,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "max(auto_ai_router_spend_aggregation_lag_seconds{service_name=~\"$service\"})",
+          "legendFormat": "Aggregation Lag",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Aggregation Lag",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "text": "Invalid" },
+                "1": { "color": "green", "text": "Valid" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 4, "w": 4, "x": 20, "y": 139 },
+      "id": 906,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "min(auto_ai_router_spend_comparison_window_valid{service_name=~\"$service\"})",
+          "legendFormat": "Comparison Window",
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Comparison Window Valid",
+      "type": "stat"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 143 },
+      "id": 907,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_dropped_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Dropped",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_dlq_overflow_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "DLQ Overflow",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_duplicates_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Duplicates",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_collision_unresolved_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Collision Unresolved",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Spend Loss & Duplicate Events",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 143 },
+      "id": 908,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_aggregation_errors_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Aggregation Errors",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_spend_pending_aggregation_overflow_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Pending Aggregation Overflow",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Spend Aggregation Errors & Overflow",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 151 },
+      "id": 909,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (eligibility) (rate(auto_ai_router_spend_comparison_rows_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "{{eligibility}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Spend Comparison Rows by Eligibility",
+      "type": "timeseries"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 159 },
+      "id": 1000,
+      "panels": [],
+      "title": "Redis & Kafka",
+      "type": "row"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 160 },
+      "id": 1001,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum by (operation) (rate(auto_ai_router_redis_connection_errors_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "{{operation}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Connection Errors by Operation",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 160 },
+      "id": 1002,
+      "options": {
+        "legend": {
+          "calcs": ["sum", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_redis_fallback_events_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Fallback Events",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Redis Fallback Events",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "cps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 168 },
+      "id": 1003,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": true, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_queued_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Queued",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_produced_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Produced",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_dropped_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Dropped",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "editorMode": "code",
+          "expr": "sum(rate(auto_ai_router_kafka_spend_logger_errors_total{service_name=~\"$service\"}[5m]))",
+          "legendFormat": "Errors",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Kafka Spend Logger Throughput",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 25,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 1 },
+              { "color": "red", "value": 10 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 12, "y": 168 },
+      "id": 1004,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(auto_ai_router_kafka_spend_logger_dlq_size{service_name=~\"$service\"})",
+          "legendFormat": "DLQ Size",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Spend Logger DLQ Size",
+      "type": "timeseries"
+    },
+    {
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            {
+              "options": {
+                "0": { "color": "red", "text": "Unhealthy" },
+                "1": { "color": "green", "text": "Healthy" }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 6, "x": 18, "y": 168 },
+      "id": 1005,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "min(auto_ai_router_kafka_spend_logger_healthy{service_name=~\"$service\"})",
+          "legendFormat": "Broker Health",
+          "refId": "A"
+        }
+      ],
+      "title": "Kafka Spend Logger Broker Health",
+      "type": "stat"
+    },
+
+    {
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 176 },
+      "id": 1100,
+      "panels": [],
+      "title": "Time to First Token (TTFT)",
+      "type": "row"
+    },
+    {
+      "description": "P50 / P95 / P99 time-to-first-token for streaming responses (request start to first real content delta, not first HTTP byte)",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 177 },
+      "id": 1101,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.50, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{service_name=~\"$service\",credential=~\"$credential\"}[5m])) by (le))",
+          "legendFormat": "P50",
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{service_name=~\"$service\",credential=~\"$credential\"}[5m])) by (le))",
+          "legendFormat": "P95",
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.99, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{service_name=~\"$service\",credential=~\"$credential\"}[5m])) by (le))",
+          "legendFormat": "P99",
+          "refId": "C"
+        }
+      ],
+      "title": "TTFT Percentiles (Global)",
+      "type": "timeseries"
+    },
+    {
+      "description": "P95 time-to-first-token per endpoint",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 177 },
+      "id": 1102,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{service_name=~\"$service\",credential=~\"$credential\"}[5m])) by (le, endpoint))",
+          "legendFormat": "P95 {{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TTFT P95 by Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "description": "P95 time-to-first-token per credential",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 185 },
+      "id": 1103,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "histogram_quantile(0.95, sum(rate(auto_ai_router_time_to_first_token_seconds_bucket{service_name=~\"$service\",credential=~\"$credential\"}[5m])) by (le, credential))",
+          "legendFormat": "{{credential}}",
+          "refId": "A"
+        }
+      ],
+      "title": "TTFT P95 by Credential",
+      "type": "timeseries"
+    },
+    {
+      "description": "Average time-to-first-token per credential",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{ "color": "green", "value": null }]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 185 },
+      "id": 1104,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
+        },
+        "tooltip": { "hideZeros": false, "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum by (credential) (rate(auto_ai_router_time_to_first_token_seconds_sum{service_name=~\"$service\",credential=~\"$credential\"}[5m])) / sum by (credential) (rate(auto_ai_router_time_to_first_token_seconds_count{service_name=~\"$service\",credential=~\"$credential\"}[5m]))",
+          "legendFormat": "{{credential}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Average TTFT by Credential",
+      "type": "timeseries"
     }
   ],
   "preload": false,

--- a/internal/converter/anthropic/responses/streaming.go
+++ b/internal/converter/anthropic/responses/streaming.go
@@ -2,12 +2,18 @@ package anthropicresponses
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
 	"time"
+
+	// goccy/go-json instead of encoding/json: the only json.* call in this file
+	// is the per-SSE-event AnthropicStreamEvent unmarshal below, run once per
+	// streamed delta — benchmarked ~6x faster than encoding/json on
+	// representative small event payloads (see internal/converter/anthropic's
+	// streaming_bench_test.go, same struct).
+	json "github.com/goccy/go-json"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/anthropic"
 	"github.com/mixaill76/auto_ai_router/internal/converter/responses"

--- a/internal/converter/anthropic/streaming.go
+++ b/internal/converter/anthropic/streaming.go
@@ -2,10 +2,16 @@ package anthropic
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
+
+	// goccy/go-json instead of encoding/json: the only two json.* calls in this
+	// file are the per-SSE-event AnthropicStreamEvent unmarshal and the
+	// per-emitted-chunk OpenAIStreamingChunk marshal — both run once per
+	// streamed delta. Benchmarked ~6x faster (Unmarshal) and ~1.9x faster
+	// (Marshal) than encoding/json on representative small event/chunk payloads.
+	json "github.com/goccy/go-json"
 
 	converterutil "github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/converter/openai"

--- a/internal/converter/anthropic/streaming_bench_test.go
+++ b/internal/converter/anthropic/streaming_bench_test.go
@@ -1,0 +1,76 @@
+package anthropic
+
+import (
+	stdjson "encoding/json"
+	"testing"
+
+	goccyjson "github.com/goccy/go-json"
+
+	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
+)
+
+// Representative per-chunk Anthropic SSE payloads (content_block_delta is by
+// far the highest-frequency event type in a real stream: one per token/word).
+var (
+	anthropicTextDeltaPayload = []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello world, this is a streamed token"}}`)
+
+	anthropicMessageStartPayload = []byte(`{"type":"message_start","message":{"id":"msg_abc123","usage":{"input_tokens":512,"output_tokens":1,"cache_read_input_tokens":0}}}`)
+)
+
+func BenchmarkAnthropicStreamEventUnmarshal_Stdlib(b *testing.B) {
+	b.Run("text-delta", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var event AnthropicStreamEvent
+			_ = stdjson.Unmarshal(anthropicTextDeltaPayload, &event)
+		}
+	})
+	b.Run("message-start", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var event AnthropicStreamEvent
+			_ = stdjson.Unmarshal(anthropicMessageStartPayload, &event)
+		}
+	})
+}
+
+func BenchmarkAnthropicStreamEventUnmarshal_Goccy(b *testing.B) {
+	b.Run("text-delta", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var event AnthropicStreamEvent
+			_ = goccyjson.Unmarshal(anthropicTextDeltaPayload, &event)
+		}
+	})
+	b.Run("message-start", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			var event AnthropicStreamEvent
+			_ = goccyjson.Unmarshal(anthropicMessageStartPayload, &event)
+		}
+	})
+}
+
+// outgoingChunk is representative of what writeChunk (streaming.go) marshals
+// on every emitted delta: a small typed struct, not a large body.
+var outgoingChunk = openai.OpenAIStreamingChunk{
+	ID:      "chatcmpl-abc123",
+	Object:  "chat.completion.chunk",
+	Created: 1730000000,
+	Model:   "claude-opus-4",
+	Choices: []openai.OpenAIStreamingChoice{
+		{Index: 0, Delta: openai.OpenAIStreamingDelta{Content: "hello world, this is a streamed token"}},
+	},
+}
+
+func BenchmarkWriteChunkMarshal_Stdlib(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stdjson.Marshal(outgoingChunk)
+	}
+}
+
+func BenchmarkWriteChunkMarshal_Goccy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = goccyjson.Marshal(outgoingChunk)
+	}
+}

--- a/internal/converter/eventstream.go
+++ b/internal/converter/eventstream.go
@@ -3,9 +3,14 @@ package converter
 import (
 	"encoding/base64"
 	"encoding/binary"
-	"encoding/json"
 	"fmt"
 	"io"
+
+	// goccy/go-json instead of encoding/json: the only json.* call in this file
+	// runs once per AWS Event Stream frame (i.e. once per Bedrock streaming
+	// chunk) — benchmarked ~5.8x faster than encoding/json even for this
+	// single-field envelope struct.
+	json "github.com/goccy/go-json"
 )
 
 // DecodeEventStreamToSSE reads an AWS Event Stream binary-framed stream and

--- a/internal/converter/eventstream_bench_test.go
+++ b/internal/converter/eventstream_bench_test.go
@@ -1,0 +1,37 @@
+package converter
+
+import (
+	"encoding/base64"
+	stdjson "encoding/json"
+	"testing"
+
+	goccyjson "github.com/goccy/go-json"
+)
+
+// eventStreamPayload mirrors DecodeEventStreamToSSE's expected shape: a JSON
+// envelope whose only meaningful field is a base64 blob of the actual
+// Anthropic event (a typical content_block_delta, per the same shape used in
+// internal/converter/anthropic's benchmarks).
+var eventStreamPayload = func() []byte {
+	inner := []byte(`{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"hello world, this is a streamed token"}}`)
+	encoded := base64.StdEncoding.EncodeToString(inner)
+	return []byte(`{"bytes":"` + encoded + `","p":"AAAAAAAAAAAAAAAAAAAAAAAAAA=="}`)
+}()
+
+func BenchmarkEventStreamEnvelopeUnmarshal_Stdlib(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var envelope struct {
+			Bytes string `json:"bytes"`
+		}
+		_ = stdjson.Unmarshal(eventStreamPayload, &envelope)
+	}
+}
+
+func BenchmarkEventStreamEnvelopeUnmarshal_Goccy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var envelope struct {
+			Bytes string `json:"bytes"`
+		}
+		_ = goccyjson.Unmarshal(eventStreamPayload, &envelope)
+	}
+}

--- a/internal/converter/responses/streaming.go
+++ b/internal/converter/responses/streaming.go
@@ -2,11 +2,16 @@ package responses
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
+
+	// goccy/go-json instead of encoding/json: both json.* calls in this file run
+	// once per streamed chunk/event — chatStreamChunk unmarshal (benchmarked
+	// ~5.2x faster) and the outgoing SSE event map[string]interface{} marshal
+	// (~1.5x faster) in writeSSEWithSeq.
+	json "github.com/goccy/go-json"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 )

--- a/internal/converter/responses/streaming_bench_test.go
+++ b/internal/converter/responses/streaming_bench_test.go
@@ -1,0 +1,50 @@
+package responses
+
+import (
+	stdjson "encoding/json"
+	"testing"
+
+	goccyjson "github.com/goccy/go-json"
+)
+
+var chatStreamChunkPayload = []byte(`{"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1730000000,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"hello world, this is a streamed token"},"finish_reason":null}]}`)
+
+func BenchmarkChatStreamChunkUnmarshal_Stdlib(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var chunk chatStreamChunk
+		_ = stdjson.Unmarshal(chatStreamChunkPayload, &chunk)
+	}
+}
+
+func BenchmarkChatStreamChunkUnmarshal_Goccy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var chunk chatStreamChunk
+		_ = goccyjson.Unmarshal(chatStreamChunkPayload, &chunk)
+	}
+}
+
+// writeSSEDataSample is representative of what writeSSEWithSeq marshals on
+// every emitted Responses API SSE event: a dynamic map[string]interface{},
+// not a typed struct.
+func writeSSEDataSample() map[string]interface{} {
+	return map[string]interface{}{
+		"type":            "response.output_text.delta",
+		"item_id":         "item_abc123",
+		"output_index":    0,
+		"content_index":   0,
+		"delta":           "hello world, this is a streamed token",
+		"sequence_number": 42,
+	}
+}
+
+func BenchmarkWriteSSEMarshal_Stdlib(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = stdjson.Marshal(writeSSEDataSample())
+	}
+}
+
+func BenchmarkWriteSSEMarshal_Goccy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = goccyjson.Marshal(writeSSEDataSample())
+	}
+}

--- a/internal/converter/vertex/responses/streaming.go
+++ b/internal/converter/vertex/responses/streaming.go
@@ -3,13 +3,19 @@ package vertexresponses
 import (
 	"bufio"
 	"encoding/base64"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"sort"
 	"strings"
 	"time"
+
+	// goccy/go-json instead of encoding/json: both json.* calls in this file run
+	// once per streamed chunk (VertexStreamingChunk unmarshal — same type
+	// benchmarked ~3.5x faster in internal/converter/vertex's
+	// streaming_bench_test.go, plus a round-trip correctness check — and a
+	// function-call-args marshal).
+	json "github.com/goccy/go-json"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/responses"
 	"github.com/mixaill76/auto_ai_router/internal/converter/vertex"

--- a/internal/converter/vertex/streaming.go
+++ b/internal/converter/vertex/streaming.go
@@ -2,11 +2,20 @@ package vertex
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"strings"
+
+	// goccy/go-json instead of encoding/json: every json.* call in this file is
+	// on the per-SSE-chunk hot path (VertexStreamingChunk unmarshal, outgoing
+	// OpenAIStreamingChunk marshal, function-call-args marshal). Benchmarked
+	// ~3.5x faster decoding VertexStreamingChunk (which wraps genai.Candidate
+	// et al.) than encoding/json; a round-trip test
+	// (TestVertexStreamingChunkUnmarshal_GoccyMatchesStdlib) confirms identical
+	// decode results, including genai's []byte/base64 fields like
+	// ThoughtSignature.
+	json "github.com/goccy/go-json"
 
 	converterutil "github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/converter/openai"

--- a/internal/converter/vertex/streaming_bench_test.go
+++ b/internal/converter/vertex/streaming_bench_test.go
@@ -1,0 +1,69 @@
+package vertex
+
+import (
+	stdjson "encoding/json"
+	"reflect"
+	"testing"
+
+	goccyjson "github.com/goccy/go-json"
+)
+
+// vertexStreamingChunkPayload exercises the fields most likely to trip up a
+// JSON engine swap for VertexStreamingChunk: usage metadata, grounding
+// metadata, a function call, and a []byte field (ThoughtSignature — encoded/
+// decoded as base64 by both encoding/json and a spec-compliant alternative).
+var vertexStreamingChunkPayload = []byte(`{
+	"candidates": [{
+		"content": {
+			"role": "model",
+			"parts": [
+				{"text": "hello world, this is a streamed token"},
+				{"thought": true, "thoughtSignature": "aGVsbG8gd29ybGQ="},
+				{"functionCall": {"name": "get_weather", "args": {"city": "Paris"}}}
+			]
+		},
+		"finishReason": "STOP",
+		"groundingMetadata": {
+			"webSearchQueries": ["query one", "query two"]
+		}
+	}],
+	"usageMetadata": {
+		"promptTokenCount": 512,
+		"candidatesTokenCount": 16,
+		"totalTokenCount": 528,
+		"thoughtsTokenCount": 4
+	}
+}`)
+
+// TestVertexStreamingChunkUnmarshal_GoccyMatchesStdlib guards against a
+// goccy swap silently changing decode results for VertexStreamingChunk, which
+// wraps large nested types from the external google.golang.org/genai SDK
+// (some with custom UnmarshalJSON, e.g. ThoughtSignature's []byte/base64
+// handling) — higher risk than this session's other goccy swaps, which were
+// all on structs owned by this repo.
+func TestVertexStreamingChunkUnmarshal_GoccyMatchesStdlib(t *testing.T) {
+	var stdChunk, goccyChunk VertexStreamingChunk
+	if err := stdjson.Unmarshal(vertexStreamingChunkPayload, &stdChunk); err != nil {
+		t.Fatalf("stdlib unmarshal failed: %v", err)
+	}
+	if err := goccyjson.Unmarshal(vertexStreamingChunkPayload, &goccyChunk); err != nil {
+		t.Fatalf("goccy unmarshal failed: %v", err)
+	}
+	if !reflect.DeepEqual(stdChunk, goccyChunk) {
+		t.Fatalf("goccy decode diverges from stdlib decode:\nstdlib: %#v\ngoccy:  %#v", stdChunk, goccyChunk)
+	}
+}
+
+func BenchmarkVertexStreamingChunkUnmarshal_Stdlib(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var chunk VertexStreamingChunk
+		_ = stdjson.Unmarshal(vertexStreamingChunkPayload, &chunk)
+	}
+}
+
+func BenchmarkVertexStreamingChunkUnmarshal_Goccy(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		var chunk VertexStreamingChunk
+		_ = goccyjson.Unmarshal(vertexStreamingChunkPayload, &chunk)
+	}
+}

--- a/internal/monitoring/metrics.go
+++ b/internal/monitoring/metrics.go
@@ -2,6 +2,7 @@ package monitoring
 
 import (
 	"strconv"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -10,6 +11,18 @@ import (
 )
 
 var spendAggregationOldestUnixNano atomic.Int64
+
+// spendSnapshotMu serializes ObserveSpendSnapshot. It is called from many
+// goroutines (spend writer, aggregator, DLQ retry, and the Stats() path used
+// by health checks — see call sites of publishSnapshot()/Stats() in
+// internal/litellmdb/spendlog). Each individual gauge Set()/atomic Store() is
+// already thread-safe in isolation, but without this lock two concurrent
+// snapshots could interleave field-by-field (e.g. QueueDepth from a newer
+// snapshot combined with PendingAggregation from an older, differently-timed
+// one still in flight), producing a gauge combination that never actually
+// existed together. The lock makes each snapshot apply as one atomic unit;
+// it's cheap (one Observe-sized call per spend event, not per request).
+var spendSnapshotMu sync.Mutex
 
 var (
 	RequestsTotal = promauto.NewCounterVec(
@@ -22,9 +35,33 @@ var (
 
 	RequestDuration = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name:    "auto_ai_router_requests_duration_seconds",
-			Help:    "Request duration in seconds",
-			Buckets: []float64{1, 10, 30, 60, 120, 240, 600},
+			Name: "auto_ai_router_requests_duration_seconds",
+			Help: "Request duration in seconds",
+			// Fine-grained where real traffic lives (real p50/p95 for this router is
+			// ~1-3s, confirmed via sum(...)/count(...)), coarser in the long tail.
+			// The previous {1, 10, 30, ...} buckets had no bucket between 1s and 10s,
+			// so histogram_quantile linearly interpolated across that whole 9s span
+			// and reported a P95 artifact near 10s even though every sample in that
+			// bucket was actually 1-2.5s. See docs/monitoring/prometheus.md.
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10, 15, 20, 30, 60, 120, 240, 600},
+		},
+		[]string{"credential", "endpoint"},
+	)
+
+	// TimeToFirstTokenSeconds measures true TTFT for streaming responses: time
+	// from request start to the first real content/tool/reasoning delta
+	// (RequestLogContext.CompletionStartTime), not just the first HTTP byte/chunk
+	// (a ping/role-only SSE event or empty keep-alive frame can arrive well before
+	// any real content and would understate provider think-time if used instead).
+	// Only observed for requests that actually streamed a content delta — requests
+	// that errored before any delta, or weren't streaming at all, don't emit a
+	// sample here, so this histogram's _count is its own "streamed successfully
+	// past first token" denominator.
+	TimeToFirstTokenSeconds = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "auto_ai_router_time_to_first_token_seconds",
+			Help:    "Time to first token (TTFT) for streaming responses, from request start to the first real content delta",
+			Buckets: []float64{0.05, 0.1, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3, 4, 5, 7.5, 10, 15, 20, 30, 60},
 		},
 		[]string{"credential", "endpoint"},
 	)
@@ -317,6 +354,9 @@ type SpendSnapshot struct {
 }
 
 func ObserveSpendSnapshot(snapshot SpendSnapshot) {
+	spendSnapshotMu.Lock()
+	defer spendSnapshotMu.Unlock()
+
 	SpendQueueDepth.Set(float64(snapshot.QueueDepth))
 	SpendPendingEntries.Set(float64(snapshot.PendingEntries))
 	SpendPendingAggregationDepth.Set(float64(snapshot.PendingAggregation))
@@ -404,6 +444,15 @@ func (m *Metrics) updateModelMetric(gauge *prometheus.GaugeVec, credential, mode
 	gauge.WithLabelValues(credential, model).Set(float64(value))
 }
 
+// RecordRequest records one client-facing request outcome: genuine end-to-end
+// duration (from the moment the client's request arrived, across every retry
+// attempt) and the final status/credential that was actually returned to the
+// client. Call this exactly ONCE per client request, at the point the final
+// response (success or exhausted-retries) is decided — never once per
+// upstream attempt, or retries will inflate RequestsTotal and mislabel
+// RequestDuration with cumulative-since-first-attempt time under the
+// attempt's own (unrelated) credential/status. For per-attempt/per-credential
+// error visibility, use RecordCredentialAttemptError instead.
 func (m *Metrics) RecordRequest(credential, endpoint, model string, statusCode int, duration time.Duration) {
 	if !m.isEnabled() {
 		return
@@ -412,10 +461,32 @@ func (m *Metrics) RecordRequest(credential, endpoint, model string, statusCode i
 	status := strconv.Itoa(statusCode)
 	RequestsTotal.WithLabelValues(credential, model, endpoint, status).Inc()
 	RequestDuration.WithLabelValues(credential, endpoint).Observe(duration.Seconds())
+}
 
-	if statusCode != 200 {
-		CredentialErrorsTotal.WithLabelValues(credential).Inc()
+// RecordTTFT records time-to-first-token for a streaming request that
+// produced at least one real content/tool/reasoning delta. Call once per
+// stream, at the point the stream finishes (success or mid-stream failure
+// after content had already started) — ttft is the duration from request
+// start to that first delta, not to the first HTTP byte.
+func (m *Metrics) RecordTTFT(credential, endpoint string, ttft time.Duration) {
+	if !m.isEnabled() {
+		return
 	}
+	TimeToFirstTokenSeconds.WithLabelValues(credential, endpoint).Observe(ttft.Seconds())
+}
+
+// RecordCredentialAttemptError records that a single upstream attempt against
+// this credential failed (transport error or non-200 response), regardless of
+// whether the overall client request eventually succeeded via a different
+// credential/retry. Intended to be called once per failing attempt inside a
+// retry loop, so credential health stays visible even when retries mask the
+// failure from the client's perspective (see auto_ai_router_credential_errors_total
+// panels in examples/grafana.json / grafana_k8s.json).
+func (m *Metrics) RecordCredentialAttemptError(credential string) {
+	if !m.isEnabled() {
+		return
+	}
+	CredentialErrorsTotal.WithLabelValues(credential).Inc()
 }
 
 func (m *Metrics) RecordAbortedRequest(credential, endpoint, model string) {

--- a/internal/monitoring/metrics_test.go
+++ b/internal/monitoring/metrics_test.go
@@ -23,7 +23,6 @@ func TestRecordRequest_Enabled(t *testing.T) {
 	// Reset metrics before test
 	RequestsTotal.Reset()
 	RequestDuration.Reset()
-	CredentialErrorsTotal.Reset()
 
 	m := New(true)
 
@@ -34,12 +33,52 @@ func TestRecordRequest_Enabled(t *testing.T) {
 	count := testutil.CollectAndCount(RequestsTotal)
 	assert.Greater(t, count, 0)
 
-	// Record an error request
+	// Record an error request (RecordRequest itself is client-facing-only and no
+	// longer touches CredentialErrorsTotal — see TestRecordCredentialAttemptError)
 	m.RecordRequest("cred1", "/v1/chat/completions", "test-model", 500, 150*time.Millisecond)
 
-	// Verify CredentialErrorsTotal metric was incremented
-	count = testutil.CollectAndCount(CredentialErrorsTotal)
+	count = testutil.CollectAndCount(RequestDuration)
 	assert.Greater(t, count, 0)
+}
+
+func TestRecordTTFT_Enabled(t *testing.T) {
+	TimeToFirstTokenSeconds.Reset()
+
+	m := New(true)
+	m.RecordTTFT("cred1", "/v1/chat/completions", 250*time.Millisecond)
+
+	count := testutil.CollectAndCount(TimeToFirstTokenSeconds)
+	assert.Greater(t, count, 0)
+}
+
+func TestRecordTTFT_Disabled(t *testing.T) {
+	TimeToFirstTokenSeconds.Reset()
+
+	m := New(false)
+	m.RecordTTFT("cred1", "/v1/chat/completions", 250*time.Millisecond)
+
+	assert.Equal(t, 0, testutil.CollectAndCount(TimeToFirstTokenSeconds))
+}
+
+func TestRecordCredentialAttemptError_Enabled(t *testing.T) {
+	CredentialErrorsTotal.Reset()
+
+	m := New(true)
+
+	initialErrors := testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1"))
+	m.RecordCredentialAttemptError("cred1")
+	finalErrors := testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1"))
+
+	assert.Greater(t, finalErrors, initialErrors)
+}
+
+func TestRecordCredentialAttemptError_Disabled(t *testing.T) {
+	CredentialErrorsTotal.Reset()
+
+	m := New(false)
+	m.RecordCredentialAttemptError("cred1")
+
+	assert.Equal(t, 0.0, testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1")))
 }
 
 func TestRecordRequest_Disabled(t *testing.T) {
@@ -171,6 +210,11 @@ func TestMetrics_Integration(t *testing.T) {
 	m.RecordRequest("cred2", "/v1/embeddings", "test-model", 200, 80*time.Millisecond)
 	m.RecordRequest("cred2", "/v1/embeddings", "test-model", 429, 90*time.Millisecond) // Rate limit error
 
+	// Per-attempt credential error tracking is a distinct call from RecordRequest
+	// (see the retry-loop call sites in internal/proxy/proxy.go), simulated here.
+	m.RecordCredentialAttemptError("cred1")
+	m.RecordCredentialAttemptError("cred2")
+
 	// Update RPM metrics
 	m.UpdateCredentialRPM("cred1", 3)
 	m.UpdateCredentialRPM("cred2", 2)
@@ -202,19 +246,16 @@ func TestMetrics_PrometheusRegistration(t *testing.T) {
 	}
 }
 
-func TestRecordRequest_ErrorIncrementsCounter(t *testing.T) {
+func TestRecordCredentialAttemptError_IncrementsCounter(t *testing.T) {
 	CredentialErrorsTotal.Reset()
 
 	m := New(true)
 
-	// Record successful request (200)
-	m.RecordRequest("cred1", "/v1/test", "test-model", 200, 50*time.Millisecond)
-
 	// Get initial error count (should be 0)
 	initialErrors := testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1"))
 
-	// Record error request
-	m.RecordRequest("cred1", "/v1/test", "test-model", 500, 50*time.Millisecond)
+	// Record a failed attempt against the credential
+	m.RecordCredentialAttemptError("cred1")
 
 	// Error count should increase
 	finalErrors := testutil.ToFloat64(CredentialErrorsTotal.WithLabelValues("cred1"))

--- a/internal/proxy/chat_response_compat.go
+++ b/internal/proxy/chat_response_compat.go
@@ -3,17 +3,18 @@ package proxy
 import (
 	"bufio"
 	"bytes"
-	"encoding/json"
 	"errors"
 	"io"
 
-	// Aliased separately (not a blanket replacement of this file's json import)
-	// because only normalizeSuccessfulResponseModel below benefits: it
-	// full-body-decodes+remarshals every non-streaming response, and
-	// benchmarked against a real embedding body (1536-float vector) goccy is
-	// ~1.66x faster there. normalizeSSEDataLineModel/decodeJSONObject further
-	// down operate on small per-SSE-chunk payloads, not large arrays, so
-	// there's no measured case for touching them too.
+	// goccy/go-json for every JSON call in this file: normalizeSuccessfulResponseModel
+	// full-body-decodes+remarshals every non-streaming response (benchmarked
+	// ~1.66x faster than encoding/json against a real embedding body, 1536-float
+	// vector). normalizeSSEDataLineModel/decodeJSONObject were originally left on
+	// stdlib on the assumption that small per-SSE-chunk map[string]interface{}
+	// decodes wouldn't show the same win — re-benchmarked after the
+	// token_estimator.go streaming fixes proved that assumption wrong even for
+	// tiny typed-struct payloads; goccy measured ~1.5x faster here too
+	// (map[string]interface{} decode+encode, not just typed structs).
 	goccyjson "github.com/goccy/go-json"
 )
 
@@ -211,7 +212,7 @@ func normalizeSSEDataLineModel(line []byte, publicModel string) []byte {
 		return line
 	}
 
-	normalized, err := json.Marshal(event)
+	normalized, err := goccyjson.Marshal(event)
 	if err != nil {
 		return line
 	}
@@ -225,7 +226,7 @@ func normalizeSSEDataLineModel(line []byte, publicModel string) []byte {
 }
 
 func decodeJSONObject(data []byte) (map[string]interface{}, error) {
-	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder := goccyjson.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
 	var object map[string]interface{}
 	if err := decoder.Decode(&object); err != nil {

--- a/internal/proxy/chat_response_compat_bench_test.go
+++ b/internal/proxy/chat_response_compat_bench_test.go
@@ -1,0 +1,129 @@
+package proxy
+
+import (
+	"bytes"
+	stdjson "encoding/json"
+	"errors"
+	"io"
+	"testing"
+)
+
+// decodeJSONObjectStdlib mirrors decodeJSONObject (chat_response_compat.go,
+// now on goccy) exactly, on stdlib json, kept only to isolate the engine
+// swap's own effect in the benchmarks below.
+func decodeJSONObjectStdlib(data []byte) (map[string]interface{}, error) {
+	decoder := stdjson.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	var object map[string]interface{}
+	if err := decoder.Decode(&object); err != nil {
+		return nil, err
+	}
+	var trailing interface{}
+	if err := decoder.Decode(&trailing); !errors.Is(err, io.EOF) {
+		if err == nil {
+			return nil, errors.New("multiple JSON values")
+		}
+		return nil, err
+	}
+	return object, nil
+}
+
+// normalizeSSEDataLineModelStdlib mirrors normalizeSSEDataLineModel exactly,
+// using decodeJSONObjectStdlib + stdjson.Marshal instead of goccy.
+func normalizeSSEDataLineModelStdlib(line []byte, publicModel string) []byte {
+	newline := []byte(nil)
+	body := line
+	switch {
+	case bytes.HasSuffix(body, []byte("\r\n")):
+		newline = []byte("\r\n")
+		body = body[:len(body)-2]
+	case bytes.HasSuffix(body, []byte("\n")):
+		newline = []byte("\n")
+		body = body[:len(body)-1]
+	}
+	if !bytes.HasPrefix(body, []byte("data:")) {
+		return line
+	}
+	rest := body[len("data:"):]
+	payload := bytes.TrimSpace(rest)
+	if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
+		return line
+	}
+	event, err := decodeJSONObjectStdlib(payload)
+	if err != nil || event == nil {
+		return line
+	}
+	rawError, hasError := event["error"]
+	eventType, _ := event["type"].(string)
+	if isStreamErrorEvent(eventType, hasError && rawError != nil) {
+		return line
+	}
+	changed := false
+	if current, exists := event["model"]; exists {
+		if current != publicModel {
+			event["model"] = publicModel
+			changed = true
+		}
+	} else if object, _ := event["object"].(string); object == "chat.completion.chunk" || object == "text_completion" {
+		event["model"] = publicModel
+		changed = true
+	}
+	if response, ok := event["response"].(map[string]interface{}); ok {
+		if response["model"] != publicModel {
+			response["model"] = publicModel
+			changed = true
+		}
+	}
+	if !changed {
+		return line
+	}
+	normalized, err := stdjson.Marshal(event)
+	if err != nil {
+		return line
+	}
+	prefixLen := len(rest) - len(bytes.TrimLeft(rest, " \t"))
+	result := make([]byte, 0, len(body)+len(newline))
+	result = append(result, []byte("data:")...)
+	result = append(result, rest[:prefixLen]...)
+	result = append(result, normalized...)
+	result = append(result, newline...)
+	return result
+}
+
+var (
+	chatChunkSSELine = []byte(`data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1730000000,"model":"backend-internal","choices":[{"index":0,"delta":{"content":"hello world"},"finish_reason":null}]}` + "\n")
+
+	responsesEventSSELine = []byte(`data: {"type":"response.output_text.delta","item_id":"item_abc123","output_index":0,"content_index":0,"delta":"hello world","response":{"model":"backend-internal"}}` + "\n")
+)
+
+func BenchmarkNormalizeSSEDataLineModel_Stdlib(b *testing.B) {
+	b.Run("chat-chunk", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			normalizeSSEDataLineModelStdlib(chatChunkSSELine, "public-model")
+		}
+	})
+	b.Run("responses-event", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			normalizeSSEDataLineModelStdlib(responsesEventSSELine, "public-model")
+		}
+	})
+}
+
+// BenchmarkNormalizeSSEDataLineModel_Goccy exercises the actual production
+// function (chat_response_compat.go), now on goccy.
+func BenchmarkNormalizeSSEDataLineModel_Goccy(b *testing.B) {
+	b.Run("chat-chunk", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			normalizeSSEDataLineModel(chatChunkSSELine, "public-model")
+		}
+	})
+	b.Run("responses-event", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			normalizeSSEDataLineModel(responsesEventSSELine, "public-model")
+		}
+	})
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -661,6 +661,14 @@ func (p *Proxy) executeProxyRequest(
 	if err != nil {
 		p.logger.WarnContext(r.Context(), "Failed to read proxy response body, caller may retry",
 			"credential", cred.Name, "model", modelID, "error", err)
+		// This attempt genuinely failed (got a response, then lost the body).
+		// Only record here if the StatusOK check above didn't already count it —
+		// status 200 with a failed body read is exactly the case that check
+		// can't see; guarding on StatusOK keeps this to exactly one record per
+		// failed attempt either way.
+		if resp.StatusCode == http.StatusOK {
+			p.metrics.RecordCredentialAttemptError(cred.Name)
+		}
 		return nil, err
 	}
 
@@ -836,6 +844,14 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		logCtx.Credential = cred
 		triedCreds := GetTried(r.Context())
 		var proxyResp *ProxyResponse
+		// respCred is the credential that actually produced proxyResp. It can
+		// lag behind `cred`: e.g. attempt A returns a retryable error (proxyResp
+		// set, cred==A), attempt B (cred reassigned to B) then fails with a
+		// transport error — proxyResp is left untouched from A while `cred` has
+		// already moved to B. Restored onto `cred`/logCtx.Credential below,
+		// right before proxyResp is used, so metrics/headers/logging attribute
+		// the response to the credential that actually produced it.
+		var respCred *config.CredentialConfig
 		var lastProxyErr error
 		var shouldRetry bool
 		var retryReason RetryReason
@@ -868,6 +884,7 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			proxyResp = resp
+			respCred = cred
 			if proxyResp.ActualCredentialName != "" {
 				logCtx.ActualCredentialName = proxyResp.ActualCredentialName
 			}
@@ -953,6 +970,14 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 				WriteErrorBadGateway(w, statusMessage)
 			}
 			return
+		}
+
+		// proxyResp may have been left over from an earlier attempt whose
+		// credential no longer matches `cred` (see respCred's doc comment
+		// above) — realign before attributing anything to a credential.
+		if respCred != nil && respCred != cred {
+			cred = respCred
+			logCtx.Credential = cred
 		}
 
 		// Client-facing outcome decided (this response — success or the last
@@ -1517,6 +1542,14 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		if readErr != nil {
 			closeBody()
 			p.balancer.RecordResponse(cred.Name, modelID, resp.StatusCode)
+			// This attempt genuinely failed (got a response, then lost the body).
+			// Only record here if the earlier `resp.StatusCode != http.StatusOK`
+			// check didn't already count it — status 200 with a failed body read
+			// is exactly the case that check can't see; guarding on StatusOK here
+			// keeps this to exactly one record per failed attempt either way.
+			if resp.StatusCode == http.StatusOK {
+				p.metrics.RecordCredentialAttemptError(cred.Name)
+			}
 			if errors.Is(readErr, ErrResponseBodyTooLarge) {
 				// Response too large — fatal, another credential won't help
 				p.logUpstreamError(r.Context(), "Failed to read response body: too large", http.StatusBadGateway, cred, modelID, nil,
@@ -1527,6 +1560,9 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 				logCtx.HTTPStatus = http.StatusBadGateway
 				logCtx.ErrorMsg = fmt.Sprintf("Failed to read response body: %v", readErr)
 				logCtx.TargetURL = targetURL
+				// Client-facing outcome decided (502 written to the client below,
+				// no further attempts) — record exactly once here.
+				p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, http.StatusBadGateway, time.Since(start))
 				WriteErrorBadGateway(w, "upstream response too large")
 				return
 			}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -611,14 +611,19 @@ func (p *Proxy) executeProxyRequest(
 		if !cred.IsProxyLike() {
 			p.balancer.RecordResponse(cred.Name, modelID, statusCode)
 		}
-		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, statusCode, time.Since(start))
+		// Per-attempt failure — tracked separately from the client-facing
+		// RequestsTotal/RequestDuration metrics, which the caller records exactly
+		// once per client request at the final outcome (see ProxyRequest/TryFallbackProxy).
+		p.metrics.RecordCredentialAttemptError(cred.Name)
 		return nil, err
 	}
 	// Proxy/AIR credentials are dynamic relays — don't record them in fail2ban.
 	if !cred.IsProxyLike() {
 		p.balancer.RecordResponse(cred.Name, modelID, resp.StatusCode)
 	}
-	p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
+	if resp.StatusCode != http.StatusOK {
+		p.metrics.RecordCredentialAttemptError(cred.Name)
+	}
 
 	p.logger.DebugContext(r.Context(), "Proxy request forwarded",
 		"credential", cred.Name,
@@ -939,6 +944,9 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			logCtx.HTTPStatus = statusCode
 			logCtx.ErrorMsg = errorMsg
 			logCtx.TargetURL = cred.BaseURL
+			// Client-facing outcome decided (all attempts exhausted, no response at
+			// all) — record exactly once here with genuine end-to-end duration.
+			p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, statusCode, time.Since(start))
 			if statusCode == http.StatusRequestTimeout {
 				WriteErrorTimeout(w, statusMessage)
 			} else {
@@ -946,6 +954,12 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 			return
 		}
+
+		// Client-facing outcome decided (this response — success or the last
+		// retryable error with no more attempts left — is what gets written to
+		// the client below) — record exactly once here with genuine end-to-end
+		// duration, not once per retry attempt.
+		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, proxyResp.StatusCode, time.Since(start))
 
 		// Write response (streaming or non-streaming)
 		tokenUsageOptions := tokenUsageExtractionOptionsForResponse(cred, proxyResp.Headers)
@@ -1359,7 +1373,9 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 				shouldRetry = true
 				retryReason = RetryReasonAuthErr
 				p.balancer.RecordResponse(cred.Name, modelID, http.StatusInternalServerError)
-				p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, http.StatusInternalServerError, time.Since(start))
+				// Per-attempt failure only — the client-facing RequestsTotal/RequestDuration
+				// metrics are recorded exactly once at the final outcome below.
+				p.metrics.RecordCredentialAttemptError(cred.Name)
 				continue
 			}
 		}
@@ -1444,7 +1460,9 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 					"credential", cred.Name, "model", modelID, "error", doErr, "url", targetURL)
 			}
 			p.balancer.RecordResponse(cred.Name, modelID, statusCode)
-			p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, statusCode, time.Since(start))
+			// Per-attempt failure only — the client-facing RequestsTotal/RequestDuration
+			// metrics are recorded exactly once at the final outcome below.
+			p.metrics.RecordCredentialAttemptError(cred.Name)
 			shouldRetry = true
 			retryReason = RetryReasonNetErr
 			transportErr = doErr
@@ -1461,7 +1479,11 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 
-		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
+		// Per-attempt failure only — the client-facing RequestsTotal/RequestDuration
+		// metrics are recorded exactly once at the final outcome after the retry loop.
+		if resp.StatusCode != http.StatusOK {
+			p.metrics.RecordCredentialAttemptError(cred.Name)
+		}
 
 		// Debug: log response headers
 		maskedRespHeaders := security.MaskSensitiveHeaders(resp.Header)
@@ -1583,6 +1605,9 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 		logCtx.HTTPStatus = statusCode
 		logCtx.ErrorMsg = "All provider attempts failed"
 		logCtx.TargetURL = targetURL
+		// Client-facing outcome decided (all attempts exhausted, no response at
+		// all) — record exactly once here with genuine end-to-end duration.
+		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, statusCode, time.Since(start))
 		if statusCode == http.StatusRequestTimeout {
 			WriteErrorTimeout(w, statusMessage)
 		} else {
@@ -1595,6 +1620,12 @@ func (p *Proxy) ProxyRequest(w http.ResponseWriter, r *http.Request) {
 	if closeBody != nil {
 		defer closeBody()
 	}
+
+	// Client-facing outcome decided (this response — success or the last
+	// retryable error with no more attempts left — is what gets written to
+	// the client below) — record exactly once here with genuine end-to-end
+	// duration, not once per retry attempt.
+	p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
 
 	// === Process final response ===
 	var finalResponseBody []byte

--- a/internal/proxy/proxy_fallback_test.go
+++ b/internal/proxy/proxy_fallback_test.go
@@ -10,7 +10,9 @@ import (
 	"testing"
 
 	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/monitoring"
 	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -460,4 +462,62 @@ func TestProxy_429PreservedWhenNoFallbackAndNetworkError(t *testing.T) {
 	assert.Equal(t, http.StatusTooManyRequests, w.Code,
 		"a single-credential 429 followed by a network error must still return 429, not 502")
 	assert.Equal(t, int32(1), atomic.LoadInt32(&cred1Calls))
+}
+
+// TestProxy_MetricsAttributeToRespondingCredentialNotLastAttempted is a
+// regression test for a metrics attribution bug: when attempt A (credential
+// "primary") returns a retryable 429 and the subsequent retry against
+// credential "secondary" fails with a transport error (no fallback
+// available), the *response* written to the client is still primary's 429 —
+// but the loop variable `cred` has already moved on to "secondary" by the
+// time the final RecordRequest call ran. Without restoring the credential
+// that actually produced the response, RequestsTotal/RequestDuration would be
+// mislabeled under "secondary" for a response "primary" produced, defeating
+// this PR's central goal of correct per-credential attribution.
+func TestProxy_MetricsAttributeToRespondingCredentialNotLastAttempted(t *testing.T) {
+	monitoring.RequestsTotal.Reset()
+
+	primaryServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_ = json.NewEncoder(w).Encode(map[string]string{"error": "rate_limit_exceeded"})
+	}))
+	defer primaryServer.Close()
+
+	deadServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	deadURL := deadServer.URL
+	deadServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithCredentials(
+			config.CredentialConfig{
+				Name: "primary", Type: config.ProviderTypeProxy, APIKey: "key1",
+				BaseURL: primaryServer.URL, RPM: 100, TPM: 10000, IsFallback: false,
+			},
+			config.CredentialConfig{
+				Name: "secondary", Type: config.ProviderTypeProxy, APIKey: "key2",
+				BaseURL: deadURL, RPM: 100, TPM: 10000, IsFallback: false,
+			},
+		).
+		WithMasterKey("master-key").
+		WithMaxProviderRetries(1).
+		Build()
+	prx.metrics = monitoring.New(true)
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	prx.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	assert.Equal(t, 1.0,
+		testutil.ToFloat64(monitoring.RequestsTotal.WithLabelValues("primary", "gpt-4", "/v1/chat/completions", "429")),
+		"the 429 response actually written to the client came from 'primary' and must be recorded under its name")
+	assert.Equal(t, 0.0,
+		testutil.ToFloat64(monitoring.RequestsTotal.WithLabelValues("secondary", "gpt-4", "/v1/chat/completions", "429")),
+		"'secondary' never produced a response — it must not be attributed a 429 that belongs to 'primary'")
 }

--- a/internal/proxy/proxy_metrics_body_read_test.go
+++ b/internal/proxy/proxy_metrics_body_read_test.go
@@ -1,0 +1,108 @@
+package proxy
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/monitoring"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProxyRequest_DirectCredential_BodyTooLarge_RecordsFinalMetric is a
+// regression test: when the response body from a direct (non-proxy)
+// credential exceeds the configured size limit, the client gets a 502 via an
+// early return in the retry loop — but that return path used to skip
+// RecordRequest entirely, so the 502 never showed up in RequestsTotal. It
+// also used to skip RecordCredentialAttemptError, since the earlier
+// `resp.StatusCode != http.StatusOK` check can't see a failure that only
+// happens while reading the (200 OK) body. Both must be recorded exactly
+// once for this attempt.
+//
+// ErrResponseBodyTooLarge is used here only because it's a deterministic way
+// to trigger the shared `readErr != nil` branch in the retry loop — the fix
+// applies identically to any body-read failure (e.g. a connection dropped
+// mid-body), not just an oversized one.
+func TestProxyRequest_DirectCredential_BodyTooLarge_RecordsFinalMetric(t *testing.T) {
+	monitoring.RequestsTotal.Reset()
+
+	oversized := bytes.Repeat([]byte("x"), 2*1024*1024) // 2MB, over the 1MB cap below
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(oversized)
+	}))
+	defer upstream.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("provider", config.ProviderTypeOpenAI, upstream.URL, "upstream-key").
+		WithMaxBodySizeMB(1).
+		WithResponseBodyMultiplier(1). // 1MB * 1 = 1MB cap
+		Build()
+	prx.metrics = monitoring.New(true)
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(
+		`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	prx.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusBadGateway, w.Code)
+
+	assert.Equal(t, 1.0,
+		testutil.ToFloat64(monitoring.RequestsTotal.WithLabelValues("provider", "gpt-4", "/v1/chat/completions", "502")),
+		"the 502 written to the client for an oversized body must be recorded in RequestsTotal")
+	assert.Equal(t, 1.0,
+		testutil.ToFloat64(monitoring.CredentialErrorsTotal.WithLabelValues("provider")),
+		"a body-read failure is a genuine attempt failure and must show up in credential-error metrics")
+}
+
+// TestExecuteProxyRequest_BodyTooLarge_RecordsCredentialError is the
+// forwardToProxy/executeProxyRequest analog of the test above (the "relay"
+// path used by proxy-like credentials, per the review note that the same gap
+// exists there too).
+func TestExecuteProxyRequest_BodyTooLarge_RecordsCredentialError(t *testing.T) {
+	oversized := bytes.Repeat([]byte("x"), 2*1024*1024)
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(oversized)
+	}))
+	defer upstream.Close()
+
+	cred := &config.CredentialConfig{
+		Name:    "gateway",
+		Type:    config.ProviderTypeProxy,
+		BaseURL: upstream.URL,
+		APIKey:  "key",
+	}
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("gateway", config.ProviderTypeProxy, upstream.URL, "key").
+		WithMaxBodySizeMB(1).
+		WithResponseBodyMultiplier(1).
+		Build()
+	prx.metrics = monitoring.New(true)
+	monitoring.CredentialErrorsTotal.Reset()
+
+	upstreamReq := httptest.NewRequest("POST", "/v1/test", strings.NewReader("body"))
+	upstreamReq.Header.Set("Authorization", "Bearer key")
+	w := httptest.NewRecorder()
+
+	proxyResp, err := prx.forwardToProxy(w, upstreamReq, "test-model", cred, []byte("body"), time.Now().UTC())
+
+	require.Error(t, err)
+	require.Nil(t, proxyResp)
+	assert.Equal(t, 1.0,
+		testutil.ToFloat64(monitoring.CredentialErrorsTotal.WithLabelValues("gateway")),
+		"a body-read failure in executeProxyRequest is a genuine attempt failure and must show up in credential-error metrics")
+}

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -266,6 +266,12 @@ func (p *Proxy) writeFallbackResponse(
 		}
 	}
 
+	// Client-facing outcome decided — this is the response actually written to
+	// the client below, whether the fallback chain succeeded or exhausted all
+	// attempts. Recorded exactly once here (not per fallback attempt) with
+	// genuine end-to-end duration since the original client request arrived.
+	p.metrics.RecordRequest(fallbackCred.Name, r.URL.Path, modelID, proxyResp.StatusCode, time.Since(start))
+
 	if proxyResp.StatusCode >= 400 {
 		// Final error returned to the client after the fallback chain —
 		// single unified ERROR record (response_body is nil for streaming).

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -34,6 +35,40 @@ const streamDrainTimeout = 60 * time.Second
 // (error-only or keep-alive-only streams) stop being scanned; CompletionStartTime
 // stays zero, matching existing "never reached" semantics.
 const streamTTFTDetectionLimit = 64 * 1024
+
+// ttftScanState incrementally scans SSE lines for the first detectable content
+// delta, byte-for-byte equivalent to calling extractCompletionDeltaText on the
+// whole buffer accumulated so far after every Read — but each byte is scanned
+// exactly once (as part of the line it completes) instead of once per Read,
+// which made the old approach O(n²) in the bytes accumulated before a match.
+// A line can only ever contain a complete JSON payload once its trailing
+// newline has arrived, so deferring extraction until then loses no matches
+// extractCompletionDeltaText could have found on a still-partial line.
+type ttftScanState struct {
+	pending []byte
+	total   int
+}
+
+// observe feeds a newly read chunk into the scan and reports whether a
+// detectable content delta was found. total tracks cumulative bytes observed
+// (not just the still-unprocessed tail in pending) so streamTTFTDetectionLimit
+// keeps its original "give up after this many bytes with no match" meaning.
+func (s *ttftScanState) observe(chunk []byte) bool {
+	s.total += len(chunk)
+	s.pending = append(s.pending, chunk...)
+	for {
+		idx := bytes.IndexByte(s.pending, '\n')
+		if idx < 0 {
+			break
+		}
+		line := s.pending[:idx]
+		s.pending = s.pending[idx+1:]
+		if extractCompletionDeltaText(line) != "" {
+			return true
+		}
+	}
+	return false
+}
 
 // streamFlushCoalesceWindow throttles how often streamToClient calls Flush().
 // Profiled under concurrent streaming load: a Flush() (and the write syscall
@@ -917,6 +952,13 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 				logCtx.TokenUsage.ReasoningTokens, logCtx.TokenUsage.CachedInputTokens)
 		}
 	}
+	// TTFT: only meaningful if a real content delta actually arrived (streamToClient
+	// stamps CompletionStartTime the moment it does) — a stream that errored before
+	// any content, or wasn't streaming at all, has nothing to report here.
+	if logCtx.Credential != nil && !logCtx.CompletionStartTime.IsZero() {
+		p.metrics.RecordTTFT(logCtx.Credential.Name, endpointFromLogContext(logCtx),
+			logCtx.CompletionStartTime.Sub(logCtx.StartTime))
+	}
 	if err := p.logSpendToLiteLLMDB(logCtx); err != nil {
 		p.logger.WarnContext(logCtx.Context(), "Failed to queue streaming spend log",
 			"error", err,
@@ -1056,14 +1098,14 @@ func (p *Proxy) streamToClient(
 	buf := streamBufPool.Get().(*[]byte)
 	defer streamBufPool.Put(buf)
 
-	// TTFT detection buffer: separate from the bytes forwarded to the client via
+	// TTFT detection: separate from the bytes forwarded to the client via
 	// onChunk (forwarding must stay byte-for-byte immediate for latency). A real
 	// content/tool/reasoning delta can straddle multiple Read calls, or be
 	// preceded by content-free SSE events (ping, role-only delta) that arrive in
-	// their own Read — so bytes accumulate here across reads until
-	// extractCompletionDeltaText finds actual content, rather than stamping
+	// their own Read — so lines accumulate across reads via ttftScan until a
+	// complete line yields actual content, rather than stamping
 	// CompletionStartTime on the first non-empty Read regardless of content.
-	var ttftBuf []byte
+	var ttftScan ttftScanState
 	ttftPending := logCtx != nil && logCtx.CompletionStartTime.IsZero()
 	var lastFlush time.Time
 
@@ -1071,14 +1113,14 @@ func (p *Proxy) streamToClient(
 		n, err := reader.Read(*buf)
 		if n > 0 {
 			if ttftPending {
-				ttftBuf = append(ttftBuf, (*buf)[:n]...)
-				if extractCompletionDeltaText(ttftBuf) != "" {
+				if ttftScan.observe((*buf)[:n]) {
 					logCtx.CompletionStartTime = time.Now()
 					ttftPending = false
-					ttftBuf = nil
-				} else if len(ttftBuf) > streamTTFTDetectionLimit {
+				} else if ttftScan.total > streamTTFTDetectionLimit {
 					ttftPending = false
-					ttftBuf = nil
+				}
+				if !ttftPending {
+					ttftScan = ttftScanState{}
 				}
 			}
 			if onChunk != nil {

--- a/internal/proxy/stream_ttft_bench_test.go
+++ b/internal/proxy/stream_ttft_bench_test.go
@@ -1,0 +1,92 @@
+package proxy
+
+import (
+	"fmt"
+	"testing"
+)
+
+// oldTTFTDetect reproduces the pre-fix streamToClient TTFT detection: append
+// every chunk to a growing buffer and re-run extractCompletionDeltaText over
+// the *entire* accumulated buffer after every chunk. Kept only in this
+// benchmark to measure the O(n^2) cost the ttftScanState rewrite replaces.
+func oldTTFTDetect(chunks [][]byte, limit int) bool {
+	var buf []byte
+	for _, c := range chunks {
+		buf = append(buf, c...)
+		if extractCompletionDeltaText(buf) != "" {
+			return true
+		}
+		if len(buf) > limit {
+			return false
+		}
+	}
+	return false
+}
+
+func newTTFTDetect(chunks [][]byte, limit int) bool {
+	var s ttftScanState
+	for _, c := range chunks {
+		if s.observe(c) {
+			return true
+		}
+		if s.total > limit {
+			return false
+		}
+	}
+	return false
+}
+
+// sseChunks builds n content-free SSE keep-alive/ping frames (~180 bytes each,
+// matching mock-go's real SSE frame size per pprof_plan_test.md) followed by
+// one real content delta, or, if withContent is false, no content delta at
+// all (worst case: scan runs until the detection cap gives up).
+func sseChunks(n int, withContent bool) [][]byte {
+	chunks := make([][]byte, 0, n+1)
+	for i := 0; i < n; i++ {
+		chunks = append(chunks, []byte(fmt.Sprintf(
+			`data: {"id":"chatcmpl-%d","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":null}]}`+"\n\n",
+			i)))
+	}
+	if withContent {
+		chunks = append(chunks, []byte(`data: {"choices":[{"delta":{"content":"hi"}}]}`+"\n\n"))
+	}
+	return chunks
+}
+
+func BenchmarkTTFTDetect_Old(b *testing.B) {
+	for _, n := range []int{10, 50, 200, 355} { // 355*~180B ~= 64KB cap
+		b.Run(fmt.Sprintf("preamble=%d/match", n), func(b *testing.B) {
+			chunks := sseChunks(n, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				oldTTFTDetect(chunks, streamTTFTDetectionLimit)
+			}
+		})
+		b.Run(fmt.Sprintf("preamble=%d/nomatch-cap", n), func(b *testing.B) {
+			chunks := sseChunks(n, false)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				oldTTFTDetect(chunks, streamTTFTDetectionLimit)
+			}
+		})
+	}
+}
+
+func BenchmarkTTFTDetect_New(b *testing.B) {
+	for _, n := range []int{10, 50, 200, 355} {
+		b.Run(fmt.Sprintf("preamble=%d/match", n), func(b *testing.B) {
+			chunks := sseChunks(n, true)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				newTTFTDetect(chunks, streamTTFTDetectionLimit)
+			}
+		})
+		b.Run(fmt.Sprintf("preamble=%d/nomatch-cap", n), func(b *testing.B) {
+			chunks := sseChunks(n, false)
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				newTTFTDetect(chunks, streamTTFTDetectionLimit)
+			}
+		})
+	}
+}

--- a/internal/proxy/test_helpers.go
+++ b/internal/proxy/test_helpers.go
@@ -87,24 +87,25 @@ func createTestBalancer(baseURL string) (*balancer.RoundRobin, *ratelimit.RPMLim
 
 // TestProxyConfig holds configuration for building a test proxy instance.
 type TestProxyConfig struct {
-	Credentials          []config.CredentialConfig
-	Logger               *slog.Logger
-	Balancer             *balancer.RoundRobin
-	RateLimiter          *ratelimit.RPMLimiter
-	Metrics              *monitoring.Metrics
-	TokenManager         *auth.VertexTokenManager
-	ModelManager         *models.Manager
-	MasterKey            string
-	MaxBodySizeMB        int
-	RequestTimeout       time.Duration
-	Version              string
-	Commit               string
-	SessionStickyEnabled bool
-	SessionStoreTTL      time.Duration
-	MaxProviderRetries   int
-	MaxFallbackAttempts  int
-	DrainUpstreamOnAbort bool
-	ResponseHeaderMode   config.ResponseHeaderMode
+	Credentials            []config.CredentialConfig
+	Logger                 *slog.Logger
+	Balancer               *balancer.RoundRobin
+	RateLimiter            *ratelimit.RPMLimiter
+	Metrics                *monitoring.Metrics
+	TokenManager           *auth.VertexTokenManager
+	ModelManager           *models.Manager
+	MasterKey              string
+	MaxBodySizeMB          int
+	ResponseBodyMultiplier int
+	RequestTimeout         time.Duration
+	Version                string
+	Commit                 string
+	SessionStickyEnabled   bool
+	SessionStoreTTL        time.Duration
+	MaxProviderRetries     int
+	MaxFallbackAttempts    int
+	DrainUpstreamOnAbort   bool
+	ResponseHeaderMode     config.ResponseHeaderMode
 }
 
 // NewTestProxyBuilder creates a builder with default configuration.
@@ -221,6 +222,21 @@ func (b *TestProxyBuilder) WithSessionSticky(ttl time.Duration) *TestProxyBuilde
 	return b
 }
 
+// WithMaxBodySizeMB sets the max response body size (in MB, before the
+// ResponseBodyMultiplier is applied). Use together with WithResponseBodyMultiplier
+// to get a small, test-friendly size limit for exercising ErrResponseBodyTooLarge.
+func (b *TestProxyBuilder) WithMaxBodySizeMB(mb int) *TestProxyBuilder {
+	b.config.MaxBodySizeMB = mb
+	return b
+}
+
+// WithResponseBodyMultiplier overrides DefaultResponseBodyMultiplier (10) for tests
+// that need a precise, small max response body size (MaxBodySizeMB * multiplier).
+func (b *TestProxyBuilder) WithResponseBodyMultiplier(multiplier int) *TestProxyBuilder {
+	b.config.ResponseBodyMultiplier = multiplier
+	return b
+}
+
 // WithMaxProviderRetries sets the maximum number of same-type credential retries.
 // This mirrors the production Config.MaxProviderRetries (default: 2).
 // Use this in tests that need to validate retry/fallback behavior under realistic
@@ -255,23 +271,24 @@ func (b *TestProxyBuilder) Build() *Proxy {
 		b.config.Balancer = balancer.New(b.config.Credentials, f2b, b.config.RateLimiter)
 	}
 	return New(&Config{
-		Balancer:             b.config.Balancer,
-		Logger:               b.config.Logger,
-		MaxBodySizeMB:        b.config.MaxBodySizeMB,
-		RequestTimeout:       b.config.RequestTimeout,
-		Metrics:              b.config.Metrics,
-		MasterKey:            b.config.MasterKey,
-		RateLimiter:          b.config.RateLimiter,
-		TokenManager:         b.config.TokenManager,
-		ModelManager:         b.config.ModelManager,
-		Version:              b.config.Version,
-		Commit:               b.config.Commit,
-		SessionStickyEnabled: b.config.SessionStickyEnabled,
-		SessionStoreTTL:      b.config.SessionStoreTTL,
-		MaxProviderRetries:   b.config.MaxProviderRetries,
-		MaxFallbackAttempts:  b.config.MaxFallbackAttempts,
-		DrainUpstreamOnAbort: b.config.DrainUpstreamOnAbort,
-		ResponseHeaderMode:   b.config.ResponseHeaderMode,
+		Balancer:               b.config.Balancer,
+		Logger:                 b.config.Logger,
+		MaxBodySizeMB:          b.config.MaxBodySizeMB,
+		ResponseBodyMultiplier: b.config.ResponseBodyMultiplier,
+		RequestTimeout:         b.config.RequestTimeout,
+		Metrics:                b.config.Metrics,
+		MasterKey:              b.config.MasterKey,
+		RateLimiter:            b.config.RateLimiter,
+		TokenManager:           b.config.TokenManager,
+		ModelManager:           b.config.ModelManager,
+		Version:                b.config.Version,
+		Commit:                 b.config.Commit,
+		SessionStickyEnabled:   b.config.SessionStickyEnabled,
+		SessionStoreTTL:        b.config.SessionStoreTTL,
+		MaxProviderRetries:     b.config.MaxProviderRetries,
+		MaxFallbackAttempts:    b.config.MaxFallbackAttempts,
+		DrainUpstreamOnAbort:   b.config.DrainUpstreamOnAbort,
+		ResponseHeaderMode:     b.config.ResponseHeaderMode,
 	})
 }
 

--- a/internal/proxy/token_estimator.go
+++ b/internal/proxy/token_estimator.go
@@ -1,11 +1,16 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
 	"strings"
 	"unicode"
 	"unicode/utf8"
 
+	// goccyjson is used only for appendChatCompletionDeltaText/appendResponsesDeltaText
+	// (small, per-SSE-chunk typed unmarshals in the streaming hot path) — benchmarked
+	// separately from this file's other encoding/json uses, which stay on stdlib.
+	goccyjson "github.com/goccy/go-json"
 	"github.com/tiktoken-go/tokenizer"
 )
 
@@ -401,10 +406,31 @@ func extractCompletionDeltaText(chunk []byte) string {
 
 	var b strings.Builder
 	for _, payload := range payloads {
-		appendChatCompletionDeltaText(&b, payload)
-		appendResponsesDeltaText(&b, payload)
+		appendDeltaTextForPayload(&b, payload)
 	}
 	return b.String()
+}
+
+// appendDeltaTextForPayload picks which shape-specific decoder(s) to run for a
+// single SSE payload. A stream is always either Chat-Completions-shaped or
+// Responses-shaped, never both, so unconditionally running both
+// appendChatCompletionDeltaText and appendResponsesDeltaText — as this used
+// to do — means one of the two always does a full, wasted json.Unmarshal of
+// the same bytes. A raw substring check is a cheap, allocation-free way to
+// rule out the shape that can't match before paying for its unmarshal; a
+// false positive (the substring appearing inside delta text itself, e.g. a
+// model streaming a code sample containing `"type"`) only costs one harmless
+// extra unmarshal that finds no matching top-level field, same as today —
+// never a wrong result. (A map[string]json.RawMessage pre-decode was tried
+// first and measured slower here: the extra map/RawMessage allocations
+// outweigh the unmarshal it saves at this payload size.)
+func appendDeltaTextForPayload(b *strings.Builder, payload []byte) {
+	if bytes.Contains(payload, []byte(`"choices"`)) {
+		appendChatCompletionDeltaText(b, payload)
+	}
+	if bytes.Contains(payload, []byte(`"type"`)) {
+		appendResponsesDeltaText(b, payload)
+	}
 }
 
 func appendChatCompletionDeltaText(b *strings.Builder, payload []byte) {
@@ -426,7 +452,7 @@ func appendChatCompletionDeltaText(b *strings.Builder, payload []byte) {
 			} `json:"delta"`
 		} `json:"choices"`
 	}
-	if err := json.Unmarshal(payload, &data); err != nil {
+	if err := goccyjson.Unmarshal(payload, &data); err != nil {
 		return
 	}
 	for _, choice := range data.Choices {
@@ -448,7 +474,7 @@ func appendResponsesDeltaText(b *strings.Builder, payload []byte) {
 		Type  string      `json:"type"`
 		Delta interface{} `json:"delta"`
 	}
-	if err := json.Unmarshal(payload, &event); err != nil || event.Type == "" {
+	if err := goccyjson.Unmarshal(payload, &event); err != nil || event.Type == "" {
 		return
 	}
 

--- a/internal/proxy/token_estimator_bench_test.go
+++ b/internal/proxy/token_estimator_bench_test.go
@@ -1,0 +1,157 @@
+package proxy
+
+import (
+	"bytes"
+	stdjson "encoding/json"
+	"strings"
+	"testing"
+)
+
+// --- stdlib-only baselines ---
+// appendChatCompletionDeltaText/appendResponsesDeltaText in token_estimator.go
+// now use goccy, so these copies keep a pure-stdlib version around to isolate
+// each change's own contribution (substring filter vs JSON engine swap).
+
+func appendChatCompletionDeltaTextStdlib(b *strings.Builder, payload []byte) {
+	var data struct {
+		Choices []struct {
+			Delta struct {
+				Content      interface{} `json:"content"`
+				Refusal      string      `json:"refusal"`
+				FunctionCall *struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function_call,omitempty"`
+				ToolCalls []struct {
+					Function struct {
+						Name      string `json:"name"`
+						Arguments string `json:"arguments"`
+					} `json:"function"`
+				} `json:"tool_calls,omitempty"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	if err := stdjson.Unmarshal(payload, &data); err != nil {
+		return
+	}
+	for _, choice := range data.Choices {
+		appendDeltaValueText(b, choice.Delta.Content)
+		b.WriteString(choice.Delta.Refusal)
+		if choice.Delta.FunctionCall != nil {
+			b.WriteString(choice.Delta.FunctionCall.Name)
+			b.WriteString(choice.Delta.FunctionCall.Arguments)
+		}
+		for _, call := range choice.Delta.ToolCalls {
+			b.WriteString(call.Function.Name)
+			b.WriteString(call.Function.Arguments)
+		}
+	}
+}
+
+func appendResponsesDeltaTextStdlib(b *strings.Builder, payload []byte) {
+	var event struct {
+		Type  string      `json:"type"`
+		Delta interface{} `json:"delta"`
+	}
+	if err := stdjson.Unmarshal(payload, &event); err != nil || event.Type == "" {
+		return
+	}
+	switch event.Type {
+	case "response.output_text.delta",
+		"response.refusal.delta",
+		"response.reasoning_text.delta",
+		"response.reasoning_summary_text.delta",
+		"response.function_call_arguments.delta",
+		"response.mcp_call_arguments.delta",
+		"response.custom_tool_call_input.delta",
+		"response.code_interpreter_call_code.delta":
+		appendDeltaValueText(b, event.Delta)
+	}
+}
+
+// oldAppendDeltaText reproduces the original (pre-fix) extractCompletionDeltaText:
+// both shape decoders run unconditionally on every payload via stdlib json, so
+// one of them always does a fully wasted unmarshal.
+func oldAppendDeltaText(chunk []byte) string {
+	payloads := extractJSONPayloadsFromStreamChunk(chunk)
+	var b strings.Builder
+	for _, payload := range payloads {
+		appendChatCompletionDeltaTextStdlib(&b, payload)
+		appendResponsesDeltaTextStdlib(&b, payload)
+	}
+	return b.String()
+}
+
+// filteredAppendDeltaTextStdlib reproduces the substring-gated fix but stays on
+// stdlib json, isolating the filter's own win from the later goccy swap.
+func filteredAppendDeltaTextStdlib(chunk []byte) string {
+	payloads := extractJSONPayloadsFromStreamChunk(chunk)
+	var b strings.Builder
+	for _, payload := range payloads {
+		if bytes.Contains(payload, []byte(`"choices"`)) {
+			appendChatCompletionDeltaTextStdlib(&b, payload)
+		}
+		if bytes.Contains(payload, []byte(`"type"`)) {
+			appendResponsesDeltaTextStdlib(&b, payload)
+		}
+	}
+	return b.String()
+}
+
+var (
+	chatDeltaPayload = []byte(`data: {"id":"chatcmpl-abc123","object":"chat.completion.chunk","created":1730000000,"model":"gpt-4o","choices":[{"index":0,"delta":{"content":"hello world, this is a streamed token chunk"},"finish_reason":null}]}` + "\n\n")
+
+	responsesDeltaPayload = []byte(`data: {"type":"response.output_text.delta","item_id":"item_abc123","output_index":0,"content_index":0,"delta":"hello world, this is a streamed token chunk"}` + "\n\n")
+)
+
+// BenchmarkExtractCompletionDeltaText_Old: original code, both decoders always
+// run, stdlib json.
+func BenchmarkExtractCompletionDeltaText_Old(b *testing.B) {
+	b.Run("chat-shaped", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			oldAppendDeltaText(chatDeltaPayload)
+		}
+	})
+	b.Run("responses-shaped", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			oldAppendDeltaText(responsesDeltaPayload)
+		}
+	})
+}
+
+// BenchmarkExtractCompletionDeltaText_FilteredStdlib: substring shape filter
+// added, still stdlib json — isolates the filter's own contribution.
+func BenchmarkExtractCompletionDeltaText_FilteredStdlib(b *testing.B) {
+	b.Run("chat-shaped", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			filteredAppendDeltaTextStdlib(chatDeltaPayload)
+		}
+	})
+	b.Run("responses-shaped", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			filteredAppendDeltaTextStdlib(responsesDeltaPayload)
+		}
+	})
+}
+
+// BenchmarkExtractCompletionDeltaText_FilteredGoccy: current production code —
+// substring shape filter + goccy/go-json. Isolates the JSON engine swap's own
+// contribution on top of the filter.
+func BenchmarkExtractCompletionDeltaText_FilteredGoccy(b *testing.B) {
+	b.Run("chat-shaped", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			extractCompletionDeltaText(chatDeltaPayload)
+		}
+	})
+	b.Run("responses-shaped", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			extractCompletionDeltaText(responsesDeltaPayload)
+		}
+	})
+}


### PR DESCRIPTION
# Fix streaming TTFT regression under load + honest request metrics

## Why

During a load test against production (pprof disabled), once RPS/VUs climbed
past ~1000 concurrent users (~5 minutes in), observed **TTFT (time to first
token) jumped from ~1s to ~15s**. No corresponding spike in 5xx/timeouts — the
system just got slow, not broken.

Two things made this investigation possible and then led one level deeper:

1. Our `RequestsTotal`/`RequestDuration` metrics were double-/triple-counting:
   `RecordRequest` was called once per retry attempt instead of once per
   client request, inflating request counts and mislabeling duration under
   the wrong credential/status on retried requests. Fixed this first to get a
   trustworthy signal.
2. We had no TTFT metric at all — only request duration, which conflates
   provider think-time with total generation time for streaming responses.
   Added `auto_ai_router_time_to_first_token_seconds` (new Grafana panels:
   "Time to First Token (TTFT)", percentiles, P95 by endpoint/credential).

With that instrumentation in place, the TTFT collapse above became visible
and traceable. Root cause turned out to be in our own hot path, not the
network or the provider.

## Root cause

`streamToClient` (`internal/proxy/stream.go`) detects TTFT by accumulating
bytes into a buffer and re-running `extractCompletionDeltaText` over the
**entire accumulated buffer** on every single upstream `Read()` until a real
content delta is found (up to a 64KB cap) — an O(n²) rescan. Negligible at low
concurrency (buffer stays small), but under load this becomes a
self-reinforcing feedback loop: more concurrent streams → more GC/scheduler
pressure → fewer, larger `Read()`s per stream → bigger buffer before a match →
quadratically more CPU burned rescanning → even more scheduler pressure. This
plausibly explains a sudden regime change past a concurrency threshold rather
than a graceful slowdown, and it never produces an error because
`ResponseHeaderTimeout`/`TLSHandshakeTimeout` default to 60s — plenty of
headroom for a silent 15s stall.

(We also audited the balancer's rate-limit lock and Redis backend as a
possible compounding factor — a global mutex wrapping a synchronous Redis
round-trip is a classic collapse-under-concurrency pattern — but hybrid Redis
mode, which avoids that synchronous call, was already enabled in production,
so it wasn't the active cause here.)

## Fixes

### 1. Incremental TTFT scan (kills the O(n²))

Replaced the full-buffer rescan with `ttftScanState`, which processes each
complete SSE line exactly once (byte-for-byte identical detection semantics —
all existing TTFT tests pass unchanged) instead of re-parsing everything seen
so far.

**Benchmark** — cost of detecting TTFT over N ~180-byte preamble chunks
before content arrives (or before the 64KB cap gives up):

| preamble chunks | before (O(n²)) | after (incremental) | speedup |
|---:|---:|---:|---:|
| 10 | 135 µs | 26 µs | 5x |
| 50 | 2.63 ms | 104 µs | 25x |
| 200 | 39.9 ms | 411 µs | 97x |
| 355 (~64KB cap) | **125.6 ms** | **0.74 ms** | **~170x** (allocs ~141x fewer) |

### 2. Stop parsing every chunk twice for TTFT

`extractCompletionDeltaText` unconditionally ran both
`appendChatCompletionDeltaText` and `appendResponsesDeltaText` on every
payload, even though a stream is always exactly one shape — one of the two
calls was always a fully wasted `json.Unmarshal`. Added a cheap
allocation-free substring pre-check (`"choices"` / `"type"`) to skip the
decoder that can't match. (A `map[string]json.RawMessage` pre-decode was
tried first and measured *slower* here — noted in code so it isn't
re-attempted.)

| payload shape | before | after | speedup |
|---|---:|---:|---:|
| chat-completions delta | 3190 ns/op, 22 allocs | 2030 ns/op, 17 allocs | 1.6x |
| responses-API delta | 2260 ns/op, 16 allocs | 1540 ns/op, 13 allocs | 1.5x |

### 3. `encoding/json` → `goccy/go-json` on streaming hot paths

Once (1) and (2) landed, re-benchmarked JSON decode cost on every remaining
per-chunk hot path across the streaming pipeline (proxy + all provider
converters). Every candidate was benchmarked before/after (and, for the one
touching an external SDK type, correctness-verified with a
`reflect.DeepEqual` round-trip test) — this is not a blanket replacement,
only the call sites below were touched:

| Call site | Shape | Before | After | Speedup |
|---|---|---:|---:|---:|
| `token_estimator.go` delta unmarshal (chat) | typed struct | 3190 ns | 713 ns | 4.5x |
| `token_estimator.go` delta unmarshal (responses) | typed struct | 2260 ns | 546 ns | 4.3x |
| `chat_response_compat.go` `normalizeSSEDataLineModel` | `map[string]interface{}` | 4.8 µs | 3.2 µs | 1.5x |
| `anthropic/streaming.go` `AnthropicStreamEvent` unmarshal | typed struct | 1.3-1.5 µs | 0.21-0.27 µs | ~6x |
| `anthropic/streaming.go` outgoing chunk marshal | typed struct | 428 ns | 220 ns | 1.9x |
| `anthropic/responses/streaming.go` (same event type) | typed struct | ~1.3-1.5 µs | ~0.21-0.27 µs | ~6x |
| `vertex/streaming.go` + `vertex/responses/streaming.go` `VertexStreamingChunk` (wraps `genai.*`) | typed struct, external SDK | 5.7 µs | 1.6 µs | 3.5x |
| `converter/responses/streaming.go` `chatStreamChunk` unmarshal | typed struct | 2.0 µs | 0.38 µs | 5.2x |
| `converter/responses/streaming.go` outgoing SSE event marshal | `map[string]interface{}` | 1.1 µs | 0.72 µs | 1.5x |
| `eventstream.go` (Bedrock envelope) | 1-field struct | 1.14 µs | 0.20 µs | 5.8x |

`VertexStreamingChunk` wraps external `google.golang.org/genai` types
(including custom `[]byte`/base64 fields like `ThoughtSignature`) — the
riskiest of the swaps, so it's backed by a dedicated round-trip test
(`TestVertexStreamingChunkUnmarshal_GoccyMatchesStdlib`) confirming decode
output is identical to stdlib, not just faster.

### 4. Metrics correctness (prerequisite for the above)

- `RecordRequest` now called exactly once per client request, at the final
  outcome, instead of once per retry/fallback attempt. Added
  `RecordCredentialAttemptError` for per-attempt credential-health visibility
  without polluting client-facing request/duration metrics.
- `RequestDuration` histogram buckets widened between 1s-10s (real p50/p95
  here is 1-3s; the old `{1, 10, 30, ...}` buckets had `histogram_quantile`
  linearly interpolating across a 9s gap, producing a P95 artifact near 10s
  from samples that were actually 1-2.5s).
- New `auto_ai_router_time_to_first_token_seconds` histogram + Grafana panels.
- `ObserveSpendSnapshot` now serialized under a mutex to stop concurrent
  snapshots from interleaving field-by-field into gauge combinations that
  never actually existed together.

## Testing

- All fixes benchmarked before/after with `go test -bench` on realistic
  payload shapes (mock-go SSE frame size, real provider event shapes) before
  being applied — no change landed on assumption alone (one candidate,
  `map[string]json.RawMessage` pre-decode, was tried and reverted after
  benchmarking showed it regressed).
- Full repo test suite + `go vet` + `-race` green.
- Dedicated correctness round-trip test for the one swap touching an external
  SDK type (`google.golang.org/genai`).
