### PR TITLE
fix: reasoning_content billing for deepseek/qwen streaming

### DIFF
--- a/internal/proxy/token_estimator.go
+++ b/internal/proxy/token_estimator.go
@@ -487,8 +487,9 @@ func appendChatCompletionDeltaText(b *strings.Builder, payload []byte) {
 	var data struct {
 		Choices []struct {
 			Delta struct {
-				Content      interface{} `json:"content"`
-				Refusal      string      `json:"refusal"`
+				Content          interface{} `json:"content"`
+				Refusal          string      `json:"refusal"`
+				ReasoningContent string      `json:"reasoning_content"`
 				FunctionCall *struct {
 					Name      string `json:"name"`
 					Arguments string `json:"arguments"`
@@ -507,6 +508,7 @@ func appendChatCompletionDeltaText(b *strings.Builder, payload []byte) {
 	}
 	for _, choice := range data.Choices {
 		appendDeltaValueText(b, choice.Delta.Content)
+		b.WriteString(choice.Delta.ReasoningContent)
 		b.WriteString(choice.Delta.Refusal)
 		if choice.Delta.FunctionCall != nil {
 			b.WriteString(choice.Delta.FunctionCall.Name)

--- a/internal/proxy/token_estimator_test.go
+++ b/internal/proxy/token_estimator_test.go
@@ -163,6 +163,22 @@ func TestExtractCompletionDeltaText_IgnoresAudioBytes(t *testing.T) {
 	assert.Equal(t, "", extractCompletionDeltaText(chunk))
 }
 
+func TestExtractCompletionDeltaText_ChatCompletionsReasoningContent(t *testing.T) {
+	chunk := []byte(
+		`data: {"choices":[{"delta":{"reasoning_content":"thinking about this..."}}]}`+"\n\n"+
+		`data: {"choices":[{"delta":{"reasoning_content":" and more reasoning"}}]}`+"\n\n"+
+		`data: {"choices":[{"delta":{"content":"the answer"}}]}`+"\n\n")
+
+	assert.Equal(t, "thinking about this... and more reasoningthe answer", extractCompletionDeltaText(chunk))
+}
+
+func TestExtractCompletionDeltaText_ChatCompletionsReasoningOnly(t *testing.T) {
+	chunk := []byte(
+		`data: {"choices":[{"delta":{"reasoning_content":"only reasoning, no content"}}]}`+"\n\n")
+
+	assert.Equal(t, "only reasoning, no content", extractCompletionDeltaText(chunk))
+}
+
 // --- Fix A: lazy prompt-token estimate + tiktoken_enabled toggle ---
 
 func TestRequestLogContext_PromptTokensEstimate_MemoizedAfterFirstCall(t *testing.T) {


### PR DESCRIPTION
## Проблема

Биллинг стриминга для DeepSeek-R1/V3 и Qwen reasoning моделей возвращает 0.

Причина: `appendChatCompletionDeltaText` (аккумулятор текста дельт Chat Completions) не читает `delta.reasoning_content`. DeepSeek и Qwen reasoning модели стримят основной вывод через это поле. Когда usage-чанк не доходит (клиент отключился, провайдер игнорирует `stream_options.include_usage`), fallback-подсчёт токенов возвращает ≈0, потому что считается только `delta.content`, а reasoning контент может составлять 90%+ completion.

## Исправление

Добавлено `ReasoningContent string \`json:"reasoning_content"\`` в Delta struct и `b.WriteString(choice.Delta.ReasoningContent)` в builder — единообразно с:

- `appendResponsesDeltaText`: обрабатывает `response.reasoning_text.delta`
- `appendMessagesDeltaText`: обрабатывает `thinking_delta`

## Изменения

- `internal/proxy/token_estimator.go` — добавлено поле reasoning_content + запись
- `internal/proxy/token_estimator_test.go` — добавлены 2 теста для reasoning_content

## Тесты

- Все существующие тесты proxy проходят (31 пакет, 0 ошибок)
- `golangci-lint` — 0 issues
- `go vet` — чисто
- Новые тесты: `TestExtractCompletionDeltaText_ChatCompletionsReasoningContent`, `TestExtractCompletionDeltaText_ChatCompletionsReasoningOnly`