### PR TITLE
Deduplicate AIR spend logs

### DIFF
--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -199,6 +199,9 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	if !litellmEnabled && !kafkaEnabled {
 		return nil
 	}
+	if logCtx != nil && logCtx.IsProxyRequest {
+		return nil
+	}
 
 	if logCtx == nil || logCtx.Credential == nil || logCtx.Request == nil {
 		return nil

--- a/internal/proxy/proxy_log_kafka_fallback_test.go
+++ b/internal/proxy/proxy_log_kafka_fallback_test.go
@@ -184,6 +184,21 @@ func TestLogSpendToLiteLLMDB_UsesClientResponseID(t *testing.T) {
 	assert.Equal(t, "chatcmpl-client-123", dbStub.loggedEntries[0].RequestID)
 }
 
+func TestLogSpendToLiteLLMDB_SkipsInternalAIRRequest(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	kafkaStub := &stubKafkaManager{enabled: true}
+	dbStub := &stubLiteLLMManager{}
+	prx.kafkaLog = kafkaStub
+	prx.LiteLLMDB = dbStub
+
+	logCtx := testLogCtx(t)
+	logCtx.IsProxyRequest = true
+
+	require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
+	assert.Empty(t, kafkaStub.events)
+	assert.Empty(t, dbStub.loggedEntries)
+}
+
 func TestLogSpendToLiteLLMDB_BillsAliasPriceBeforeRealModelPrice(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	registry := routermodels.NewModelPriceRegistry()


### PR DESCRIPTION
Keep internal AIR relay rows in PostgreSQL while excluding them from entity and daily accounting. Publish only the edge spend event to Kafka.\n\nTests: go test ./...; make lint