### PR TITLE
fix: infer litellm_provider from bare model-name prefix at load time

### DIFF
--- a/internal/models/price_loader.go
+++ b/internal/models/price_loader.go
@@ -63,6 +63,8 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 		if price.LiteLLMProvider == "" {
 			if slash := strings.IndexByte(fullName, '/'); slash > 0 {
 				price.LiteLLMProvider = fullName[:slash]
+			} else {
+				price.LiteLLMProvider = inferProviderFromModelName(fullName)
 			}
 		}
 		normalized := NormalizeModelName(fullName)
@@ -182,4 +184,32 @@ func NormalizeModelName(fullName string) string {
 
 	// Convert to lowercase for case-insensitive matching
 	return strings.ToLower(modelName)
+}
+
+// modelNameProviderPrefixes maps well-known bare model-name prefixes to their
+// provider tag, for price files that key entries by plain model name (e.g.
+// "gemini-2.5-pro") rather than "provider/model" (e.g. "vertex_ai/gemini-2.5-pro")
+// and don't set litellm_provider explicitly. Only unambiguous, first-party
+// naming conventions are listed here to avoid misclassifying unrelated models.
+var modelNameProviderPrefixes = []struct {
+	prefix   string
+	provider string
+}{
+	{"gemini-", "gemini"},
+	{"vertex-", "vertex"},
+	{"google-", "google"},
+}
+
+// inferProviderFromModelName is a last-resort fallback for price entries that
+// have neither an explicit litellm_provider nor a "provider/model" key
+// convention. It only matches a known, unambiguous model-name prefix and
+// returns "" (no guess) otherwise.
+func inferProviderFromModelName(fullName string) string {
+	name := strings.ToLower(strings.TrimSpace(fullName))
+	for _, p := range modelNameProviderPrefixes {
+		if strings.HasPrefix(name, p.prefix) {
+			return p.provider
+		}
+	}
+	return ""
 }

--- a/internal/models/price_loader_test.go
+++ b/internal/models/price_loader_test.go
@@ -118,6 +118,43 @@ func TestLoadModelPrices_InfersProviderFromPrefixedKey(t *testing.T) {
 	assert.Equal(t, "vertex_ai", prices["gemini-2.5-flash"].LiteLLMProvider)
 }
 
+func TestLoadModelPrices_InfersProviderFromBareModelName(t *testing.T) {
+	// Real-world case: a price file keys entries by plain model name (no
+	// "provider/model" convention) and never sets litellm_provider at all --
+	// the model-name prefix is the only signal available.
+	filePath := filepath.Join(t.TempDir(), "prices.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{
+		"gemini-2.5-pro": {
+			"input_cost_per_token": 0.000001625,
+			"input_cost_per_token_above_200k_tokens": 0.00000325
+		},
+		"claude-sonnet-4.5": {
+			"input_cost_per_token": 0.0000039,
+			"input_cost_per_token_above_200k_tokens": 0.0000078
+		}
+	}`), 0o600))
+
+	prices, err := LoadModelPrices(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "gemini", prices["gemini-2.5-pro"].LiteLLMProvider)
+	// A bare name with no recognized prefix must stay empty, not guess wrong.
+	assert.Equal(t, "", prices["claude-sonnet-4.5"].LiteLLMProvider)
+}
+
+func TestLoadModelPrices_ExplicitProviderWinsOverNameInference(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "prices.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{
+		"gemini-2.5-pro": {
+			"input_cost_per_token": 0.000001625,
+			"litellm_provider": "vertex_ai"
+		}
+	}`), 0o600))
+
+	prices, err := LoadModelPrices(filePath)
+	require.NoError(t, err)
+	assert.Equal(t, "vertex_ai", prices["gemini-2.5-pro"].LiteLLMProvider)
+}
+
 func TestLoadModelPrices_FromFilePath(t *testing.T) {
 	// Create a temporary file with valid JSON
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Проблема

#127 добавил full-session биллинг Gemini/Vertex на пороге 200k, завязанный на `ModelPrice.LiteLLMProvider`. На реальном проде это поле оказалось пустым: прайс-файл ключует модели голым именем (`gemini-2.5-pro`, без слэша) и нигде не проставляет `litellm_provider` явно — а роутер до сих пор умел выводить provider только из явного поля или из префикса вида `provider/model` перед слэшем. В итоге #127 задеплоен, но фактически не срабатывает — `config.IsGoogleGeminiProvider("")` всегда `false`, Gemini продолжает считаться пропорционально.

Подтверждено на реальных прод-данных (`llmarena/services`, `default.libsonnet`/`client_a.libsonnet`) — поле `litellm_provider` не встречается вообще ни разу во всём файле, ни у одной модели.

## Фикс

Добавлен `inferProviderFromModelName` — последний fallback в `LoadModelPrices`: если явного `litellm_provider` нет и в ключе нет слэша, смотрим на префикс самого имени модели (`gemini-`, `vertex-`, `google-` — только однозначные, не пересекающиеся с другими провайдерами). Правка только в `internal/models/price_loader.go`, прайс-файл не трогает вообще.

## Проверка

- Новые тесты: подхват provider по голому имени (`gemini-2.5-pro` → `gemini`), негативный кейс (незнакомый префикс остаётся пустым, не гадаем), явное поле `litellm_provider` по-прежнему побеждает автоопределение.
- `go build`/`go vet`/`go test ./...`/`golangci-lint` — чисто.
- Живая локальная проверка: убрал `litellm_provider` из локального `model_prices.json` (чтобы точно повторить структуру прод-файла) и прогнал реальный >200k-токенный запрос на `gemini-2.5-pro` через AIR — full-session сработал корректно (`211965 × 0.00000325 = 0.68889`), так же, как и с явным полем.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run`
- [x] Локальная сквозная проверка с прайс-файлом без `litellm_provider`