### PR TITLE
Drop LiteLLM session ID

### DIFF
--- a/docs/advanced/session_sticky.md
+++ b/docs/advanced/session_sticky.md
@@ -143,6 +143,7 @@ The proxy extracts a session ID from the request body in the following priority 
 | Field                           | Location                          |
 | ------------------------------- | --------------------------------- |
 | `extra_body.litellm_session_id` | nested in `extra_body`            |
+| `litellm_session_id`            | top-level field                   |
 | `extra_body.chat_id`            | nested in `extra_body`            |
 | `extra_body.session_id`         | nested in `extra_body`            |
 | `session_id`                    | top-level field                   |

--- a/internal/proxy/response_helpers.go
+++ b/internal/proxy/response_helpers.go
@@ -194,6 +194,9 @@ func extractSessionIDFromRawBody(reqBody map[string]goccyjson.RawMessage) string
 			}
 		}
 	}
+	if sid, ok := rawJSONString(reqBody["litellm_session_id"]); ok && sid != "" {
+		return sid
+	}
 	if sid, ok := rawJSONString(reqBody["session_id"]); ok && sid != "" {
 		return sid
 	}
@@ -350,9 +353,12 @@ func sanitizeJSONRequestBody(body []byte) (sanitizedRequestBody, error) {
 	}
 	result.ModelID = model
 
-	// Extract session ID (check extra_body first, then root level)
-	// Priority: litellm_session_id > chat_id > session_id > user > safety_identifier > prompt_cache_key
+	// Extract session ID before removing LiteLLM-only request metadata.
 	result.SessionID = extractSessionIDFromRawBody(reqBody)
+	if _, exists := reqBody["litellm_session_id"]; exists {
+		delete(reqBody, "litellm_session_id")
+		changed = true
+	}
 
 	// Check if this is a streaming request
 	stream, _ := rawJSONBool(reqBody["stream"])

--- a/internal/proxy/service_tier_sanitization_test.go
+++ b/internal/proxy/service_tier_sanitization_test.go
@@ -52,6 +52,11 @@ func TestExtractMetadataFromBodyStripsClientControlledServiceTier(t *testing.T) 
 			body:          `{"model":"gpt-4","messages":[],"service_tier":null,"extra_body":{"service_tier":[],"litellm_session_id":"session-1"}}`,
 			wantSessionID: "session-1",
 		},
+		{
+			name:          "top-level LiteLLM session ID",
+			body:          `{"model":"gpt-4","messages":[],"litellm_session_id":"session-1"}`,
+			wantSessionID: "session-1",
+		},
 	}
 
 	for _, tt := range tests {
@@ -65,6 +70,7 @@ func TestExtractMetadataFromBodyStripsClientControlledServiceTier(t *testing.T) 
 			var body map[string]json.RawMessage
 			require.NoError(t, json.Unmarshal(result.Body, &body))
 			assert.NotContains(t, body, "service_tier")
+			assert.NotContains(t, body, "litellm_session_id")
 			if extraRaw, exists := body["extra_body"]; exists {
 				var extra map[string]json.RawMessage
 				require.NoError(t, json.Unmarshal(extraRaw, &extra))
@@ -150,6 +156,7 @@ func TestProxyRequestNeverForwardsClientControlledServiceTier(t *testing.T) {
 		{name: "proxy chat", provider: config.ProviderTypeProxy, path: "/v1/chat/completions", body: `{"model":"gpt-4","messages":[{"role":"user","content":"test"}],"service_tier":"priority","extra_body":{"service_tier":"flex","keep":"yes"}}`},
 		{name: "AIR chat", provider: config.ProviderTypeAIR, path: "/v1/chat/completions", body: `{"model":"gpt-4","messages":[{"role":"user","content":"test"}],"service_tier":"priority"}`},
 		{name: "direct OpenAI chat", provider: config.ProviderTypeOpenAI, path: "/v1/chat/completions", body: `{"model":"gpt-4","messages":[{"role":"user","content":"test"}],"service_tier":"priority"}`},
+		{name: "direct OpenAI chat with LiteLLM session", provider: config.ProviderTypeOpenAI, path: "/v1/chat/completions", body: `{"model":"gpt-4","messages":[{"role":"user","content":"test"}],"litellm_session_id":"session-1"}`},
 		{name: "native responses passthrough", provider: config.ProviderTypeOpenAI, path: "/v1/responses", body: `{"model":"gpt-4","input":"test","service_tier":"priority"}`},
 		{name: "Anthropic messages proxy", provider: config.ProviderTypeProxy, path: "/v1/messages", body: `{"model":"gpt-4","max_tokens":16,"messages":[{"role":"user","content":"test"}],"service_tier":"priority"}`},
 	}
@@ -186,6 +193,7 @@ func TestProxyRequestNeverForwardsClientControlledServiceTier(t *testing.T) {
 
 			require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
 			assert.NotContains(t, outbound, "service_tier")
+			assert.NotContains(t, outbound, "litellm_session_id")
 			assert.Contains(t, outbound, "model")
 			if tt.path == "/v1/chat/completions" {
 				assert.Contains(t, outbound, "messages")


### PR DESCRIPTION
Strip `litellm_session_id` before upstream requests while preserving it for session routing.

Tests: `make test`, `make lint`