### PR TITLE
Preserve regional spend logs

### DIFF
--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -599,6 +599,7 @@ type SpendLogEntry struct {
 	// Runtime-only observability flag; persisted inside Metadata rather than as
 	// a LiteLLM_SpendLogs column.
 	ComparisonEligible bool
+	SkipAccounting     bool
 }
 
 // ==================== Stats ====================

--- a/internal/litellmdb/spendlog/atomic_writer_test.go
+++ b/internal/litellmdb/spendlog/atomic_writer_test.go
@@ -228,6 +228,19 @@ func TestAtomicWriterCollisionWithoutAirEventIDIsObservable(t *testing.T) {
 		"the unresolvable drop must be counted instead of silently discarded")
 }
 
+func TestAtomicWriterPersistsRawRowWithoutAccounting(t *testing.T) {
+	logger := newAtomicTestLogger()
+	entry := atomicProviderIDEntry("chatcmpl-relay", "air-event-relay")
+	entry.SkipAccounting = true
+	tx := &atomicTestTx{insertResults: [][]string{{"chatcmpl-relay"}}}
+
+	inserted, err := logger.commitBatchTransaction(context.Background(), tx, []*models.SpendLogEntry{entry})
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"chatcmpl-relay"}, inserted)
+	assert.Empty(t, tx.attemptedSQL)
+}
+
 func TestAtomicWriterProviderIDReplayDoesNotFeedAnyAccounting(t *testing.T) {
 	logger := newAtomicTestLogger()
 	entry := atomicProviderIDEntry("chatcmpl-replay", "air-event-replay")

--- a/internal/litellmdb/spendlog/logger.go
+++ b/internal/litellmdb/spendlog/logger.go
@@ -693,7 +693,8 @@ func (sl *Logger) writeBatchInTransaction(ctx context.Context, tx pgx.Tx, batch 
 	if len(filteredBatch) != len(insertedIDs) {
 		return nil, fmt.Errorf("map inserted rows to batch: expected %d, mapped %d", len(insertedIDs), len(filteredBatch))
 	}
-	spendUpdates := aggregateSpendUpdates(insertedEntries(filteredBatch))
+	accountingBatch := accountingEntries(filteredBatch)
+	spendUpdates := aggregateSpendUpdates(insertedEntries(accountingBatch))
 	if err := executeSpendUpdates(ctx, tx, spendUpdates); err != nil {
 		return nil, fmt.Errorf("spend updates: %w", err)
 	}
@@ -701,7 +702,7 @@ func (sl *Logger) writeBatchInTransaction(ctx context.Context, tx pgx.Tx, batch 
 	// Daily aggregates are built from the in-memory entries. Re-reading the
 	// just-inserted rows from LiteLLM_SpendLogs is a heavy query on the LiteLLM
 	// schema, and everything it returned is already known to the writer.
-	records, err := buildSpendLogRecords(filteredBatch, sl.logger, "atomic")
+	records, err := buildSpendLogRecords(accountingBatch, sl.logger, "atomic")
 	if err != nil {
 		return nil, fmt.Errorf("build daily aggregation records: %w", err)
 	}
@@ -972,6 +973,16 @@ func insertedEntries(inserted []insertedSpendEntry) []*models.SpendLogEntry {
 	entries := make([]*models.SpendLogEntry, 0, len(inserted))
 	for _, item := range inserted {
 		entries = append(entries, item.entry)
+	}
+	return entries
+}
+
+func accountingEntries(inserted []insertedSpendEntry) []insertedSpendEntry {
+	entries := make([]insertedSpendEntry, 0, len(inserted))
+	for _, item := range inserted {
+		if item.entry != nil && !item.entry.SkipAccounting {
+			entries = append(entries, item)
+		}
 	}
 	return entries
 }

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -315,6 +315,29 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 	return string(jsonBytes)
 }
 
+func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRequest bool) string {
+	var doc map[string]interface{}
+	if json.Unmarshal([]byte(metadata), &doc) != nil {
+		doc = make(map[string]interface{})
+	}
+	spendMetadata, _ := doc["spend_logs_metadata"].(map[string]interface{})
+	if spendMetadata == nil {
+		spendMetadata = make(map[string]interface{})
+		doc["spend_logs_metadata"] = spendMetadata
+	}
+	spendMetadata["air_event_id"] = eventID
+	spendMetadata["accounting_eligible"] = !isProxyRequest
+	spendMetadata["is_proxy_request"] = isProxyRequest
+	if providerResponseID != "" {
+		spendMetadata["provider_response_id"] = providerResponseID
+	}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return metadata
+	}
+	return string(encoded)
+}
+
 // extractEndUser extracts end_user from request headers or body
 func extractEndUser(r *http.Request) string {
 	// Check X-End-User header first

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -199,10 +199,6 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	if !litellmEnabled && !kafkaEnabled {
 		return nil
 	}
-	if logCtx != nil && logCtx.IsProxyRequest {
-		return nil
-	}
-
 	if logCtx == nil || logCtx.Credential == nil || logCtx.Request == nil {
 		return nil
 	}
@@ -322,7 +318,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	// metadata at insert time, instead of needing a separate update later —
 	// see buildMetadata's kafkaFallbackReason parameter below.
 	var kafkaFallbackReason string
-	if kafkaEnabled {
+	if kafkaEnabled && !logCtx.IsProxyRequest {
 		// Deliberately distinct from the Postgres metadata's overheadMs (which
 		// measures full elapsed time since the request started, near-identical
 		// to duration_ms): kafkaOverheadMs measures only the cost of this
@@ -344,6 +340,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	requesterIP := getClientIP(logCtx.Request)
 	overheadMs := float64(time.Since(logCtx.StartTime).Microseconds()) / 1000.0
 	metadata := buildMetadata(hashedToken, logCtx.TokenInfo, logCtx.ErrorMsg, logCtx.HTTPStatus, logCtx.TokenUsage, requesterIP, tokenCosts, logCtx.ModelID, overheadMs, kafkaFallbackReason)
+	metadata = addAIRSpendMetadata(metadata, logCtx.RequestID, logCtx.ClientResponseID, logCtx.IsProxyRequest)
 
 	var completionStartTime *time.Time
 	if !logCtx.CompletionStartTime.IsZero() {
@@ -354,6 +351,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	if litellmEnabled {
 		pgErr = p.LiteLLMDB.LogSpend(&litellmdb.SpendLogEntry{
 			RequestID:           logCtx.spendRequestID(),
+			AirEventID:          logCtx.RequestID,
 			StartTime:           logCtx.StartTime,
 			EndTime:             endTime,
 			CompletionStartTime: completionStartTime,
@@ -376,6 +374,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 			RequesterIP:         requesterIP,
 			Status:              status,
 			SessionID:           logCtx.SessionID,
+			SkipAccounting:      logCtx.IsProxyRequest,
 		})
 	}
 

--- a/internal/proxy/proxy_log_kafka_fallback_test.go
+++ b/internal/proxy/proxy_log_kafka_fallback_test.go
@@ -181,22 +181,45 @@ func TestLogSpendToLiteLLMDB_UsesClientResponseID(t *testing.T) {
 
 	require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
 	require.Len(t, dbStub.loggedEntries, 1)
-	assert.Equal(t, "chatcmpl-client-123", dbStub.loggedEntries[0].RequestID)
+	entry := dbStub.loggedEntries[0]
+	assert.Equal(t, "chatcmpl-client-123", entry.RequestID)
+	assert.Equal(t, "req-123", entry.AirEventID)
+	assert.False(t, entry.SkipAccounting)
+
+	var metadata map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(entry.Metadata), &metadata))
+	spendMetadata := metadata["spend_logs_metadata"].(map[string]interface{})
+	assert.Equal(t, "req-123", spendMetadata["air_event_id"])
+	assert.Equal(t, "chatcmpl-client-123", spendMetadata["provider_response_id"])
+	assert.Equal(t, true, spendMetadata["accounting_eligible"])
 }
 
-func TestLogSpendToLiteLLMDB_SkipsInternalAIRRequest(t *testing.T) {
+func TestLogSpendToLiteLLMDB_PersistsInternalAIRRequestWithoutKafkaAccounting(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	kafkaStub := &stubKafkaManager{enabled: true}
 	dbStub := &stubLiteLLMManager{}
 	prx.kafkaLog = kafkaStub
 	prx.LiteLLMDB = dbStub
+	setTestModelPrice(prx, "gpt-4o-mini", &routermodels.ModelPrice{
+		InputCostPerToken: 0.000001, OutputCostPerToken: 0.000002,
+	})
 
 	logCtx := testLogCtx(t)
 	logCtx.IsProxyRequest = true
 
 	require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
 	assert.Empty(t, kafkaStub.events)
-	assert.Empty(t, dbStub.loggedEntries)
+	require.Len(t, dbStub.loggedEntries, 1)
+	entry := dbStub.loggedEntries[0]
+	assert.Equal(t, "req-123", entry.AirEventID)
+	assert.True(t, entry.SkipAccounting)
+
+	var metadata map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(entry.Metadata), &metadata))
+	spendMetadata := metadata["spend_logs_metadata"].(map[string]interface{})
+	assert.Equal(t, "req-123", spendMetadata["air_event_id"])
+	assert.Equal(t, false, spendMetadata["accounting_eligible"])
+	assert.Equal(t, true, spendMetadata["is_proxy_request"])
 }
 
 func TestLogSpendToLiteLLMDB_BillsAliasPriceBeforeRealModelPrice(t *testing.T) {


### PR DESCRIPTION
Keep internal AIR relay rows in PostgreSQL while excluding them from entity and daily accounting. Kafka retains only the edge spend event.\n\nTests: go test ./...; make lint