### PR TITLE
fix: Gemini image-generation output was double-billed (text rate + flat image rate)

### DIFF
--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -247,13 +247,26 @@ type OpenAIImageInputTokenDetails struct {
 	ImageTokens int `json:"image_tokens"`
 }
 
+// OpenAIImageOutputTokenDetails breaks down output token counts for image API
+// responses. Not part of OpenAI's own gpt-image-1 schema (whose output is
+// always 100% image), but needed for Gemini-backed models, which can return
+// a text caption alongside the generated image within the same output token
+// count. Mirrors the same field the generic usage extractor
+// (converter.ExtractTokenUsageWithOptions) already reads from
+// output_tokens_details.image_tokens for the Responses API shape.
+type OpenAIImageOutputTokenDetails struct {
+	TextTokens  int `json:"text_tokens,omitempty"`
+	ImageTokens int `json:"image_tokens,omitempty"`
+}
+
 // OpenAIImageUsage is the usage format for the images API (gpt-image-1 style),
 // distinct from the chat-completions OpenAIUsage.
 type OpenAIImageUsage struct {
-	InputTokens        int                          `json:"input_tokens"`
-	InputTokensDetails OpenAIImageInputTokenDetails `json:"input_tokens_details"`
-	OutputTokens       int                          `json:"output_tokens"`
-	TotalTokens        int                          `json:"total_tokens"`
+	InputTokens         int                            `json:"input_tokens"`
+	InputTokensDetails  OpenAIImageInputTokenDetails   `json:"input_tokens_details"`
+	OutputTokens        int                            `json:"output_tokens"`
+	OutputTokensDetails *OpenAIImageOutputTokenDetails `json:"output_tokens_details,omitempty"`
+	TotalTokens         int                            `json:"total_tokens"`
 }
 
 // OpenAIImageResponse represents OpenAI image response

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -393,13 +393,29 @@ func convertVertexUsageToImageUsage(meta *genai.GenerateContentResponseUsageMeta
 	}
 
 	outputTokens := int(meta.CandidatesTokenCount)
+	var outputTextTokens, outputImageTokens int
 	for _, detail := range meta.CandidatesTokensDetails {
 		if detail == nil {
 			continue
 		}
 		switch genai.MediaModality(detail.Modality) {
 		case genai.MediaModalityImage, genai.MediaModalityVideo:
-			// image output tokens counted in CandidatesTokenCount
+			outputImageTokens += int(detail.TokenCount)
+		default:
+			outputTextTokens += int(detail.TokenCount)
+		}
+	}
+
+	var outputDetails *openai.OpenAIImageOutputTokenDetails
+	if outputTextTokens > 0 || outputImageTokens > 0 {
+		// Gemini image models can return a text caption alongside the
+		// generated image within the same CandidatesTokenCount total (unlike
+		// OpenAI's gpt-image-1, whose output is always 100% image). Billing
+		// needs the split to price image output tokens at
+		// output_cost_per_image_token instead of the much lower text rate.
+		outputDetails = &openai.OpenAIImageOutputTokenDetails{
+			TextTokens:  outputTextTokens,
+			ImageTokens: outputImageTokens,
 		}
 	}
 
@@ -409,8 +425,9 @@ func convertVertexUsageToImageUsage(meta *genai.GenerateContentResponseUsageMeta
 			TextTokens:  textTokens,
 			ImageTokens: imageTokens,
 		},
-		OutputTokens: outputTokens,
-		TotalTokens:  inputTokens + outputTokens,
+		OutputTokens:        outputTokens,
+		OutputTokensDetails: outputDetails,
+		TotalTokens:         inputTokens + outputTokens,
 	}
 }
 

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -561,6 +561,68 @@ func TestConvertVertexUsageToImageUsage(t *testing.T) {
 		assert.Equal(t, 100, got.InputTokensDetails.ImageTokens)
 	})
 
+	t.Run("candidate modality details split output into text and image tokens", func(t *testing.T) {
+		// Gemini image models can return a text caption alongside the
+		// generated image within the same CandidatesTokenCount total (unlike
+		// OpenAI's gpt-image-1, whose output is always 100% image). Billing
+		// needs this split to price image output tokens at
+		// output_cost_per_image_token instead of the text rate.
+		meta := &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     11,
+			CandidatesTokenCount: 1421,
+			CandidatesTokensDetails: []*genai.ModalityTokenCount{
+				{Modality: genai.MediaModality(genai.MediaModalityText), TokenCount: 301},
+				{Modality: genai.MediaModality(genai.MediaModalityImage), TokenCount: 1120},
+			},
+		}
+		got := convertVertexUsageToImageUsage(meta)
+		require.NotNil(t, got)
+		assert.Equal(t, 1421, got.OutputTokens)
+		require.NotNil(t, got.OutputTokensDetails)
+		assert.Equal(t, 301, got.OutputTokensDetails.TextTokens)
+		assert.Equal(t, 1120, got.OutputTokensDetails.ImageTokens)
+	})
+
+	t.Run("candidate video tokens counted as image tokens", func(t *testing.T) {
+		meta := &genai.GenerateContentResponseUsageMetadata{
+			CandidatesTokenCount: 900,
+			CandidatesTokensDetails: []*genai.ModalityTokenCount{
+				{Modality: genai.MediaModality(genai.MediaModalityText), TokenCount: 100},
+				{Modality: genai.MediaModality(genai.MediaModalityVideo), TokenCount: 800},
+			},
+		}
+		got := convertVertexUsageToImageUsage(meta)
+		require.NotNil(t, got)
+		require.NotNil(t, got.OutputTokensDetails)
+		assert.Equal(t, 100, got.OutputTokensDetails.TextTokens)
+		assert.Equal(t, 800, got.OutputTokensDetails.ImageTokens)
+	})
+
+	t.Run("no candidate modality details leaves OutputTokensDetails nil", func(t *testing.T) {
+		meta := &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     268,
+			CandidatesTokenCount: 1024,
+		}
+		got := convertVertexUsageToImageUsage(meta)
+		require.NotNil(t, got)
+		assert.Nil(t, got.OutputTokensDetails)
+	})
+
+	t.Run("nil candidate modality detail entries are skipped", func(t *testing.T) {
+		meta := &genai.GenerateContentResponseUsageMetadata{
+			CandidatesTokenCount: 500,
+			CandidatesTokensDetails: []*genai.ModalityTokenCount{
+				nil,
+				{Modality: genai.MediaModality(genai.MediaModalityImage), TokenCount: 500},
+			},
+		}
+		got := convertVertexUsageToImageUsage(meta)
+		require.NotNil(t, got)
+		require.NotNil(t, got.OutputTokensDetails)
+		assert.Equal(t, 0, got.OutputTokensDetails.TextTokens)
+		assert.Equal(t, 500, got.OutputTokensDetails.ImageTokens)
+	})
+
 	t.Run("nil modality detail entries are skipped", func(t *testing.T) {
 		meta := &genai.GenerateContentResponseUsageMetadata{
 			PromptTokenCount:     100,


### PR DESCRIPTION
## Проблема

Для `images.generate`/`images.edit` на Gemini image-моделях Google в usage может разбивать output на картинку и сопроводительный текстовый caption **внутри одного `CandidatesTokenCount`** (в отличие от `gpt-image-1`, где output всегда 100% картинка). `convertVertexUsageToImageUsage` эту разбивку по модальности читал, но выбрасывал в no-op цикле — `OpenAIImageUsage` никогда не отдавал наружу split output-токенов на картинку/текст.

Последствия:
1. Все output-токены билились по базовой текстовой ставке (`output_cost_per_token`).
2. Поскольку `outputImageTokens` всегда был `0`, срабатывал fallback калькулятора на плоскую цену (`imageCount × output_cost_per_image`) **поверх** уже посчитанного текстового output — картинка биллилась дважды: один раз по текстовой ставке за все токены, второй раз плоско за картинку.

## Проверка на реальных данных

Живой `images.edit` на `gemini-3-pro-image` (загрузка картинки + правка):

**До фикса:** output = 1193 токена, все посчитаны по текстовой ставке (`output_cost = $0.0185`) **плюс** плоские `$0.1206` за картинку сверху → `total = $0.1397854`.

**После фикса:** `output_cost = $0.0011` (только реальные 73 текстовых токена) + `$0.121` за 1120 картиночных токенов по `output_cost_per_image_token` → `total = $0.1227982`. Задвоения нет, и используется правильная per-token ставка (которая масштабируется по разрешению картинки, в отличие от плоской цены).

Дополнительно проверено на 4K-изображении: output image_tokens корректно масштабировался с 1120 до 2000 при более крупной генерации, и биллинг отмасштабировался вместе с ним (per-token, не плоско).

## Фикс

Добавлен `OpenAIImageOutputTokenDetails` (по аналогии с уже существующим `OpenAIImageInputTokenDetails`) и заполняется в `convertVertexUsageToImageUsage` из `CandidatesTokensDetails`. Генерик-экстрактор usage (`converter.ExtractTokenUsageWithOptions`) уже умеет читать `output_tokens_details.image_tokens` для формата Responses API — там ничего менять не пришлось, только сама конвертация Vertex-ответа была неполной.

## Проверка

- 6 новых юнит-тестов на `convertVertexUsageToImageUsage`: разбивка candidate-модальности на текст/картинку, video-токены считаются как image, отсутствие деталей оставляет `OutputTokensDetails` nil, nil-записи в деталях пропускаются.
- `go build`/`go vet`/`go test ./...`/`golangci-lint` — чисто.
- Живая локальная проверка через реальный Gemini API-ключ на `gemini-3-pro-image` (`images.edit` с загруженной картинкой, включая 4K) — см. выше.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] `golangci-lint run`
- [x] Живая проверка на реальном images.edit запросе к gemini-3-pro-image (обычная и 4K картинка)
