### PR TITLE
feat: пороги тарификации 32k/128k/256k для моделей

### DIFF
--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -76,6 +76,12 @@ For reference:
 | `output_cost_per_token`                                       | Regular output tokens                                                        |
 | `input_cost_per_token_above_200k_tokens`                      | Input rate for tokens beyond the 200k threshold                              |
 | `output_cost_per_token_above_200k_tokens`                     | Output rate for tokens beyond the 200k threshold                             |
+| `input_cost_per_token_above_32k_tokens`                       | Full-session input rate when prompt exceeds 32k tokens                       |
+| `output_cost_per_token_above_32k_tokens`                      | Full-session output rate when prompt exceeds 32k tokens                      |
+| `input_cost_per_token_above_128k_tokens`                      | Full-session input rate when prompt exceeds 128k tokens                      |
+| `output_cost_per_token_above_128k_tokens`                     | Full-session output rate when prompt exceeds 128k tokens                     |
+| `input_cost_per_token_above_256k_tokens`                      | Full-session input rate when prompt exceeds 256k tokens                      |
+| `output_cost_per_token_above_256k_tokens`                     | Full-session output rate when prompt exceeds 256k tokens                     |
 | `input_cost_per_token_above_272k_tokens`                      | Full-session input rate when prompt exceeds 272k tokens                      |
 | `output_cost_per_token_above_272k_tokens`                     | Full-session output rate when prompt exceeds 272k tokens                     |
 | `input_cost_per_audio_token`                                  | Audio input tokens (falls back to `input_cost_per_token` if absent)          |
@@ -90,6 +96,12 @@ For reference:
 | `cache_creation_input_token_cost_above_200k_tokens`           | Full-session 5m/unclassified cache write rate above 200k                     |
 | `cache_creation_input_token_cost_above_1hr`                   | Anthropic 1h cache write rate (falls back to regular cache write rate)       |
 | `cache_creation_input_token_cost_above_1hr_above_200k_tokens` | Anthropic 1h cache write rate above 200k                                     |
+| `cache_read_input_token_cost_above_32k_tokens`                | Full-session cache read rate when prompt exceeds 32k tokens                  |
+| `cache_creation_input_token_cost_above_32k_tokens`            | Full-session cache write rate when prompt exceeds 32k tokens                 |
+| `cache_read_input_token_cost_above_128k_tokens`               | Full-session cache read rate when prompt exceeds 128k tokens                 |
+| `cache_creation_input_token_cost_above_128k_tokens`           | Full-session cache write rate when prompt exceeds 128k tokens                |
+| `cache_read_input_token_cost_above_256k_tokens`               | Full-session cache read rate when prompt exceeds 256k tokens                 |
+| `cache_creation_input_token_cost_above_256k_tokens`           | Full-session cache write rate when prompt exceeds 256k tokens                |
 | `cache_read_input_token_cost_above_272k_tokens`               | Full-session cache read rate when prompt exceeds 272k tokens                 |
 | `cache_creation_input_token_cost_above_272k_tokens`           | Full-session cache write rate when prompt exceeds 272k tokens                |
 | `cache_read_input_audio_token_cost`                           | Cached audio input rate (falls back to the selected cache read rate)         |
@@ -191,11 +203,17 @@ input_cost = regular_below × input_cost_per_token
 
 The same logic applies to output tokens using `output_cost_per_token_above_200k_tokens`.
 
-Cache prices follow LiteLLM's full-session semantics: when `prompt_tokens > 200_000`, all cache read/write tokens use the matching `*_above_200k_tokens` rate. The 272k cache fields take precedence when both tiers are configured.
+Cache prices follow LiteLLM's full-session semantics: when `prompt_tokens > 200_000`, all cache read/write tokens use the matching `*_above_200k_tokens` rate. The 32k/128k/256k/272k full-session cache fields take precedence over the 200k tier whenever configured, with the highest exceeded threshold winning (see "Long-context pricing" below).
 
-### Long-context pricing (272k threshold)
+### Long-context pricing (32k / 128k / 256k / 272k full-session tiers)
 
-When the prompt exceeds 272 000 tokens, models such as GPT-5.6 apply their `*_above_272k_tokens` rates to the full session rather than only the tokens beyond the threshold. The prompt size selects the tier for regular input, output, cache reads, and cache writes. At exactly 272 000 tokens, base rates still apply.
+When the prompt exceeds one of these thresholds, the matching `*_above_<N>k_tokens` rate applies to the **full session** rather than only the tokens beyond the threshold — the prompt size selects the tier for regular input, output, cache reads, and cache writes. At exactly the threshold, base rates still apply (the check is strictly "greater than").
+
+272k was added first for models such as GPT-5.6; 32k/128k/256k were added for Alibaba Cloud models (Qwen 3.x, GLM) whose published pricing is a flat rate per input-length bracket (e.g. 0–32k / 32k–128k / 128k–256k / >256k) rather than an incremental rate for the overflow.
+
+A price entry may configure any subset of these four thresholds (e.g. only 32k and 256k, skipping 128k). For each cost component (input, output, cache read, cache write) independently, AIR picks the **highest configured threshold that the prompt exceeds**, in descending order 272k → 256k → 128k → 32k, and skips any threshold whose rate field isn't set. If none of the four apply, cost calculation falls back to the 200k proportional tier described above, then to the base rate.
+
+Example: a model with only `input_cost_per_token_above_128k_tokens` and `input_cost_per_token_above_256k_tokens` set bills a 150k-token prompt at the 128k rate and a 300k-token prompt at the 256k rate; a 100k-token prompt still uses the base rate.
 
 ### Specialised token types
 

--- a/internal/litellmdb/model_table/model_table.go
+++ b/internal/litellmdb/model_table/model_table.go
@@ -405,11 +405,29 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	if p.OutputCostPerToken != nil {
 		price.OutputCostPerToken = *p.OutputCostPerToken
 	}
+	if p.InputCostPerTokenAbove32kTokens != nil {
+		price.InputCostPerTokenAbove32k = *p.InputCostPerTokenAbove32kTokens
+	}
+	if p.OutputCostPerTokenAbove32kTokens != nil {
+		price.OutputCostPerTokenAbove32k = *p.OutputCostPerTokenAbove32kTokens
+	}
+	if p.InputCostPerTokenAbove128kTokens != nil {
+		price.InputCostPerTokenAbove128k = *p.InputCostPerTokenAbove128kTokens
+	}
+	if p.OutputCostPerTokenAbove128kTokens != nil {
+		price.OutputCostPerTokenAbove128k = *p.OutputCostPerTokenAbove128kTokens
+	}
 	if p.InputCostPerTokenAbove200kTokens != nil {
 		price.InputCostPerTokenAbove200k = *p.InputCostPerTokenAbove200kTokens
 	}
 	if p.OutputCostPerTokenAbove200kTokens != nil {
 		price.OutputCostPerTokenAbove200k = *p.OutputCostPerTokenAbove200kTokens
+	}
+	if p.InputCostPerTokenAbove256kTokens != nil {
+		price.InputCostPerTokenAbove256k = *p.InputCostPerTokenAbove256kTokens
+	}
+	if p.OutputCostPerTokenAbove256kTokens != nil {
+		price.OutputCostPerTokenAbove256k = *p.OutputCostPerTokenAbove256kTokens
 	}
 	if p.InputCostPerTokenAbove272kTokens != nil {
 		price.InputCostPerTokenAbove272k = *p.InputCostPerTokenAbove272kTokens
@@ -432,11 +450,29 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	if p.CacheCreationInputTokenCost != nil {
 		price.CacheCreationInputTokenCost = *p.CacheCreationInputTokenCost
 	}
+	if p.CacheReadInputTokenCostAbove32kTokens != nil {
+		price.CacheReadInputTokenCostAbove32k = *p.CacheReadInputTokenCostAbove32kTokens
+	}
+	if p.CacheCreationInputTokenCostAbove32kTokens != nil {
+		price.CacheCreationInputTokenCostAbove32k = *p.CacheCreationInputTokenCostAbove32kTokens
+	}
+	if p.CacheReadInputTokenCostAbove128kTokens != nil {
+		price.CacheReadInputTokenCostAbove128k = *p.CacheReadInputTokenCostAbove128kTokens
+	}
+	if p.CacheCreationInputTokenCostAbove128kTokens != nil {
+		price.CacheCreationInputTokenCostAbove128k = *p.CacheCreationInputTokenCostAbove128kTokens
+	}
 	if p.CacheReadInputTokenCostAbove200kTokens != nil {
 		price.CacheReadInputTokenCostAbove200k = *p.CacheReadInputTokenCostAbove200kTokens
 	}
 	if p.CacheCreationInputTokenCostAbove200kTokens != nil {
 		price.CacheCreationInputTokenCostAbove200k = *p.CacheCreationInputTokenCostAbove200kTokens
+	}
+	if p.CacheReadInputTokenCostAbove256kTokens != nil {
+		price.CacheReadInputTokenCostAbove256k = *p.CacheReadInputTokenCostAbove256kTokens
+	}
+	if p.CacheCreationInputTokenCostAbove256kTokens != nil {
+		price.CacheCreationInputTokenCostAbove256k = *p.CacheCreationInputTokenCostAbove256kTokens
 	}
 	if p.CacheCreationInputTokenCostAbove1hr != nil {
 		price.CacheCreationInputTokenCostAbove1hr = *p.CacheCreationInputTokenCostAbove1hr

--- a/internal/litellmdb/model_table/model_table_test.go
+++ b/internal/litellmdb/model_table/model_table_test.go
@@ -160,8 +160,14 @@ func TestConvertPricingToModelPrice(t *testing.T) {
 func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	input := 0.01
 	output := 0.02
+	inputAbove32k := 0.021
+	outputAbove32k := 0.022
+	inputAbove128k := 0.023
+	outputAbove128k := 0.024
 	inputAbove200k := 0.03
 	outputAbove200k := 0.04
+	inputAbove256k := 0.041
+	outputAbove256k := 0.042
 	inputAbove272k := 0.045
 	outputAbove272k := 0.047
 	inputAudio := 0.05
@@ -169,8 +175,14 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	outputReasoning := 0.07
 	cacheRead := 0.08
 	cacheCreation := 0.085
+	cacheReadAbove32k := 0.0811
+	cacheCreationAbove32k := 0.0812
+	cacheReadAbove128k := 0.0821
+	cacheCreationAbove128k := 0.0822
 	cacheReadAbove200k := 0.084
 	cacheCreationAbove200k := 0.0845
+	cacheReadAbove256k := 0.0846
+	cacheCreationAbove256k := 0.0847
 	cacheCreationAbove1hr := 0.0855
 	cacheCreationAbove1hrAbove200k := 0.0857
 	cacheReadAbove272k := 0.086
@@ -188,8 +200,14 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	price := convertPricingToModelPrice(&queries.CustomPricingLiteLLMParams{
 		InputCostPerToken:                                  &input,
 		OutputCostPerToken:                                 &output,
+		InputCostPerTokenAbove32kTokens:                    &inputAbove32k,
+		OutputCostPerTokenAbove32kTokens:                   &outputAbove32k,
+		InputCostPerTokenAbove128kTokens:                   &inputAbove128k,
+		OutputCostPerTokenAbove128kTokens:                  &outputAbove128k,
 		InputCostPerTokenAbove200kTokens:                   &inputAbove200k,
 		OutputCostPerTokenAbove200kTokens:                  &outputAbove200k,
+		InputCostPerTokenAbove256kTokens:                   &inputAbove256k,
+		OutputCostPerTokenAbove256kTokens:                  &outputAbove256k,
 		InputCostPerTokenAbove272kTokens:                   &inputAbove272k,
 		OutputCostPerTokenAbove272kTokens:                  &outputAbove272k,
 		InputCostPerAudioToken:                             &inputAudio,
@@ -197,8 +215,14 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 		OutputCostPerReasoningToken:                        &outputReasoning,
 		CacheReadInputTokenCost:                            &cacheRead,
 		CacheCreationInputTokenCost:                        &cacheCreation,
+		CacheReadInputTokenCostAbove32kTokens:              &cacheReadAbove32k,
+		CacheCreationInputTokenCostAbove32kTokens:          &cacheCreationAbove32k,
+		CacheReadInputTokenCostAbove128kTokens:             &cacheReadAbove128k,
+		CacheCreationInputTokenCostAbove128kTokens:         &cacheCreationAbove128k,
 		CacheReadInputTokenCostAbove200kTokens:             &cacheReadAbove200k,
 		CacheCreationInputTokenCostAbove200kTokens:         &cacheCreationAbove200k,
+		CacheReadInputTokenCostAbove256kTokens:             &cacheReadAbove256k,
+		CacheCreationInputTokenCostAbove256kTokens:         &cacheCreationAbove256k,
 		CacheCreationInputTokenCostAbove1hr:                &cacheCreationAbove1hr,
 		CacheCreationInputTokenCostAbove1hrAbove200kTokens: &cacheCreationAbove1hrAbove200k,
 		CacheReadInputTokenCostAbove272kTokens:             &cacheReadAbove272k,
@@ -213,8 +237,14 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	assert.NotNil(t, price)
 	assert.Equal(t, input, price.InputCostPerToken)
 	assert.Equal(t, output, price.OutputCostPerToken)
+	assert.Equal(t, inputAbove32k, price.InputCostPerTokenAbove32k)
+	assert.Equal(t, outputAbove32k, price.OutputCostPerTokenAbove32k)
+	assert.Equal(t, inputAbove128k, price.InputCostPerTokenAbove128k)
+	assert.Equal(t, outputAbove128k, price.OutputCostPerTokenAbove128k)
 	assert.Equal(t, inputAbove200k, price.InputCostPerTokenAbove200k)
 	assert.Equal(t, outputAbove200k, price.OutputCostPerTokenAbove200k)
+	assert.Equal(t, inputAbove256k, price.InputCostPerTokenAbove256k)
+	assert.Equal(t, outputAbove256k, price.OutputCostPerTokenAbove256k)
 	assert.Equal(t, inputAbove272k, price.InputCostPerTokenAbove272k)
 	assert.Equal(t, outputAbove272k, price.OutputCostPerTokenAbove272k)
 	assert.Equal(t, inputAudio, price.InputCostPerAudioToken)
@@ -222,8 +252,14 @@ func TestConvertPricingToModelPrice_AllFields(t *testing.T) {
 	assert.Equal(t, outputReasoning, price.OutputCostPerReasoningToken)
 	assert.Equal(t, cacheRead, price.InputCostPerCachedToken)
 	assert.Equal(t, cacheCreation, price.CacheCreationInputTokenCost)
+	assert.Equal(t, cacheReadAbove32k, price.CacheReadInputTokenCostAbove32k)
+	assert.Equal(t, cacheCreationAbove32k, price.CacheCreationInputTokenCostAbove32k)
+	assert.Equal(t, cacheReadAbove128k, price.CacheReadInputTokenCostAbove128k)
+	assert.Equal(t, cacheCreationAbove128k, price.CacheCreationInputTokenCostAbove128k)
 	assert.Equal(t, cacheReadAbove200k, price.CacheReadInputTokenCostAbove200k)
 	assert.Equal(t, cacheCreationAbove200k, price.CacheCreationInputTokenCostAbove200k)
+	assert.Equal(t, cacheReadAbove256k, price.CacheReadInputTokenCostAbove256k)
+	assert.Equal(t, cacheCreationAbove256k, price.CacheCreationInputTokenCostAbove256k)
 	assert.Equal(t, cacheCreationAbove1hr, price.CacheCreationInputTokenCostAbove1hr)
 	assert.Equal(t, cacheCreationAbove1hrAbove200k, price.CacheCreationInputTokenCostAbove1hrAbove200k)
 	assert.Equal(t, cacheReadAbove272k, price.CacheReadInputTokenCostAbove272k)

--- a/internal/litellmdb/queries/model_table.go
+++ b/internal/litellmdb/queries/model_table.go
@@ -8,8 +8,10 @@ const QueryProxyModelTable = `SELECT model_id, model_name, litellm_params, model
 type CustomPricingLiteLLMParams struct {
 	InputCostPerToken                 *float64 `json:"input_cost_per_token,omitempty"`
 	OutputCostPerToken                *float64 `json:"output_cost_per_token,omitempty"`
+	OutputCostPerTokenAbove32kTokens  *float64 `json:"output_cost_per_token_above_32k_tokens,omitempty"`
 	OutputCostPerTokenAbove128kTokens *float64 `json:"output_cost_per_token_above_128k_tokens,omitempty"`
 	OutputCostPerTokenAbove200kTokens *float64 `json:"output_cost_per_token_above_200k_tokens,omitempty"`
+	OutputCostPerTokenAbove256kTokens *float64 `json:"output_cost_per_token_above_256k_tokens,omitempty"`
 	OutputCostPerTokenAbove272kTokens *float64 `json:"output_cost_per_token_above_272k_tokens,omitempty"`
 
 	InputCostPerSecond  *float64 `json:"input_cost_per_second,omitempty"`
@@ -18,16 +20,24 @@ type CustomPricingLiteLLMParams struct {
 	// Гибкие настройки стоимости (Flex/Priority/Cache)
 	CacheReadInputTokenCost                            *float64 `json:"cache_read_input_token_cost,omitempty"`
 	CacheCreationInputTokenCost                        *float64 `json:"cache_creation_input_token_cost,omitempty"`
+	CacheReadInputTokenCostAbove32kTokens              *float64 `json:"cache_read_input_token_cost_above_32k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove32kTokens          *float64 `json:"cache_creation_input_token_cost_above_32k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove128kTokens             *float64 `json:"cache_read_input_token_cost_above_128k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove128kTokens         *float64 `json:"cache_creation_input_token_cost_above_128k_tokens,omitempty"`
 	CacheReadInputTokenCostAbove200kTokens             *float64 `json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove200kTokens         *float64 `json:"cache_creation_input_token_cost_above_200k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove256kTokens             *float64 `json:"cache_read_input_token_cost_above_256k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove256kTokens         *float64 `json:"cache_creation_input_token_cost_above_256k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove1hr                *float64 `json:"cache_creation_input_token_cost_above_1hr,omitempty"`
 	CacheCreationInputTokenCostAbove1hrAbove200kTokens *float64 `json:"cache_creation_input_token_cost_above_1hr_above_200k_tokens,omitempty"`
 	CacheReadInputTokenCostAbove272kTokens             *float64 `json:"cache_read_input_token_cost_above_272k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove272kTokens         *float64 `json:"cache_creation_input_token_cost_above_272k_tokens,omitempty"`
 	CacheReadInputAudioTokenCost                       *float64 `json:"cache_read_input_audio_token_cost,omitempty"`
 
+	InputCostPerTokenAbove32kTokens  *float64 `json:"input_cost_per_token_above_32k_tokens,omitempty"`
 	InputCostPerTokenAbove128kTokens *float64 `json:"input_cost_per_token_above_128k_tokens,omitempty"`
 	InputCostPerTokenAbove200kTokens *float64 `json:"input_cost_per_token_above_200k_tokens,omitempty"`
+	InputCostPerTokenAbove256kTokens *float64 `json:"input_cost_per_token_above_256k_tokens,omitempty"`
 	InputCostPerTokenAbove272kTokens *float64 `json:"input_cost_per_token_above_272k_tokens,omitempty"`
 
 	InputCostPerAudioToken                    *float64 `json:"input_cost_per_audio_token,omitempty"`

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -36,6 +36,25 @@ type ModelPrice struct {
 	InputCostPerTokenAbove272k  float64 `json:"input_cost_per_token_above_272k_tokens,omitempty"`
 	OutputCostPerTokenAbove272k float64 `json:"output_cost_per_token_above_272k_tokens,omitempty"`
 
+	// Full-session tiered pricing (Alibaba Cloud style): once the prompt
+	// exceeds the threshold, the entire request is billed at that tier's
+	// rate rather than only the tokens beyond it. Same semantics as the
+	// 272k tier above, generalised to more brackets.
+	InputCostPerTokenAbove32k           float64 `json:"input_cost_per_token_above_32k_tokens,omitempty"`
+	OutputCostPerTokenAbove32k          float64 `json:"output_cost_per_token_above_32k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove32k     float64 `json:"cache_read_input_token_cost_above_32k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove32k float64 `json:"cache_creation_input_token_cost_above_32k_tokens,omitempty"`
+
+	InputCostPerTokenAbove128k           float64 `json:"input_cost_per_token_above_128k_tokens,omitempty"`
+	OutputCostPerTokenAbove128k          float64 `json:"output_cost_per_token_above_128k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove128k     float64 `json:"cache_read_input_token_cost_above_128k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove128k float64 `json:"cache_creation_input_token_cost_above_128k_tokens,omitempty"`
+
+	InputCostPerTokenAbove256k           float64 `json:"input_cost_per_token_above_256k_tokens,omitempty"`
+	OutputCostPerTokenAbove256k          float64 `json:"output_cost_per_token_above_256k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove256k     float64 `json:"cache_read_input_token_cost_above_256k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove256k float64 `json:"cache_creation_input_token_cost_above_256k_tokens,omitempty"`
+
 	// Audio tokens (can be more specific than regular tokens)
 	InputCostPerAudioToken  float64 `json:"input_cost_per_audio_token,omitempty"`
 	OutputCostPerAudioToken float64 `json:"output_cost_per_audio_token,omitempty"`

--- a/internal/models/price_calculator.go
+++ b/internal/models/price_calculator.go
@@ -9,8 +9,76 @@ import (
 
 const (
 	tokenTiering200kThreshold = 200_000
+	tokenTiering32kThreshold  = 32_000
+	tokenTiering128kThreshold = 128_000
+	tokenTiering256kThreshold = 256_000
 	tokenTiering272kThreshold = 272_000
 )
+
+// fullSessionTier describes one "Alibaba Cloud style" pricing bracket: once
+// the prompt exceeds threshold, the ENTIRE request (not just the excess) is
+// billed at this tier's rates. Zero-value rates mean "not configured for
+// this tier" and are skipped by fullSessionRate.
+type fullSessionTier struct {
+	threshold         int
+	inputRate         float64
+	outputRate        float64
+	cacheReadRate     float64
+	cacheCreationRate float64
+}
+
+// fullSessionTiers returns the configured full-session tiers in descending
+// threshold order, so the first matching entry is always the highest
+// (most specific) bracket the prompt has crossed.
+func fullSessionTiers(price *ModelPrice) []fullSessionTier {
+	return []fullSessionTier{
+		{
+			threshold:         tokenTiering272kThreshold,
+			inputRate:         price.InputCostPerTokenAbove272k,
+			outputRate:        price.OutputCostPerTokenAbove272k,
+			cacheReadRate:     price.CacheReadInputTokenCostAbove272k,
+			cacheCreationRate: price.CacheCreationInputTokenCostAbove272k,
+		},
+		{
+			threshold:         tokenTiering256kThreshold,
+			inputRate:         price.InputCostPerTokenAbove256k,
+			outputRate:        price.OutputCostPerTokenAbove256k,
+			cacheReadRate:     price.CacheReadInputTokenCostAbove256k,
+			cacheCreationRate: price.CacheCreationInputTokenCostAbove256k,
+		},
+		{
+			threshold:         tokenTiering128kThreshold,
+			inputRate:         price.InputCostPerTokenAbove128k,
+			outputRate:        price.OutputCostPerTokenAbove128k,
+			cacheReadRate:     price.CacheReadInputTokenCostAbove128k,
+			cacheCreationRate: price.CacheCreationInputTokenCostAbove128k,
+		},
+		{
+			threshold:         tokenTiering32kThreshold,
+			inputRate:         price.InputCostPerTokenAbove32k,
+			outputRate:        price.OutputCostPerTokenAbove32k,
+			cacheReadRate:     price.CacheReadInputTokenCostAbove32k,
+			cacheCreationRate: price.CacheCreationInputTokenCostAbove32k,
+		},
+	}
+}
+
+// fullSessionRate walks tiers (already sorted by descending threshold) and
+// returns the rate selected by pick for the first tier whose threshold is
+// exceeded by promptTokens and whose selected rate is actually configured
+// (non-zero). Returns ok=false when no full-session tier applies, in which
+// case callers should fall back to the existing 200k-proportional/base rate.
+func fullSessionRate(tiers []fullSessionTier, promptTokens int, pick func(fullSessionTier) float64) (rate float64, ok bool) {
+	for _, tier := range tiers {
+		if promptTokens <= tier.threshold {
+			continue
+		}
+		if r := pick(tier); r > 0 {
+			return r, true
+		}
+	}
+	return 0, false
+}
 
 // CalculateTokenCosts computes costs based on token usage and model pricing
 // Returns nil if price is nil (model not found in pricing database)
@@ -52,14 +120,23 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	rejectedPredictionTokens := converterutil.NonNegativeTokenCount(usage.RejectedPredictionTokens)
 	imageCount := converterutil.NonNegativeTokenCount(usage.ImageCount)
 
-	longContext272k := promptTokens > tokenTiering272kThreshold
+	// Full-session tiers (32k/128k/256k/272k): the highest exceeded threshold
+	// whose rate is configured wins and applies to the WHOLE request, not
+	// just the excess. Falls back to the 200k proportional tier (unchanged
+	// below) when no full-session tier matches.
+	tiers := fullSessionTiers(price)
+	fullSessionInputRate, fullSessionInputMatched := fullSessionRate(tiers, promptTokens, func(t fullSessionTier) float64 { return t.inputRate })
+	fullSessionOutputRate, fullSessionOutputMatched := fullSessionRate(tiers, promptTokens, func(t fullSessionTier) float64 { return t.outputRate })
+	fullSessionCacheReadRate, fullSessionCacheReadMatched := fullSessionRate(tiers, promptTokens, func(t fullSessionTier) float64 { return t.cacheReadRate })
+	fullSessionCacheCreationRate, fullSessionCacheCreationMatched := fullSessionRate(tiers, promptTokens, func(t fullSessionTier) float64 { return t.cacheCreationRate })
+
 	inputCostPerToken := price.InputCostPerToken
-	if longContext272k && price.InputCostPerTokenAbove272k > 0 {
-		inputCostPerToken = price.InputCostPerTokenAbove272k
+	if fullSessionInputMatched {
+		inputCostPerToken = fullSessionInputRate
 	}
 	outputCostPerToken := price.OutputCostPerToken
-	if longContext272k && price.OutputCostPerTokenAbove272k > 0 {
-		outputCostPerToken = price.OutputCostPerTokenAbove272k
+	if fullSessionOutputMatched {
+		outputCostPerToken = fullSessionOutputRate
 	}
 
 	cachedInputTokens := converterutil.NonNegativeTokenCount(usage.CachedInputTokens)
@@ -72,8 +149,8 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 		regularInputTokens = 0
 	}
 
-	// Regular input with 200k tiering
-	if longContext272k && price.InputCostPerTokenAbove272k > 0 {
+	// Regular input with full-session or 200k tiering
+	if fullSessionInputMatched {
 		costs.InputCost = float64(regularInputTokens) * inputCostPerToken
 	} else if price.InputCostPerTokenAbove200k > 0 && promptTokens > tokenTiering200kThreshold {
 		above := promptTokens - tokenTiering200kThreshold
@@ -96,8 +173,8 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 		regularOutputTokens = 0
 	}
 
-	// Regular output with 200k tiering
-	if longContext272k && price.OutputCostPerTokenAbove272k > 0 {
+	// Regular output with full-session or 200k tiering
+	if fullSessionOutputMatched {
 		costs.OutputCost = float64(regularOutputTokens) * outputCostPerToken
 	} else if price.OutputCostPerTokenAbove200k > 0 && completionTokens > tokenTiering200kThreshold {
 		above := completionTokens - tokenTiering200kThreshold
@@ -129,8 +206,8 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 	if cachedInputCost == 0 {
 		cachedInputCost = price.CacheReadInputTokenCost
 	}
-	if longContext272k && price.CacheReadInputTokenCostAbove272k > 0 {
-		cachedInputCost = price.CacheReadInputTokenCostAbove272k
+	if fullSessionCacheReadMatched {
+		cachedInputCost = fullSessionCacheReadRate
 	} else if promptTokens > tokenTiering200kThreshold && price.CacheReadInputTokenCostAbove200k > 0 {
 		cachedInputCost = price.CacheReadInputTokenCostAbove200k
 	}
@@ -150,10 +227,10 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 		float64(cachedAudioTokens)*cachedAudioCost
 
 	cacheCreationCost := price.CacheCreationInputTokenCost
-	cacheCreationUses272kRate := false
-	if longContext272k && price.CacheCreationInputTokenCostAbove272k > 0 {
-		cacheCreationCost = price.CacheCreationInputTokenCostAbove272k
-		cacheCreationUses272kRate = true
+	cacheCreationFullSession := false
+	if fullSessionCacheCreationMatched {
+		cacheCreationCost = fullSessionCacheCreationRate
+		cacheCreationFullSession = true
 	} else if promptTokens > tokenTiering200kThreshold && price.CacheCreationInputTokenCostAbove200k > 0 {
 		cacheCreationCost = price.CacheCreationInputTokenCostAbove200k
 	}
@@ -161,7 +238,7 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 		cacheCreationCost = inputCostPerToken
 	}
 	cacheCreation1hCost := cacheCreationCost
-	if !cacheCreationUses272kRate {
+	if !cacheCreationFullSession {
 		cacheCreation1hCost = price.CacheCreationInputTokenCostAbove1hr
 		if promptTokens > tokenTiering200kThreshold && price.CacheCreationInputTokenCostAbove1hrAbove200k > 0 {
 			cacheCreation1hCost = price.CacheCreationInputTokenCostAbove1hrAbove200k

--- a/internal/models/price_calculator_test.go
+++ b/internal/models/price_calculator_test.go
@@ -906,3 +906,180 @@ func TestCalculateTokenCosts_WebSearchDefaultsToMedium(t *testing.T) {
 	assert.InDelta(t, 0.20, costs.WebSearchCost, 1e-9)
 	assert.InDelta(t, 0.20, costs.TotalCost, 1e-9)
 }
+
+// --- Alibaba Cloud style full-session tiers: 32k / 128k / 256k ---
+
+func TestCalculateTokenCosts_Above32kFullSession(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens:     40_000,
+		CompletionTokens: 1_000,
+	}
+	price := &ModelPrice{
+		InputCostPerToken:          0.01,
+		OutputCostPerToken:         0.02,
+		InputCostPerTokenAbove32k:  0.005,
+		OutputCostPerTokenAbove32k: 0.01,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	// Full session: the WHOLE prompt/completion is billed at the above-32k
+	// rate, not just the tokens beyond 32k.
+	assert.InDelta(t, 200.0, costs.InputCost, 1e-9) // 40_000 * 0.005
+	assert.InDelta(t, 10.0, costs.OutputCost, 1e-9) // 1_000 * 0.01
+	assert.InDelta(t, 210.0, costs.TotalCost, 1e-9)
+}
+
+func TestCalculateTokenCosts_32kThresholdIsExclusive(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens: tokenTiering32kThreshold,
+	}
+	price := &ModelPrice{
+		InputCostPerToken:         0.01,
+		InputCostPerTokenAbove32k: 0.005,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	// Exactly at the threshold: still base rate, tier only applies strictly above it.
+	assert.InDelta(t, 320.0, costs.InputCost, 1e-9) // 32_000 * 0.01
+}
+
+func TestCalculateTokenCosts_Above128kFullSession(t *testing.T) {
+	usage := &converter.TokenUsage{PromptTokens: 150_000}
+	price := &ModelPrice{
+		InputCostPerToken:          0.001,
+		InputCostPerTokenAbove128k: 0.0006,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 90.0, costs.InputCost, 1e-9) // 150_000 * 0.0006
+}
+
+func TestCalculateTokenCosts_Above256kFullSession(t *testing.T) {
+	usage := &converter.TokenUsage{PromptTokens: 300_000}
+	price := &ModelPrice{
+		InputCostPerToken:          0.001,
+		InputCostPerTokenAbove256k: 0.0004,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 120.0, costs.InputCost, 1e-9) // 300_000 * 0.0004
+}
+
+func TestCalculateTokenCosts_MultiTierLadder_128kAnd256k(t *testing.T) {
+	// Mirrors qwen3.5-plus: two brackets configured, base rate below both.
+	price := &ModelPrice{
+		InputCostPerToken:          0.002,
+		InputCostPerTokenAbove128k: 0.0015,
+		InputCostPerTokenAbove256k: 0.001,
+	}
+
+	tests := []struct {
+		name         string
+		promptTokens int
+		wantInput    float64
+	}{
+		{"below_128k_uses_base_rate", 100_000, 200.0},            // 100_000 * 0.002
+		{"between_128k_and_256k_uses_128k_rate", 150_000, 225.0}, // 150_000 * 0.0015
+		{"above_256k_uses_256k_rate", 300_000, 300.0},            // 300_000 * 0.001
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			costs := CalculateTokenCosts(&converter.TokenUsage{PromptTokens: tt.promptTokens}, price)
+			require.NotNil(t, costs)
+			assert.InDelta(t, tt.wantInput, costs.InputCost, 1e-9)
+		})
+	}
+}
+
+func TestCalculateTokenCosts_LadderSkipsUnconfiguredTier(t *testing.T) {
+	// Mirrors qwen3.7-flash: 32k and 256k configured, 128k intentionally left
+	// unset. A prompt between the two configured thresholds must still fall
+	// through to the 32k rate rather than the base rate.
+	price := &ModelPrice{
+		InputCostPerToken:          0.003,
+		InputCostPerTokenAbove32k:  0.0025,
+		InputCostPerTokenAbove256k: 0.001,
+	}
+
+	tests := []struct {
+		name         string
+		promptTokens int
+		wantInput    float64
+	}{
+		{"between_32k_and_256k_uses_32k_rate", 150_000, 375.0}, // 150_000 * 0.0025
+		{"above_256k_uses_256k_rate", 300_000, 300.0},          // 300_000 * 0.001
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			costs := CalculateTokenCosts(&converter.TokenUsage{PromptTokens: tt.promptTokens}, price)
+			require.NotNil(t, costs)
+			assert.InDelta(t, tt.wantInput, costs.InputCost, 1e-9)
+		})
+	}
+}
+
+func TestCalculateTokenCosts_272kTakesPrecedenceOver256k(t *testing.T) {
+	usage := &converter.TokenUsage{PromptTokens: 280_000} // above both 256k and 272k
+	price := &ModelPrice{
+		InputCostPerToken:          0.01,
+		InputCostPerTokenAbove256k: 0.001,
+		InputCostPerTokenAbove272k: 0.0009,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 252.0, costs.InputCost, 1e-9) // 280_000 * 0.0009, not the 256k rate
+}
+
+func TestCalculateTokenCosts_CacheTierOverridesBaseCacheRate(t *testing.T) {
+	// Mirrors qwen3-vl-flash: a non-zero BASE cache_read rate is configured
+	// alongside a tiered one. The base rate must not "win" once the prompt
+	// crosses the threshold — the fallback-to-base-rate path only applies
+	// when no explicit cache rate is configured at all.
+	usage := &converter.TokenUsage{
+		PromptTokens:      40_000,
+		CachedInputTokens: 1_000,
+	}
+	price := &ModelPrice{
+		InputCostPerToken:               0.01,
+		CacheReadInputTokenCost:         0.0001, // base cache rate (non-zero)
+		CacheReadInputTokenCostAbove32k: 0.00005,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 0.05, costs.CachedInputCost, 1e-9) // 1_000 * 0.00005, NOT 1_000 * 0.0001
+}
+
+func TestCalculateTokenCosts_CacheAbove32kFullSession(t *testing.T) {
+	usage := &converter.TokenUsage{
+		PromptTokens:        50_000,
+		CachedInputTokens:   1_000,
+		CacheCreationTokens: 500,
+	}
+	price := &ModelPrice{
+		InputCostPerToken:                   0.01,
+		CacheReadInputTokenCost:             0.001,
+		CacheReadInputTokenCostAbove32k:     0.0005,
+		CacheCreationInputTokenCost:         0.002,
+		CacheCreationInputTokenCostAbove32k: 0.0015,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 0.5, costs.CachedInputCost, 1e-9)    // 1_000 * 0.0005
+	assert.InDelta(t, 0.75, costs.CacheCreationCost, 1e-9) // 500 * 0.0015
+}


### PR DESCRIPTION
## Что сделано

В Alibaba Cloud стоимость некоторых моделей зависит от диапазона входных токенов — роутер поддерживал только пороги 200k (пропорционально, только избыток) и 272k (весь запрос по повышенной ставке). Добавлены новые полносессионные пороги **32k / 128k / 256k**, работающие по той же логике, что и 272k: весь запрос (а не только токены сверх порога) биллится по ставке выбранного порога.

### Ключевые правки

- **`internal/models/manager.go`** — в `ModelPrice` добавлено 12 новых полей: для каждого из порогов 32k/128k/256k — ставки на input, output, чтение кэша (cache read) и запись кэша (cache creation).
- **`internal/models/price_calculator.go`** — старая логика "если больше 272k — используем спецставку" обобщена в отсортированный список порогов (272k → 256k → 128k → 32k). Для input, output, cache read и cache creation **отдельно** выбирается самый высокий превышенный порог, у которого задана ненулевая ставка — она применяется ко всей позиции целиком. Модель может задавать любое подмножество порогов (например, только 32k и 256k, пропуская 128k) — логика это корректно обрабатывает. Порог 200k (пропорциональный, старая семантика) не тронут вообще.
- **`internal/models/price_calculator_test.go`** — добавлено 9 новых тестов: отдельно по каждому порогу, лестница из двух порогов (128k+256k), пропуск незаданного порога (32k+256k без 128k, как у qwen3.7-flash), приоритет 272k над 256k, а также explicit-тест на то, что тарифная ставка кэша побеждает базовую (не тарифную), если обе заданы одновременно — реальный кейс qwen3-vl-flash.
- **`docs/litellm-integration/pricing.md`** — задокументированы новые поля и обновлено описание секции "Long-context pricing" под общую лестницу порогов.

### Модели, для которых нужны новые пороги

qwen3.7-plus (256k), qwen3.6-plus (256k), qwen3.6-flash (256k), qwen3.5-plus (128k, 256k), qwen3.5-flash (128k, 256k), qwen3.5-397b-a17b (128k), qwen3-vl-flash (32k, 128k), qwen3-vl-plus (32k, 128k), glm-5.1 (32k), qwen3.7-flash (32k, 256k), qwen3-max-2026-01-23 (32k, 128k), qwen3.6-max-preview (128k), qwen3-coder-next (32k, 128k). Тарифы для implicit cache hit (автокэш) добавлены для qwen3.7-plus, qwen3-vl-flash, qwen3-vl-plus, glm-5.1 и qwen3.7-flash.

## Проверка

- `go build ./...`, `go vet ./...`, `golangci-lint run` — чисто.
- `go test ./...` по всему репозиторию — без регрессий, новые тесты зелёные.
- Проверено живыми запросами через реальный ключ на 12 из 13 моделей: реальный `usage.prompt_tokens`, вернувшийся от провайдера, корректно определяет нужный порог, а посчитанный AIR spend точно совпадает с ожидаемым по тарифу (сверено по `LiteLLM_SpendLogs`). Единственное исключение — `qwen3-vl-plus`, у которого сам relay стабильно отдаёт 524 (gateway timeout) на промптах 120k+ токенов — это не связано с логикой тарификации.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run`
- [x] Живая проверка тарифных порогов на реальных запросах (12/13 моделей)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>