### PR TITLE
Support legacy inference paths

### DIFF
--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -33,6 +33,38 @@ var proxiedPublicPaths = map[string]struct{}{
 	"/v1/responses":          {},
 }
 
+var legacyPublicPathAliases = map[string]string{
+	"/chat/completions":   "/v1/chat/completions",
+	"/completions":        "/v1/completions",
+	"/embeddings":         "/v1/embeddings",
+	"/image/generations":  "/v1/images/generations",
+	"/images/edits":       "/v1/images/edits",
+	"/images/generations": "/v1/images/generations",
+	"/messages":           "/v1/messages",
+	"/models":             "/v1/models",
+	"/responses":          "/v1/responses",
+}
+
+func canonicalPublicPath(path string) string {
+	canonicalPath := strings.TrimSuffix(path, "/")
+	if target, ok := legacyPublicPathAliases[canonicalPath]; ok {
+		return target
+	}
+	if strings.HasPrefix(path, "/responses/") {
+		return "/v1" + path
+	}
+	return path
+}
+
+func normalizePublicPath(req *http.Request) {
+	path := canonicalPublicPath(req.URL.Path)
+	if path == req.URL.Path {
+		return
+	}
+	req.URL.Path = path
+	req.URL.RawPath = ""
+}
+
 func publicPathAllowedMethod(req *http.Request) (string, bool) {
 	path := req.URL.Path
 	if path == "/v1/models" {
@@ -82,6 +114,7 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	w.Header().Set("Content-Security-Policy", "frame-ancestors 'none'")
 	w.Header().Set("X-Frame-Options", "DENY")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
+	normalizePublicPath(req)
 
 	// Recover from handler panics so they land in our logging system at ERROR
 	// (net/http's built-in recovery only prints to stderr) and the client gets

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -435,6 +435,58 @@ func TestServeHTTP_ProxyRequest(t *testing.T) {
 	}
 }
 
+func TestCanonicalPublicPath(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/chat/completions", "/v1/chat/completions"},
+		{"/chat/completions/", "/v1/chat/completions"},
+		{"/completions", "/v1/completions"},
+		{"/embeddings", "/v1/embeddings"},
+		{"/image/generations", "/v1/images/generations"},
+		{"/images/generations", "/v1/images/generations"},
+		{"/images/edits", "/v1/images/edits"},
+		{"/messages", "/v1/messages"},
+		{"/models", "/v1/models"},
+		{"/responses", "/v1/responses"},
+		{"/responses/resp_123", "/v1/responses/resp_123"},
+		{"/responses/resp_123/", "/v1/responses/resp_123/"},
+		{"/v1/chat/completions", "/v1/chat/completions"},
+		{"/health", "/health"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, canonicalPublicPath(tt.path))
+		})
+	}
+}
+
+func TestServeHTTPLegacyChatCompletionsAlias(t *testing.T) {
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v1/chat/completions", r.URL.Path)
+		assert.Equal(t, "value", r.URL.Query().Get("query"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"choices":[{"message":{"role":"assistant","content":"ok"}}]}`)
+	}))
+	defer upstream.Close()
+
+	prx := createProxyWithMockServer(upstream.URL)
+	router := New(prx, nil, testhelpers.NewTestMonitoringConfig("/health", false, ""), testhelpers.NewTestLogger(), nil)
+	req := httptest.NewRequest(http.MethodPost, "/chat/completions?query=value", strings.NewReader(`{
+		"model":"test-model",
+		"messages":[{"role":"user","content":"test"}]
+	}`))
+	req.Header.Set("Authorization", "Bearer test-key")
+	req.Header.Set("Content-Type", "application/json")
+	result := httptest.NewRecorder()
+
+	router.ServeHTTP(result, req)
+
+	require.Equal(t, http.StatusOK, result.Code)
+}
+
 func TestServeHTTP_Messages(t *testing.T) {
 	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/v1/chat/completions", r.URL.Path)


### PR DESCRIPTION
Adds LiteLLM-compatible aliases for supported public endpoints.