### PR TITLE
Add reasoning-only credential routing

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -179,7 +179,7 @@ Common fields for all credentials:
 | `rpm`              | int    | Requests per minute limit (-1 = unlimited)                                                  |
 | `tpm`              | int    | Tokens per minute limit (-1 = unlimited)                                                    |
 | `is_fallback`      | bool   | Use as fallback when primary credentials are exhausted                                      |
-| `reasoning_only`   | bool   | Route only requests that explicitly enable reasoning/thinking                                |
+| `reasoning_only`   | bool   | Route only requests that explicitly enable reasoning/thinking                               |
 | `scopes`           | list   | Optional client scopes allowed to use and see this credential                               |
 | `denied_scopes`    | list   | Optional client scopes that must not use or see this credential                             |
 | `forbidden_scopes` | list   | Alias for `denied_scopes`                                                                   |

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -179,6 +179,7 @@ Common fields for all credentials:
 | `rpm`              | int    | Requests per minute limit (-1 = unlimited)                                                  |
 | `tpm`              | int    | Tokens per minute limit (-1 = unlimited)                                                    |
 | `is_fallback`      | bool   | Use as fallback when primary credentials are exhausted                                      |
+| `reasoning_only`   | bool   | Route only requests that explicitly enable reasoning/thinking                                |
 | `scopes`           | list   | Optional client scopes allowed to use and see this credential                               |
 | `denied_scopes`    | list   | Optional client scopes that must not use or see this credential                             |
 | `forbidden_scopes` | list   | Alias for `denied_scopes`                                                                   |
@@ -241,6 +242,23 @@ Scope filtering applies to routing, retry/fallback selection, `/health`, `/v1/mo
 
 In both LiteLLM API-key metadata and `LiteLLM_CredentialsTable.credential_info`,
 `air_forbidden_scopes` is accepted as an alias for `air_denied_scopes`.
+
+Set `reasoning_only: true` on a credential when its provider accepts only reasoning traffic:
+
+```yaml
+credentials:
+  - name: anthropic-reasoning
+    type: anthropic
+    api_key: "os.environ/ANTHROPIC_API_KEY"
+    base_url: "https://api.anthropic.com"
+    reasoning_only: true
+```
+
+The filter recognizes enabled `reasoning_effort`, `reasoning`, `thinking`,
+`thinking_budget`, and `thinking_level` parameters. Requests that omit reasoning or
+explicitly disable it skip the credential during initial selection, sticky routing,
+retries, and fallback selection. For DB-loaded credentials, use
+`"air_reasoning_only": true` in `credential_info`.
 
 ## Models
 

--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -183,8 +183,16 @@ func (r *RoundRobin) NextFallbackForModelScoped(modelID string, visibility scope
 	return r.nextScoped(modelID, true, false, visibility)
 }
 
+func (r *RoundRobin) NextFallbackForModelExcludingScoped(modelID string, exclude map[string]bool, visibility scope.Context) (*config.CredentialConfig, error) {
+	return r.nextExcludingScoped(modelID, true, false, "", exclude, visibility)
+}
+
 func (r *RoundRobin) NextFallbackProxyForModelScoped(modelID string, visibility scope.Context) (*config.CredentialConfig, error) {
 	return r.nextScoped(modelID, true, true, visibility)
+}
+
+func (r *RoundRobin) NextFallbackProxyForModelExcludingScoped(modelID string, exclude map[string]bool, visibility scope.Context) (*config.CredentialConfig, error) {
+	return r.nextExcludingScoped(modelID, true, true, "", exclude, visibility)
 }
 
 // NextSpecific tries to return a specific credential by name without advancing the

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -667,6 +667,7 @@ type CredentialConfig struct {
 	TPM                     int               `yaml:"tpm"`
 	Weight                  int               `yaml:"weight"` // Default weighted round-robin weight for this credential (0 = 1)
 	FallbackPriority        int               `yaml:"fallback_priority,omitempty"`
+	ReasoningOnly           bool              `yaml:"reasoning_only,omitempty"`
 	Scopes                  []string          `yaml:"scopes,omitempty"`
 	DeniedScopes            []string          `yaml:"denied_scopes,omitempty"`
 	ProviderScopes          []string          `yaml:"-"`
@@ -729,6 +730,7 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 		TPM              string           `yaml:"tpm"`
 		Weight           string           `yaml:"weight"`
 		FallbackPriority string           `yaml:"fallback_priority,omitempty"`
+		ReasoningOnly    string           `yaml:"reasoning_only,omitempty"`
 		Scopes           []string         `yaml:"scopes,omitempty"`
 		DeniedScopes     []string         `yaml:"denied_scopes,omitempty"`
 		ForbiddenScopes  []string         `yaml:"forbidden_scopes,omitempty"`
@@ -779,6 +781,9 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	if c.FallbackPriority, err = parseField(temp.FallbackPriority, 0, strconv.Atoi, "fallback_priority for credential '"+c.Name+"'"); err != nil {
+		return err
+	}
+	if c.ReasoningOnly, err = parseField(temp.ReasoningOnly, false, strconv.ParseBool, "reasoning_only for credential '"+c.Name+"'"); err != nil {
 		return err
 	}
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -104,6 +104,22 @@ credentials:
 	assert.Equal(t, ResponseHeaderModeAllowlist, cfg.Server.ResponseHeaders.Mode)
 }
 
+func TestCredentialConfigReasoningOnly(t *testing.T) {
+	t.Setenv("TEST_REASONING_ONLY", "true")
+
+	var credential CredentialConfig
+	err := yaml.Unmarshal([]byte(`
+name: anthropic-reasoning
+type: anthropic
+api_key: key
+base_url: https://api.anthropic.com
+reasoning_only: os.environ/TEST_REASONING_ONLY
+`), &credential)
+
+	require.NoError(t, err)
+	assert.True(t, credential.ReasoningOnly)
+}
+
 func TestLoad_ResponseHeadersModeFromEnvironment(t *testing.T) {
 	t.Setenv("TEST_RESPONSE_HEADER_MODE", "ALLOWLIST")
 	configPath := filepath.Join(t.TempDir(), "config.yaml")

--- a/internal/litellmdb/model_table/model_table.go
+++ b/internal/litellmdb/model_table/model_table.go
@@ -347,6 +347,7 @@ func convertCredentialTableToConfig(cred queries.CredentialTable) config.Credent
 	if cred.CredentialInfo != nil {
 		cfg.Scopes = scope.NormalizeList(cred.CredentialInfo.AirScopes)
 		cfg.DeniedScopes = scope.NormalizeList(append(cred.CredentialInfo.AirDeniedScopes, cred.CredentialInfo.AirForbiddenScopes...))
+		cfg.ReasoningOnly = cred.CredentialInfo.AirReasoningOnly
 	}
 
 	fillCredentialFromParams(&cfg, cred.CredentialParams)

--- a/internal/litellmdb/model_table/model_table_helpers_test.go
+++ b/internal/litellmdb/model_table/model_table_helpers_test.go
@@ -160,6 +160,21 @@ func TestConvertCredentialTableToConfig_ProviderTypes(t *testing.T) {
 	}
 }
 
+func TestConvertCredentialTableToConfig_ReasoningOnly(t *testing.T) {
+	name := "anthropic-reasoning"
+	provider := "anthropic"
+
+	cfg := convertCredentialTableToConfig(queries.CredentialTable{
+		CredentialName: &name,
+		CredentialInfo: &queries.CredentialLiteLLMInfo{
+			CustomLLMProvider: &provider,
+			AirReasoningOnly:  true,
+		},
+	})
+
+	assert.True(t, cfg.ReasoningOnly)
+}
+
 // Helper to create string pointer
 func ptr(s string) *string {
 	return &s

--- a/internal/litellmdb/queries/credentials_table.go
+++ b/internal/litellmdb/queries/credentials_table.go
@@ -22,6 +22,7 @@ type CredentialLiteLLMInfo struct {
 	AirScopes          []string `json:"air_scopes,omitempty"`
 	AirDeniedScopes    []string `json:"air_denied_scopes,omitempty"`
 	AirForbiddenScopes []string `json:"air_forbidden_scopes,omitempty"`
+	AirReasoningOnly   bool     `json:"air_reasoning_only,omitempty"`
 }
 
 type CredentialTable struct {

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -79,6 +79,13 @@ func (p *Proxy) orchestrateRequest(
 		return nil, false
 	}
 
+	routingExclusions := p.reasoningOnlyExclusions(body)
+	triedCreds := GetTried(r.Context())
+	for name := range routingExclusions {
+		triedCreds[name] = true
+	}
+	r = r.WithContext(SetTried(r.Context(), triedCreds))
+
 	// proxyBody: body with the original alias restored.
 	// Proxy credentials handle their own model routing, so they must receive the
 	// alias ("anthropic/claude-sonnet-4.6"), not the provider-specific real name
@@ -119,7 +126,7 @@ func (p *Proxy) orchestrateRequest(
 		}
 	}
 
-	cred, ok := p.selectCredentialForModel(w, modelID, logCtx.SessionID, preferredCredentialName, logCtx)
+	cred, ok := p.selectCredentialForModel(w, modelID, logCtx.SessionID, preferredCredentialName, routingExclusions, logCtx)
 	if !ok {
 		return nil, false
 	}
@@ -686,6 +693,7 @@ func (p *Proxy) selectCredentialForModel(
 	modelID string,
 	sessionID string,
 	preferredCredentialName string,
+	exclude map[string]bool,
 	logCtx *RequestLogContext,
 ) (*config.CredentialConfig, bool) {
 	if p.modelManager != nil && p.modelManager.IsEnabled() && len(p.modelManager.GetCredentialsForModel(modelID)) == 0 {
@@ -707,7 +715,7 @@ func (p *Proxy) selectCredentialForModel(
 		return nil, false
 	}
 
-	if preferredCredentialName != "" {
+	if preferredCredentialName != "" && !exclude[preferredCredentialName] {
 		cred, err := p.balancer.NextSpecificScoped(preferredCredentialName, modelID, logCtx.Scope)
 		if err == nil {
 			p.logger.DebugContext(logCtx.Context(), "Responses API sticky routing: using credential from previous_response_id",
@@ -725,7 +733,7 @@ func (p *Proxy) selectCredentialForModel(
 	}
 
 	if sessionID != "" && p.sessionStore != nil {
-		if credName, ok := p.sessionStore.Get(sessionID, modelID); ok {
+		if credName, ok := p.sessionStore.Get(sessionID, modelID); ok && !exclude[credName] {
 			cred, err := p.balancer.NextSpecificScoped(credName, modelID, logCtx.Scope)
 			if err == nil {
 				p.logger.DebugContext(logCtx.Context(), "Session-sticky routing: using cached credential",
@@ -745,13 +753,13 @@ func (p *Proxy) selectCredentialForModel(
 		}
 	}
 
-	cred, err := p.balancer.NextForModelScoped(modelID, logCtx.Scope)
+	cred, err := p.balancer.NextForModelExcludingScoped(modelID, exclude, logCtx.Scope)
 	if err == nil {
 		return cred, true
 	}
 
 	fallbackErr := error(nil)
-	cred, fallbackErr = p.balancer.NextFallbackForModelScoped(modelID, logCtx.Scope)
+	cred, fallbackErr = p.balancer.NextFallbackForModelExcludingScoped(modelID, exclude, logCtx.Scope)
 	if fallbackErr == nil {
 		return cred, true
 	}

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -176,6 +176,7 @@ func TestSelectCredentialForModelMarksDirectSpendLogComplete(t *testing.T) {
 		"missing-model",
 		"",
 		"",
+		nil,
 		logCtx,
 	)
 
@@ -208,6 +209,7 @@ func TestSelectCredentialForModelLogsZeroCostRowWhenPriceUnavailable(t *testing.
 		"missing-model",
 		"",
 		"",
+		nil,
 		logCtx,
 	)
 

--- a/internal/proxy/reasoning_filter.go
+++ b/internal/proxy/reasoning_filter.go
@@ -1,0 +1,112 @@
+package proxy
+
+import (
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	"github.com/mixaill76/auto_ai_router/internal/monitoring"
+)
+
+func (p *Proxy) reasoningOnlyExclusions(body []byte) map[string]bool {
+	if requestUsesReasoning(body) {
+		return nil
+	}
+
+	excluded := make(map[string]bool)
+	for _, cred := range p.balancer.GetCredentialsSnapshot() {
+		if cred.ReasoningOnly {
+			excluded[cred.Name] = true
+			monitoring.CredentialSelectionRejected.WithLabelValues("reasoning_required").Inc()
+		}
+	}
+	return excluded
+}
+
+func requestUsesReasoning(body []byte) bool {
+	var request map[string]interface{}
+	if json.Unmarshal(body, &request) != nil {
+		return false
+	}
+	return mapUsesReasoning(request)
+}
+
+func mapUsesReasoning(fields map[string]interface{}) bool {
+	if value, ok := fields["reasoning_effort"]; ok && reasoningValueEnabled(value) {
+		return true
+	}
+	if value, ok := fields["reasoning"]; ok && reasoningValueEnabled(value) {
+		return true
+	}
+	if value, ok := fields["thinking"]; ok && reasoningValueEnabled(value) {
+		return true
+	}
+	if value, ok := fields["thinking_budget"]; ok && reasoningBudgetEnabled(value) {
+		return true
+	}
+	if value, ok := fields["thinking_level"]; ok && reasoningValueEnabled(value) {
+		return true
+	}
+	if nested, ok := fields["thinking_config"].(map[string]interface{}); ok && mapUsesReasoning(nested) {
+		return true
+	}
+	if nested, ok := fields["extra_body"].(map[string]interface{}); ok && mapUsesReasoning(nested) {
+		return true
+	}
+	return false
+}
+
+func reasoningValueEnabled(value interface{}) bool {
+	switch typed := value.(type) {
+	case string:
+		return reasoningStringEnabled(typed)
+	case bool:
+		return typed
+	case float64:
+		return typed != 0
+	case map[string]interface{}:
+		if effort, ok := typed["effort"]; ok {
+			if effort != nil {
+				return reasoningValueEnabled(effort)
+			}
+		}
+		if kind, ok := typed["type"]; ok {
+			if kind != nil {
+				return reasoningValueEnabled(kind)
+			}
+		}
+		if budget, ok := typed["budget_tokens"]; ok {
+			return reasoningBudgetEnabled(budget)
+		}
+		if budget, ok := typed["thinking_budget"]; ok {
+			return reasoningBudgetEnabled(budget)
+		}
+		if level, ok := typed["thinking_level"]; ok {
+			return reasoningValueEnabled(level)
+		}
+		return len(typed) > 0
+	default:
+		return false
+	}
+}
+
+func reasoningBudgetEnabled(value interface{}) bool {
+	switch typed := value.(type) {
+	case float64:
+		return typed != 0
+	case string:
+		budget, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		return err == nil && budget != 0
+	default:
+		return false
+	}
+}
+
+func reasoningStringEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "0", "false", "none", "disable", "disabled", "off":
+		return false
+	default:
+		return true
+	}
+}

--- a/internal/proxy/reasoning_filter_test.go
+++ b/internal/proxy/reasoning_filter_test.go
@@ -1,0 +1,63 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestUsesReasoning(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{name: "absent", body: `{"model":"claude","messages":[]}`},
+		{name: "effort", body: `{"reasoning_effort":"high"}`, want: true},
+		{name: "disabled effort", body: `{"reasoning_effort":"none"}`},
+		{name: "responses reasoning", body: `{"reasoning":{"effort":"medium"}}`, want: true},
+		{name: "responses default effort", body: `{"reasoning":{"effort":null,"summary":"auto"}}`, want: true},
+		{name: "anthropic thinking", body: `{"thinking":{"type":"enabled","budget_tokens":1024}}`, want: true},
+		{name: "adaptive thinking", body: `{"thinking":{"type":"adaptive"}}`, want: true},
+		{name: "disabled thinking", body: `{"thinking":{"type":"disabled"}}`},
+		{name: "gemini budget", body: `{"thinking_budget":-1}`, want: true},
+		{name: "gemini disabled budget", body: `{"thinking_budget":0}`},
+		{name: "nested extra body", body: `{"extra_body":{"reasoning_effort":"low"}}`, want: true},
+		{name: "include thoughts only", body: `{"thinking_config":{"include_thoughts":true}}`},
+		{name: "invalid json", body: `{`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, requestUsesReasoning([]byte(tt.body)))
+		})
+	}
+}
+
+func TestReasoningOnlyExclusions(t *testing.T) {
+	prx := NewTestProxyBuilder().WithCredentials(
+		config.CredentialConfig{Name: "reasoning", Type: config.ProviderTypeAnthropic, ReasoningOnly: true, RPM: -1},
+		config.CredentialConfig{Name: "general", Type: config.ProviderTypeAnthropic, RPM: -1},
+	).Build()
+
+	assert.Equal(t, map[string]bool{"reasoning": true}, prx.reasoningOnlyExclusions([]byte(`{"messages":[]}`)))
+	assert.Empty(t, prx.reasoningOnlyExclusions([]byte(`{"reasoning_effort":"high"}`)))
+}
+
+func TestSelectCredentialForModelSkipsReasoningOnly(t *testing.T) {
+	credentials := []config.CredentialConfig{
+		{Name: "reasoning", Type: config.ProviderTypeAnthropic, ReasoningOnly: true, RPM: -1},
+		{Name: "general", Type: config.ProviderTypeAnthropic, RPM: -1},
+	}
+	prx := NewTestProxyBuilder().WithCredentials(credentials...).Build()
+	logCtx := testLogCtx(t)
+	exclude := prx.reasoningOnlyExclusions([]byte(`{"messages":[]}`))
+
+	credential, ok := prx.selectCredentialForModel(httptest.NewRecorder(), "claude", "", "", exclude, logCtx)
+
+	require.True(t, ok)
+	assert.Equal(t, "general", credential.Name)
+}

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -139,7 +139,7 @@ func (p *Proxy) TryFallbackProxy(
 		if logCtx != nil {
 			visibility = logCtx.Scope
 		}
-		fallbackCred, err := p.balancer.NextFallbackProxyForModelScoped(modelID, visibility)
+		fallbackCred, err := p.balancer.NextFallbackProxyForModelExcludingScoped(modelID, triedCreds, visibility)
 		if err != nil {
 			if attempt == 0 {
 				p.logger.DebugContext(r.Context(), "No fallback proxy available for retry",


### PR DESCRIPTION
Adds `reasoning_only` credential filtering across selection, sticky routing, retries, and fallbacks.

Tests: `make test`, `make lint`