### PR TITLE
Fix null spend accounting

### DIFF
--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -584,11 +584,21 @@ type SpendLogEntry struct {
 	Spend float64 // Request cost in USD
 
 	// User identification
-	APIKey         string // sha256 hash of token
-	UserID         string // User ID
-	TeamID         string // Team ID
+	APIKey string // sha256 hash of token
+	UserID string // User ID
+	TeamID string // Team ID: real team, or provider credential name when
+	// credential_name_as_team_id substitutes one for attribution in spend
+	// logs/Kafka/DailyTeamSpend. NOT safe to use for billing decisions.
 	OrganizationID string // Organization ID
 	EndUser        string // End user ID (from metadata)
+
+	// BillingTeamID is the token's real team assignment only (empty when the
+	// key has no team), independent of any credential_name_as_team_id
+	// substitution in TeamID above. aggregateSpendUpdates must key off this
+	// field to decide whether spend goes to LiteLLM_UserTable (personal) or
+	// LiteLLM_TeamTable/LiteLLM_TeamMembership (team) — a synthetic TeamID
+	// used only for log attribution must never suppress the personal debit.
+	BillingTeamID string
 
 	// Status
 	Status string // "success" | "failure"

--- a/internal/litellmdb/queries/spend_updates.go
+++ b/internal/litellmdb/queries/spend_updates.go
@@ -9,14 +9,14 @@ const (
 	// bumps last_active (schemas that already have the last_active column).
 	QueryUpdateTokenSpendWithLastActive = `
 		UPDATE "LiteLLM_VerificationToken"
-		SET spend = spend + $1, updated_at = NOW(), last_active = NOW()
-		WHERE token = $2 AND spend IS NOT NULL`
+		SET spend = COALESCE(spend, 0) + $1, updated_at = NOW(), last_active = NOW()
+		WHERE token = $2`
 
 	// QueryUpdateTokenModelSpendWithLastActive increments the scalar key spend
 	// and the per-model JSON counter, and bumps last_active.
 	QueryUpdateTokenModelSpendWithLastActive = `
 		UPDATE "LiteLLM_VerificationToken"
-		SET spend = spend + $1,
+		SET spend = COALESCE(spend, 0) + $1,
 		    model_spend = jsonb_set(
 		        COALESCE(model_spend, '{}'::jsonb),
 		        ARRAY[$2]::text[],
@@ -25,19 +25,19 @@ const (
 		    ),
 		    updated_at = NOW(),
 		    last_active = NOW()
-		WHERE token = $3 AND spend IS NOT NULL`
+		WHERE token = $3`
 
 	// QueryUpdateTokenSpend is the fallback for schemas without last_active.
 	QueryUpdateTokenSpend = `
 		UPDATE "LiteLLM_VerificationToken"
-		SET spend = spend + $1, updated_at = NOW()
-		WHERE token = $2 AND spend IS NOT NULL`
+		SET spend = COALESCE(spend, 0) + $1, updated_at = NOW()
+		WHERE token = $2`
 
 	// QueryUpdateTokenModelSpend is the model-counter fallback for schemas
 	// without last_active.
 	QueryUpdateTokenModelSpend = `
 		UPDATE "LiteLLM_VerificationToken"
-		SET spend = spend + $1,
+		SET spend = COALESCE(spend, 0) + $1,
 		    model_spend = jsonb_set(
 		        COALESCE(model_spend, '{}'::jsonb),
 		        ARRAY[$2]::text[],
@@ -45,21 +45,21 @@ const (
 		        true
 		    ),
 		    updated_at = NOW()
-		WHERE token = $3 AND spend IS NOT NULL`
+		WHERE token = $3`
 
 	// QueryUpdateEntitySpendTemplate builds an entity counter update without a
 	// model dimension. Table and ID column are compile-time constants supplied
 	// only by the spendlog wrappers.
 	QueryUpdateEntitySpendTemplate = `
 		UPDATE %s
-		SET spend = spend + $1, updated_at = NOW()
-		WHERE %s = $2 AND spend IS NOT NULL`
+		SET spend = COALESCE(spend, 0) + $1, updated_at = NOW()
+		WHERE %s = $2`
 
 	// QueryUpdateEntityModelSpendTemplate builds an entity counter update where
 	// scalar spend and the per-model JSON number change in one statement.
 	QueryUpdateEntityModelSpendTemplate = `
 		UPDATE %s
-		SET spend = spend + $1,
+		SET spend = COALESCE(spend, 0) + $1,
 		    model_spend = jsonb_set(
 		        COALESCE(model_spend, '{}'::jsonb),
 		        ARRAY[$2]::text[],
@@ -67,22 +67,22 @@ const (
 		        true
 		    ),
 		    updated_at = NOW()
-		WHERE %s = $3 AND spend IS NOT NULL`
+		WHERE %s = $3`
 
 	// QueryUpdateTeamMemberSpendWithTotal increments both spend and total_spend
 	// (schemas that already have the total_spend column).
-	QueryUpdateTeamMemberSpendWithTotal = `UPDATE "LiteLLM_TeamMembership" SET spend = spend + $1, total_spend = total_spend + $1 WHERE team_id = $2 AND user_id = $3 AND spend IS NOT NULL`
+	QueryUpdateTeamMemberSpendWithTotal = `UPDATE "LiteLLM_TeamMembership" SET spend = COALESCE(spend, 0) + $1, total_spend = COALESCE(total_spend, 0) + $1 WHERE team_id = $2 AND user_id = $3`
 
 	// QueryUpdateTeamMemberSpend is the fallback for schemas without
 	// total_spend.
-	QueryUpdateTeamMemberSpend = `UPDATE "LiteLLM_TeamMembership" SET spend = spend + $1 WHERE team_id = $2 AND user_id = $3 AND spend IS NOT NULL`
+	QueryUpdateTeamMemberSpend = `UPDATE "LiteLLM_TeamMembership" SET spend = COALESCE(spend, 0) + $1 WHERE team_id = $2 AND user_id = $3`
 
 	// QueryUpdateOrganizationMemberSpend increments the member's spend within
 	// the organization.
 	QueryUpdateOrganizationMemberSpend = `
 		UPDATE "LiteLLM_OrganizationMembership"
-		SET spend = spend + $1, updated_at = NOW()
-		WHERE organization_id = $2 AND user_id = $3 AND spend IS NOT NULL`
+		SET spend = COALESCE(spend, 0) + $1, updated_at = NOW()
+		WHERE organization_id = $2 AND user_id = $3`
 
 	// QueryUpsertEndUserSpend inserts or increments the end user's spend.
 	QueryUpsertEndUserSpend = `

--- a/internal/litellmdb/queries/spend_updates_test.go
+++ b/internal/litellmdb/queries/spend_updates_test.go
@@ -1,0 +1,24 @@
+package queries
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSpendUpdateQueriesInitializeNullSpend(t *testing.T) {
+	for _, query := range []string{
+		QueryUpdateTokenSpendWithLastActive,
+		QueryUpdateTokenModelSpendWithLastActive,
+		QueryUpdateTokenSpend,
+		QueryUpdateTokenModelSpend,
+		QueryUpdateEntitySpendTemplate,
+		QueryUpdateEntityModelSpendTemplate,
+		QueryUpdateTeamMemberSpendWithTotal,
+		QueryUpdateTeamMemberSpend,
+		QueryUpdateOrganizationMemberSpend,
+	} {
+		assert.Contains(t, query, "COALESCE(spend, 0) + $1")
+		assert.NotContains(t, query, "spend IS NOT NULL")
+	}
+}

--- a/internal/litellmdb/spendlog/spend_updater.go
+++ b/internal/litellmdb/spendlog/spend_updater.go
@@ -133,14 +133,18 @@ func aggregateSpendUpdates(batch []*models.SpendLogEntry) *SpendUpdates {
 			updates.Tokens[entityModelKey{EntityID: entry.APIKey, Model: entry.Model}] += entry.Spend
 		}
 
-		// Team spend is charged through team membership, not the personal balance.
-		if entry.UserID != "" && entry.TeamID == "" {
+		// Team spend is charged through team membership, not the personal
+		// balance. Routed on BillingTeamID, not TeamID: TeamID can hold a
+		// synthetic provider-credential name (credential_name_as_team_id)
+		// used only for log/DailyTeamSpend attribution, and that must not
+		// suppress the personal debit or be charged to a nonexistent team.
+		if entry.UserID != "" && entry.BillingTeamID == "" {
 			updates.Users[entityModelKey{EntityID: entry.UserID, Model: entry.Model}] += entry.Spend
 		}
 
 		// Team (if present)
-		if entry.TeamID != "" {
-			updates.Teams[entityModelKey{EntityID: entry.TeamID, Model: entry.Model}] += entry.Spend
+		if entry.BillingTeamID != "" {
+			updates.Teams[entityModelKey{EntityID: entry.BillingTeamID, Model: entry.Model}] += entry.Spend
 		}
 
 		// Organization (if present)
@@ -149,8 +153,8 @@ func aggregateSpendUpdates(batch []*models.SpendLogEntry) *SpendUpdates {
 		}
 
 		// TeamMembership (if User + Team)
-		if entry.UserID != "" && entry.TeamID != "" {
-			updates.TeamMembers[teamMemberKey{TeamID: entry.TeamID, UserID: entry.UserID}] += entry.Spend
+		if entry.UserID != "" && entry.BillingTeamID != "" {
+			updates.TeamMembers[teamMemberKey{TeamID: entry.BillingTeamID, UserID: entry.UserID}] += entry.Spend
 		}
 
 		if entry.UserID != "" && entry.OrganizationID != "" {

--- a/internal/litellmdb/spendlog/spend_updater.go
+++ b/internal/litellmdb/spendlog/spend_updater.go
@@ -254,7 +254,6 @@ func updateTokens(ctx context.Context, tx spendUpdateExecer, tokens map[entityMo
 }
 
 // updateUsers updates LiteLLM_UserTable.spend and model_spend.
-// Checks spend IS NOT NULL to avoid accidentally updating null values.
 func updateUsers(ctx context.Context, tx spendUpdateExecer, users map[entityModelKey]float64) error {
 	for _, key := range sortedSpendKeys(users, compareEntityModelKey) {
 		amount := users[key]
@@ -270,7 +269,6 @@ func updateUsers(ctx context.Context, tx spendUpdateExecer, users map[entityMode
 }
 
 // updateTeams updates LiteLLM_TeamTable.spend and model_spend.
-// Checks spend IS NOT NULL to avoid accidentally updating null values.
 func updateTeams(ctx context.Context, tx spendUpdateExecer, teams map[entityModelKey]float64) error {
 	for _, key := range sortedSpendKeys(teams, compareEntityModelKey) {
 		amount := teams[key]
@@ -286,7 +284,6 @@ func updateTeams(ctx context.Context, tx spendUpdateExecer, teams map[entityMode
 }
 
 // updateOrgs updates LiteLLM_OrganizationTable.spend and model_spend.
-// Checks spend IS NOT NULL to avoid accidentally updating null values.
 func updateOrgs(ctx context.Context, tx spendUpdateExecer, orgs map[entityModelKey]float64) error {
 	for _, key := range sortedSpendKeys(orgs, compareEntityModelKey) {
 		amount := orgs[key]

--- a/internal/litellmdb/spendlog/spend_updater_test.go
+++ b/internal/litellmdb/spendlog/spend_updater_test.go
@@ -17,6 +17,7 @@ func TestAggregateSpendUpdates_AllEntities(t *testing.T) {
 			APIKey:         "token-1",
 			UserID:         "user-1",
 			TeamID:         "team-1",
+			BillingTeamID:  "team-1",
 			OrganizationID: "org-1",
 			Model:          "model-1",
 			EndUser:        "end-user-1",
@@ -26,6 +27,7 @@ func TestAggregateSpendUpdates_AllEntities(t *testing.T) {
 			APIKey:         "token-1",
 			UserID:         "user-1",
 			TeamID:         "team-1",
+			BillingTeamID:  "team-1",
 			OrganizationID: "org-1",
 			Model:          "model-1",
 			EndUser:        "end-user-1",
@@ -97,9 +99,10 @@ func TestAggregateSpendUpdates_PartialEntities(t *testing.T) {
 			// No TeamID, OrganizationID
 		},
 		{
-			APIKey: "token-2",
-			TeamID: "team-1",
-			Spend:  3.0,
+			APIKey:        "token-2",
+			TeamID:        "team-1",
+			BillingTeamID: "team-1",
+			Spend:         3.0,
 			// No UserID, OrganizationID
 		},
 	}
@@ -124,16 +127,18 @@ func TestAggregateSpendUpdates_PartialEntities(t *testing.T) {
 func TestAggregateSpendUpdates_TeamMember(t *testing.T) {
 	batch := []*models.SpendLogEntry{
 		{
-			APIKey: "token-1",
-			UserID: "user-1",
-			TeamID: "team-1",
-			Spend:  10.0,
+			APIKey:        "token-1",
+			UserID:        "user-1",
+			TeamID:        "team-1",
+			BillingTeamID: "team-1",
+			Spend:         10.0,
 		},
 		{
-			APIKey: "token-1",
-			UserID: "user-2",
-			TeamID: "team-1",
-			Spend:  5.0,
+			APIKey:        "token-1",
+			UserID:        "user-2",
+			TeamID:        "team-1",
+			BillingTeamID: "team-1",
+			Spend:         5.0,
 		},
 	}
 
@@ -307,6 +312,7 @@ func TestAggregateSpendUpdatesPreservesZeroSpendModelAndCompositeIDs(t *testing.
 		APIKey:         "token:west",
 		UserID:         "user:east",
 		TeamID:         "team:blue",
+		BillingTeamID:  "team:blue",
 		OrganizationID: "org:green",
 		Model:          "provider:model:v1",
 		Spend:          0,
@@ -316,19 +322,176 @@ func TestAggregateSpendUpdatesPreservesZeroSpendModelAndCompositeIDs(t *testing.
 
 	for _, present := range []bool{
 		hasEntityModelKey(updates.Tokens, entityModelKey{EntityID: entry.APIKey, Model: entry.Model}),
-		hasEntityModelKey(updates.Teams, entityModelKey{EntityID: entry.TeamID, Model: entry.Model}),
+		hasEntityModelKey(updates.Teams, entityModelKey{EntityID: entry.BillingTeamID, Model: entry.Model}),
 		hasEntityModelKey(updates.Orgs, entityModelKey{EntityID: entry.OrganizationID, Model: entry.Model}),
 	} {
 		assert.True(t, present, "zero-spend rows must still create their model counter key")
 	}
 	assert.False(t, hasEntityModelKey(updates.Users, entityModelKey{EntityID: entry.UserID, Model: entry.Model}))
-	_, teamMemberPresent := updates.TeamMembers[teamMemberKey{TeamID: entry.TeamID, UserID: entry.UserID}]
+	_, teamMemberPresent := updates.TeamMembers[teamMemberKey{TeamID: entry.BillingTeamID, UserID: entry.UserID}]
 	assert.True(t, teamMemberPresent)
 	_, organizationMemberPresent := updates.OrganizationMembers[organizationMemberKey{
 		OrganizationID: entry.OrganizationID,
 		UserID:         entry.UserID,
 	}]
 	assert.True(t, organizationMemberPresent)
+}
+
+// TestAggregateSpendUpdates_BillingTeamIDDrivesRouting reproduces the vsellm
+// incident and its neighboring cases: credential_name_as_team_id substitutes
+// the provider credential name into TeamID for log/DailyTeamSpend attribution
+// on keys that have no real team. That synthetic TeamID must never be mistaken
+// for a real team billing entity, in any combination with UserID/OrgID.
+func TestAggregateSpendUpdates_BillingTeamIDDrivesRouting(t *testing.T) {
+	tests := []struct {
+		name string
+
+		userID        string
+		teamID        string // raw attribution value written to the log
+		billingTeamID string // real team, drives the routing decision
+		orgID         string
+		spend         float64
+
+		wantUserCharged       bool
+		wantTeamCharged       bool
+		wantTeamMemberCharged bool
+		wantOrgMemberCharged  bool
+	}{
+		{
+			name:            "no team at all: personal balance charged",
+			userID:          "user-1",
+			teamID:          "",
+			billingTeamID:   "",
+			spend:           10,
+			wantUserCharged: true,
+		},
+		{
+			name:            "credential-name attribution only (the bug case): personal balance still charged",
+			userID:          "user-1",
+			teamID:          "air-ru01", // credential_name_as_team_id fallback
+			billingTeamID:   "",         // token has no real team
+			spend:           10,
+			wantUserCharged: true,
+		},
+		{
+			name:                  "real team, no credential fallback in play: team charged, not personal",
+			userID:                "user-1",
+			teamID:                "team-1",
+			billingTeamID:         "team-1",
+			spend:                 10,
+			wantTeamCharged:       true,
+			wantTeamMemberCharged: true,
+		},
+		{
+			name:                  "real team even though credential_name_as_team_id is enabled: real TeamID always wins over the synthetic fallback",
+			userID:                "user-1",
+			teamID:                "team-1", // TokenInfo.TeamID was non-empty, so proxy_log.go never substitutes credName
+			billingTeamID:         "team-1",
+			spend:                 10,
+			wantTeamCharged:       true,
+			wantTeamMemberCharged: true,
+		},
+		{
+			name:                  "real team plus org membership: both charged, personal balance untouched",
+			userID:                "user-1",
+			teamID:                "team-1",
+			billingTeamID:         "team-1",
+			orgID:                 "org-1",
+			spend:                 10,
+			wantTeamCharged:       true,
+			wantTeamMemberCharged: true,
+			wantOrgMemberCharged:  true,
+		},
+		{
+			name:                 "credential-name attribution plus org membership: org still charged, personal balance still charged, no phantom team",
+			userID:               "user-1",
+			teamID:               "air-ru01",
+			billingTeamID:        "",
+			orgID:                "org-1",
+			spend:                10,
+			wantUserCharged:      true,
+			wantOrgMemberCharged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			batch := []*models.SpendLogEntry{{
+				APIKey:         "token-1",
+				UserID:         tt.userID,
+				TeamID:         tt.teamID,
+				BillingTeamID:  tt.billingTeamID,
+				OrganizationID: tt.orgID,
+				Model:          "model-1",
+				Spend:          tt.spend,
+			}}
+
+			result := aggregateSpendUpdates(batch)
+
+			userKey := entityModelKey{EntityID: tt.userID, Model: "model-1"}
+			if tt.wantUserCharged {
+				assert.Equal(t, tt.spend, result.Users[userKey])
+			} else {
+				assert.NotContains(t, result.Users, userKey)
+			}
+
+			teamKey := entityModelKey{EntityID: tt.billingTeamID, Model: "model-1"}
+			if tt.wantTeamCharged {
+				assert.Equal(t, tt.spend, result.Teams[teamKey])
+			} else {
+				assert.Empty(t, result.Teams, "must never charge the synthetic credential-name team")
+			}
+
+			teamMemberKey := teamMemberKey{TeamID: tt.billingTeamID, UserID: tt.userID}
+			if tt.wantTeamMemberCharged {
+				assert.Equal(t, tt.spend, result.TeamMembers[teamMemberKey])
+			} else {
+				assert.Empty(t, result.TeamMembers, "must never create a membership row for a nonexistent team")
+			}
+
+			orgMemberKey := organizationMemberKey{OrganizationID: tt.orgID, UserID: tt.userID}
+			if tt.wantOrgMemberCharged {
+				assert.Equal(t, tt.spend, result.OrganizationMembers[orgMemberKey])
+			} else {
+				assert.Empty(t, result.OrganizationMembers)
+			}
+		})
+	}
+}
+
+// TestAggregateSpendUpdates_MixedBatchRoutesEachEntryIndependently guards
+// against a routing decision leaking across entries when a single batch mixes
+// a personal key (credential-name attribution only) with a real team key —
+// exactly what a shared AIR instance with one provider credential produces.
+func TestAggregateSpendUpdates_MixedBatchRoutesEachEntryIndependently(t *testing.T) {
+	batch := []*models.SpendLogEntry{
+		{
+			APIKey: "token-personal",
+			UserID: "user-personal",
+			TeamID: "air-ru01", // synthetic attribution, no real team
+			Model:  "model-1",
+			Spend:  7.0,
+		},
+		{
+			APIKey:        "token-team",
+			UserID:        "user-team-member",
+			TeamID:        "team-real",
+			BillingTeamID: "team-real",
+			Model:         "model-1",
+			Spend:         4.0,
+		},
+	}
+
+	result := aggregateSpendUpdates(batch)
+
+	assert.Equal(t, 7.0, result.Users[entityModelKey{EntityID: "user-personal", Model: "model-1"}])
+	assert.NotContains(t, result.Users, entityModelKey{EntityID: "user-team-member", Model: "model-1"})
+
+	assert.Equal(t, 4.0, result.Teams[entityModelKey{EntityID: "team-real", Model: "model-1"}])
+	assert.Len(t, result.Teams, 1, "the synthetic credential-name team must not appear")
+
+	assert.Equal(t, 4.0, result.TeamMembers[teamMemberKey{TeamID: "team-real", UserID: "user-team-member"}])
+	assert.Len(t, result.TeamMembers, 1)
 }
 
 func hasEntityModelKey(updates map[entityModelKey]float64, key entityModelKey) bool {

--- a/internal/litellmdb/spendlog/spend_updater_test.go
+++ b/internal/litellmdb/spendlog/spend_updater_test.go
@@ -399,7 +399,7 @@ func TestEntityUpdatesPersistSpendAndNumericModelSpendTogether(t *testing.T) {
 
 			call := execer.calls[0]
 			assert.Contains(t, call.query, "UPDATE "+tt.table)
-			assert.Contains(t, call.query, "SET spend = spend + $1")
+			assert.Contains(t, call.query, "SET spend = COALESCE(spend, 0) + $1")
 			assert.Contains(t, call.query, "model_spend = jsonb_set")
 			assert.Contains(t, call.query, "ARRAY[$2]::text[]")
 			assert.Contains(t, call.query, "to_jsonb")

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -230,6 +230,12 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 		teamID = logCtx.TokenInfo.TeamID
 		organizationID = logCtx.TokenInfo.OrganizationID
 	}
+	// billingTeamID captures the token's real team assignment before the
+	// credential-name substitution below. That substitution exists only to
+	// attribute spend logs/Kafka/DailyTeamSpend by provider credential on
+	// billing-aggregator instances; it must never make aggregateSpendUpdates
+	// think a personal key belongs to a real, billable team.
+	billingTeamID := teamID
 	if teamID == "" && p.credentialNameAsTeamID {
 		teamID = credName
 	}
@@ -369,6 +375,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 			APIKey:              hashedToken,
 			UserID:              userID,
 			TeamID:              teamID,
+			BillingTeamID:       billingTeamID,
 			OrganizationID:      organizationID,
 			EndUser:             endUser,
 			RequesterIP:         requesterIP,

--- a/internal/proxy/proxy_log_kafka_fallback_test.go
+++ b/internal/proxy/proxy_log_kafka_fallback_test.go
@@ -134,18 +134,24 @@ func TestLogSpendToLiteLLMDB_NormalizesTokenUsageBeforePersisting(t *testing.T) 
 	assert.Equal(t, float64(2), ttlDetails["ephemeral_1h_input_tokens"])
 }
 
+// TestLogSpendToLiteLLMDB_PreservesTeamID also asserts BillingTeamID: it must
+// hold the token's real team only, never the credential-name substitution
+// used for log/DailyTeamSpend attribution — see BillingTeamID's doc comment
+// in models.SpendLogEntry for why aggregateSpendUpdates depends on that split.
 func TestLogSpendToLiteLLMDB_PreservesTeamID(t *testing.T) {
 	tests := []struct {
-		name               string
-		teamID             string
-		actualCredential   string
-		credentialFallback bool
-		expectedID         string
+		name                  string
+		teamID                string
+		actualCredential      string
+		credentialFallback    bool
+		expectedID            string
+		expectedBillingTeamID string
 	}{
-		{name: "no team", expectedID: ""},
-		{name: "credential fallback", credentialFallback: true, expectedID: "openai_primary"},
-		{name: "actual credential fallback", actualCredential: "provider-1", credentialFallback: true, expectedID: "provider-1"},
-		{name: "token team", teamID: "team-1", credentialFallback: true, expectedID: "team-1"},
+		{name: "no team, fallback disabled", expectedID: "", expectedBillingTeamID: ""},
+		{name: "no team, fallback enabled: credential name attributes the log, billing stays personal", credentialFallback: true, expectedID: "openai_primary", expectedBillingTeamID: ""},
+		{name: "no team, fallback enabled, actual credential name differs from key alias", actualCredential: "provider-1", credentialFallback: true, expectedID: "provider-1", expectedBillingTeamID: ""},
+		{name: "real team, fallback enabled: real team wins on both fields", teamID: "team-1", credentialFallback: true, expectedID: "team-1", expectedBillingTeamID: "team-1"},
+		{name: "real team, fallback disabled: unaffected either way", teamID: "team-1", credentialFallback: false, expectedID: "team-1", expectedBillingTeamID: "team-1"},
 	}
 
 	for _, tt := range tests {
@@ -164,6 +170,7 @@ func TestLogSpendToLiteLLMDB_PreservesTeamID(t *testing.T) {
 			require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
 			require.Len(t, dbStub.loggedEntries, 1)
 			assert.Equal(t, tt.expectedID, dbStub.loggedEntries[0].TeamID)
+			assert.Equal(t, tt.expectedBillingTeamID, dbStub.loggedEntries[0].BillingTeamID)
 		})
 	}
 }


### PR DESCRIPTION
Summary
- Initialize null scalar spend counters during accounting updates
- Keep key spend reads unchanged when the current value is unknown
- Add query coverage for null tolerant spend updates

Tests
- go test ./internal/litellmdb/queries ./internal/litellmdb/spendlog
- go test ./internal/proxy