### PR TITLE
Restore user spend updates for team-bound keys

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -886,19 +886,20 @@ func initializeLiteLLMDB(cfg *config.Config, log *slog.Logger) litellmdb.Manager
 	log.Info("Initializing LiteLLM DB integration...", "is_required", cfg.LiteLLMDB.IsRequired)
 
 	litellmCfg := &litellmdb.Config{
-		DatabaseURL:           cfg.LiteLLMDB.DatabaseURL,
-		MaxConns:              int32(cfg.LiteLLMDB.MaxConns),
-		MinConns:              int32(cfg.LiteLLMDB.MinConns),
-		HealthCheckInterval:   cfg.LiteLLMDB.HealthCheckInterval,
-		ConnectTimeout:        cfg.LiteLLMDB.ConnectTimeout,
-		AuthCacheTTL:          cfg.LiteLLMDB.AuthCacheTTL,
-		AuthCacheSize:         cfg.LiteLLMDB.AuthCacheSize,
-		LogQueueSize:          cfg.LiteLLMDB.LogQueueSize,
-		LogBatchSize:          cfg.LiteLLMDB.LogBatchSize,
-		LogFlushInterval:      cfg.LiteLLMDB.LogFlushInterval,
-		LogWorkers:            cfg.LiteLLMDB.LogWorkers,
-		DisableSpendLogsWrite: cfg.LiteLLMDB.DisableSpendLogsWrite,
-		Logger:                log,
+		DatabaseURL:                 cfg.LiteLLMDB.DatabaseURL,
+		MaxConns:                    int32(cfg.LiteLLMDB.MaxConns),
+		MinConns:                    int32(cfg.LiteLLMDB.MinConns),
+		HealthCheckInterval:         cfg.LiteLLMDB.HealthCheckInterval,
+		ConnectTimeout:              cfg.LiteLLMDB.ConnectTimeout,
+		AuthCacheTTL:                cfg.LiteLLMDB.AuthCacheTTL,
+		AuthCacheSize:               cfg.LiteLLMDB.AuthCacheSize,
+		LogQueueSize:                cfg.LiteLLMDB.LogQueueSize,
+		LogBatchSize:                cfg.LiteLLMDB.LogBatchSize,
+		LogFlushInterval:            cfg.LiteLLMDB.LogFlushInterval,
+		LogWorkers:                  cfg.LiteLLMDB.LogWorkers,
+		DisableSpendLogsWrite:       cfg.LiteLLMDB.DisableSpendLogsWrite,
+		IncludeTeamSpendInUserSpend: &cfg.LiteLLMDB.IncludeTeamSpendInUserSpend,
+		Logger:                      log,
 	}
 
 	manager, err := litellmdb.New(litellmCfg)

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -94,6 +94,7 @@ litellm_db:
   log_queue_size: 5000
   log_batch_size: 100
   log_flush_interval: 5s
+  include_team_spend_in_user_spend: true
   log_retry_attempts: 3
   log_retry_delay: 1s
 ```

--- a/docs/litellm-integration/litellm_db.md
+++ b/docs/litellm-integration/litellm_db.md
@@ -14,26 +14,28 @@ litellm_db:
   max_conns: 25
   min_conns: 5
   log_queue_size: 5000
+  include_team_spend_in_user_spend: true
 ```
 
 ## Parameters
 
-| Parameter               | Type     | Default | Description                                           |
-| ----------------------- | -------- | ------- | ----------------------------------------------------- |
-| `enabled`               | bool     | false   | Enable LiteLLM DB integration                         |
-| `is_required`           | bool     | false   | Fail startup if DB connection fails                   |
-| `database_url`          | string   | —       | PostgreSQL connection string (supports env variables) |
-| `max_conns`             | int      | 25      | Maximum database connections                          |
-| `min_conns`             | int      | 5       | Minimum database connections                          |
-| `health_check_interval` | duration | 10s     | DB health check interval                              |
-| `connect_timeout`       | duration | 5s      | Connection timeout                                    |
-| `auth_cache_ttl`        | duration | 20s     | Auth cache TTL                                        |
-| `auth_cache_size`       | int      | 10000   | Auth cache size                                       |
-| `log_queue_size`        | int      | 5000    | Spend log queue size                                  |
-| `log_batch_size`        | int      | 100     | Spend log batch size                                  |
-| `log_flush_interval`    | duration | 5s      | Spend log flush interval                              |
-| `log_retry_attempts`    | int      | 3       | Retry attempts on log insert failure                  |
-| `log_retry_delay`       | duration | 1s      | Delay between retry attempts                          |
+| Parameter                          | Type     | Default | Description                                                       |
+| ---------------------------------- | -------- | ------- | ----------------------------------------------------------------- |
+| `enabled`                          | bool     | false   | Enable LiteLLM DB integration                                     |
+| `is_required`                      | bool     | false   | Fail startup if DB connection fails                               |
+| `database_url`                     | string   | —       | PostgreSQL connection string (supports env variables)             |
+| `max_conns`                        | int      | 25      | Maximum database connections                                      |
+| `min_conns`                        | int      | 5       | Minimum database connections                                      |
+| `health_check_interval`            | duration | 10s     | DB health check interval                                          |
+| `connect_timeout`                  | duration | 5s      | Connection timeout                                                |
+| `auth_cache_ttl`                   | duration | 20s     | Auth cache TTL                                                    |
+| `auth_cache_size`                  | int      | 10000   | Auth cache size                                                   |
+| `log_queue_size`                   | int      | 5000    | Spend log queue size                                              |
+| `log_batch_size`                   | int      | 100     | Spend log batch size                                              |
+| `log_flush_interval`               | duration | 5s      | Spend log flush interval                                          |
+| `include_team_spend_in_user_spend` | bool     | true    | Include team-bound events in the cumulative user spend projection |
+| `log_retry_attempts`               | int      | 3       | Retry attempts on log insert failure                              |
+| `log_retry_delay`                  | duration | 1s      | Delay between retry attempts                                      |
 
 ## Features
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -895,6 +895,10 @@ type LiteLLMDBConfig struct {
 	// where Kafka (see KafkaConfig) is the sole spend-analytics write-path.
 	DisableSpendLogsWrite bool `yaml:"disable_spend_logs_write"` // default: false
 
+	// IncludeTeamSpendInUserSpend controls whether team-bound events update the
+	// cumulative LiteLLM_UserTable spend projection.
+	IncludeTeamSpendInUserSpend bool `yaml:"include_team_spend_in_user_spend"` // default: true
+
 	// EnforceBudgetReservation enables atomic Redis-backed budget pre-reservation
 	// (prevents the overspend race described in todo_auth_billing.md P1.4).
 	// Auto-disabled (safe no-op) if redis.enabled=false, regardless of this flag.
@@ -1118,22 +1122,23 @@ func (m *MonitoringConfig) UnmarshalYAML(value *yaml.Node) error {
 // UnmarshalYAML implements custom unmarshaling for LiteLLMDBConfig with env variable support
 func (l *LiteLLMDBConfig) UnmarshalYAML(value *yaml.Node) error {
 	type tempConfig struct {
-		Enabled               string `yaml:"enabled"`
-		IsRequired            string `yaml:"is_required"`
-		LoadLitellmDBModels   string `yaml:"load_db_models"`
-		LitellmDBSyncInterval string `yaml:"db_model_sync_interval"`
-		DatabaseURL           string `yaml:"database_url"`
-		MaxConns              string `yaml:"max_conns"`
-		MinConns              string `yaml:"min_conns"`
-		HealthCheckInterval   string `yaml:"health_check_interval"`
-		ConnectTimeout        string `yaml:"connect_timeout"`
-		AuthCacheTTL          string `yaml:"auth_cache_ttl"`
-		AuthCacheSize         string `yaml:"auth_cache_size"`
-		LogQueueSize          string `yaml:"log_queue_size"`
-		LogBatchSize          string `yaml:"log_batch_size"`
-		LogFlushInterval      string `yaml:"log_flush_interval"`
-		LogWorkers            string `yaml:"log_workers"`
-		DisableSpendLogsWrite string `yaml:"disable_spend_logs_write"`
+		Enabled                     string `yaml:"enabled"`
+		IsRequired                  string `yaml:"is_required"`
+		LoadLitellmDBModels         string `yaml:"load_db_models"`
+		LitellmDBSyncInterval       string `yaml:"db_model_sync_interval"`
+		DatabaseURL                 string `yaml:"database_url"`
+		MaxConns                    string `yaml:"max_conns"`
+		MinConns                    string `yaml:"min_conns"`
+		HealthCheckInterval         string `yaml:"health_check_interval"`
+		ConnectTimeout              string `yaml:"connect_timeout"`
+		AuthCacheTTL                string `yaml:"auth_cache_ttl"`
+		AuthCacheSize               string `yaml:"auth_cache_size"`
+		LogQueueSize                string `yaml:"log_queue_size"`
+		LogBatchSize                string `yaml:"log_batch_size"`
+		LogFlushInterval            string `yaml:"log_flush_interval"`
+		LogWorkers                  string `yaml:"log_workers"`
+		DisableSpendLogsWrite       string `yaml:"disable_spend_logs_write"`
+		IncludeTeamSpendInUserSpend string `yaml:"include_team_spend_in_user_spend"`
 
 		EnforceBudgetReservation         string `yaml:"enforce_budget_reservation"`
 		BudgetReservationTTL             string `yaml:"budget_reservation_ttl"`
@@ -1161,6 +1166,9 @@ func (l *LiteLLMDBConfig) UnmarshalYAML(value *yaml.Node) error {
 		return err
 	}
 	if l.DisableSpendLogsWrite, err = parseField(temp.DisableSpendLogsWrite, false, strconv.ParseBool, "litellm_db.disable_spend_logs_write"); err != nil {
+		return err
+	}
+	if l.IncludeTeamSpendInUserSpend, err = parseField(temp.IncludeTeamSpendInUserSpend, true, strconv.ParseBool, "litellm_db.include_team_spend_in_user_spend"); err != nil {
 		return err
 	}
 	if l.EnforceBudgetReservation, err = parseField(temp.EnforceBudgetReservation, false, strconv.ParseBool, "litellm_db.enforce_budget_reservation"); err != nil {
@@ -1501,6 +1509,7 @@ func defaultLiteLLMDBConfig() LiteLLMDBConfig {
 		LogBatchSize:                     100,
 		LogFlushInterval:                 5 * time.Second,
 		LogWorkers:                       4,
+		IncludeTeamSpendInUserSpend:      true,
 		EnforceBudgetReservation:         false,
 		BudgetReservationTTL:             15 * time.Minute,
 		EnforceKeyRateLimits:             false,

--- a/internal/config/config_budget_test.go
+++ b/internal/config/config_budget_test.go
@@ -16,6 +16,13 @@ func TestLiteLLMDBBudgetEnforcementIsOptIn(t *testing.T) {
 	assert.False(t, cfg.EnforceKeyRateLimits)
 	assert.Equal(t, 15*time.Minute, cfg.BudgetReservationTTL)
 	assert.Equal(t, 1000, cfg.DefaultEstimatedCompletionTokens)
+	assert.True(t, cfg.IncludeTeamSpendInUserSpend)
+}
+
+func TestLiteLLMDBTeamSpendProjectionParsesExplicitSetting(t *testing.T) {
+	var cfg LiteLLMDBConfig
+	require.NoError(t, yaml.Unmarshal([]byte("include_team_spend_in_user_spend: false\n"), &cfg))
+	assert.False(t, cfg.IncludeTeamSpendInUserSpend)
 }
 
 func TestServerCredentialNameAsTeamIDParsesExplicitSetting(t *testing.T) {

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -206,6 +206,7 @@ func PrintConfig(logger *slog.Logger, cfg *Config) {
 			"log_flush_interval", cfg.LiteLLMDB.LogFlushInterval.String(),
 			"log_workers", cfg.LiteLLMDB.LogWorkers,
 			"disable_spend_logs_write", cfg.LiteLLMDB.DisableSpendLogsWrite,
+			"include_team_spend_in_user_spend", cfg.LiteLLMDB.IncludeTeamSpendInUserSpend,
 			"enforce_budget_reservation", cfg.LiteLLMDB.EnforceBudgetReservation,
 			"budget_reservation_ttl", cfg.LiteLLMDB.BudgetReservationTTL.String(),
 			"enforce_key_rate_limits", cfg.LiteLLMDB.EnforceKeyRateLimits,

--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -69,23 +69,29 @@ type Config struct {
 	// Postgres while leaving auth (ValidateToken) untouched (default: false).
 	DisableSpendLogsWrite bool
 
+	// IncludeTeamSpendInUserSpend controls whether team-bound events update the
+	// cumulative LiteLLM_UserTable spend projection. Nil defaults to true.
+	IncludeTeamSpendInUserSpend *bool
+
 	// Logger
 	Logger *slog.Logger
 }
 
 // DefaultConfig returns configuration with default values
 func DefaultConfig() *Config {
+	includeTeamSpendInUserSpend := true
 	return &Config{
-		MaxConns:            10,
-		MinConns:            2,
-		HealthCheckInterval: 10 * time.Second,
-		ConnectTimeout:      5 * time.Second,
-		AuthCacheTTL:        5 * time.Second,
-		AuthCacheSize:       10000,
-		LogQueueSize:        10000,
-		LogBatchSize:        100,
-		LogFlushInterval:    5 * time.Second,
-		LogWorkers:          4,
+		MaxConns:                    10,
+		MinConns:                    2,
+		HealthCheckInterval:         10 * time.Second,
+		ConnectTimeout:              5 * time.Second,
+		AuthCacheTTL:                5 * time.Second,
+		AuthCacheSize:               10000,
+		LogQueueSize:                10000,
+		LogBatchSize:                100,
+		LogFlushInterval:            5 * time.Second,
+		LogWorkers:                  4,
+		IncludeTeamSpendInUserSpend: &includeTeamSpendInUserSpend,
 	}
 }
 
@@ -126,9 +132,17 @@ func (c *Config) ApplyDefaults() {
 	if c.LogWorkers == 0 {
 		c.LogWorkers = defaults.LogWorkers
 	}
+	if c.IncludeTeamSpendInUserSpend == nil {
+		c.IncludeTeamSpendInUserSpend = defaults.IncludeTeamSpendInUserSpend
+	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()
 	}
+}
+
+// TeamSpendUpdatesUserSpend reports the configured user projection policy.
+func (c *Config) TeamSpendUpdatesUserSpend() bool {
+	return c == nil || c.IncludeTeamSpendInUserSpend == nil || *c.IncludeTeamSpendInUserSpend
 }
 
 // Validate checks configuration validity

--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -592,12 +592,9 @@ type SpendLogEntry struct {
 	OrganizationID string // Organization ID
 	EndUser        string // End user ID (from metadata)
 
-	// BillingTeamID is the token's real team assignment only (empty when the
-	// key has no team), independent of any credential_name_as_team_id
-	// substitution in TeamID above. aggregateSpendUpdates must key off this
-	// field to decide whether spend goes to LiteLLM_UserTable (personal) or
-	// LiteLLM_TeamTable/LiteLLM_TeamMembership (team) — a synthetic TeamID
-	// used only for log attribution must never suppress the personal debit.
+	// BillingTeamID is the token's real team assignment. It is independent of
+	// credential_name_as_team_id substitution in TeamID. Team and membership
+	// projections use this field so synthetic attribution cannot create a team.
 	BillingTeamID string
 
 	// Status

--- a/internal/litellmdb/models/models_test.go
+++ b/internal/litellmdb/models/models_test.go
@@ -23,6 +23,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 10000, cfg.LogQueueSize)
 	assert.Equal(t, 100, cfg.LogBatchSize)
 	assert.Equal(t, 5*time.Second, cfg.LogFlushInterval)
+	assert.True(t, cfg.TeamSpendUpdatesUserSpend())
 }
 
 // ==================== Config.ApplyDefaults Tests ====================
@@ -41,7 +42,22 @@ func TestConfig_ApplyDefaults_AllZero(t *testing.T) {
 	assert.Equal(t, defaults.LogQueueSize, cfg.LogQueueSize)
 	assert.Equal(t, defaults.LogBatchSize, cfg.LogBatchSize)
 	assert.Equal(t, defaults.LogFlushInterval, cfg.LogFlushInterval)
+	assert.True(t, cfg.TeamSpendUpdatesUserSpend())
 	assert.NotNil(t, cfg.Logger)
+}
+
+func TestConfig_ApplyDefaults_PreservesDisabledTeamSpendProjection(t *testing.T) {
+	disabled := false
+	cfg := &Config{IncludeTeamSpendInUserSpend: &disabled}
+
+	cfg.ApplyDefaults()
+
+	assert.False(t, cfg.TeamSpendUpdatesUserSpend())
+}
+
+func TestConfig_NilDefaultsTeamSpendProjectionToEnabled(t *testing.T) {
+	var cfg *Config
+	assert.True(t, cfg.TeamSpendUpdatesUserSpend())
 }
 
 func TestConfig_ApplyDefaults_KeepNonZero(t *testing.T) {

--- a/internal/litellmdb/spendlog/logger.go
+++ b/internal/litellmdb/spendlog/logger.go
@@ -694,7 +694,10 @@ func (sl *Logger) writeBatchInTransaction(ctx context.Context, tx pgx.Tx, batch 
 		return nil, fmt.Errorf("map inserted rows to batch: expected %d, mapped %d", len(insertedIDs), len(filteredBatch))
 	}
 	accountingBatch := accountingEntries(filteredBatch)
-	spendUpdates := aggregateSpendUpdates(insertedEntries(accountingBatch))
+	spendUpdates := aggregateSpendUpdates(
+		insertedEntries(accountingBatch),
+		sl.config.TeamSpendUpdatesUserSpend(),
+	)
 	if err := executeSpendUpdates(ctx, tx, spendUpdates); err != nil {
 		return nil, fmt.Errorf("spend updates: %w", err)
 	}

--- a/internal/litellmdb/spendlog/spend_observability_test.go
+++ b/internal/litellmdb/spendlog/spend_observability_test.go
@@ -37,7 +37,7 @@ func TestFilterBatchByInsertedIDs_DeduplicatesInputBatch(t *testing.T) {
 	inserted := filterBatchByInsertedIDs(batch, []string{"req-1"})
 	require.Len(t, inserted, 1)
 	assert.Equal(t, "req-1", inserted[0].entry.RequestID)
-	assert.Equal(t, 1.0, aggregateSpendUpdates(insertedEntries(inserted)).Tokens[entityModelKey{EntityID: "key-1"}])
+	assert.Equal(t, 1.0, aggregateSpendUpdates(insertedEntries(inserted), true).Tokens[entityModelKey{EntityID: "key-1"}])
 }
 
 func TestRecordCommittedBatchCountsOnlyPersistedRows(t *testing.T) {

--- a/internal/litellmdb/spendlog/spend_updater.go
+++ b/internal/litellmdb/spendlog/spend_updater.go
@@ -133,12 +133,8 @@ func aggregateSpendUpdates(batch []*models.SpendLogEntry) *SpendUpdates {
 			updates.Tokens[entityModelKey{EntityID: entry.APIKey, Model: entry.Model}] += entry.Spend
 		}
 
-		// Team spend is charged through team membership, not the personal
-		// balance. Routed on BillingTeamID, not TeamID: TeamID can hold a
-		// synthetic provider-credential name (credential_name_as_team_id)
-		// used only for log/DailyTeamSpend attribution, and that must not
-		// suppress the personal debit or be charged to a nonexistent team.
-		if entry.UserID != "" && entry.BillingTeamID == "" {
+		// User spend is an independent cumulative projection.
+		if entry.UserID != "" {
 			updates.Users[entityModelKey{EntityID: entry.UserID, Model: entry.Model}] += entry.Spend
 		}
 

--- a/internal/litellmdb/spendlog/spend_updater.go
+++ b/internal/litellmdb/spendlog/spend_updater.go
@@ -113,7 +113,7 @@ func compareOrganizationMemberKey(left, right organizationMemberKey) int {
 //	    Tokens: {"abc": 15},       ← 1 UPDATE instead of 2
 //	    Users: {"user1": 15},      ← 1 UPDATE instead of 2
 //	  }
-func aggregateSpendUpdates(batch []*models.SpendLogEntry) *SpendUpdates {
+func aggregateSpendUpdates(batch []*models.SpendLogEntry, includeTeamSpendInUserSpend bool) *SpendUpdates {
 	updates := &SpendUpdates{
 		Tokens:              make(map[entityModelKey]float64),
 		Users:               make(map[entityModelKey]float64),
@@ -133,8 +133,8 @@ func aggregateSpendUpdates(batch []*models.SpendLogEntry) *SpendUpdates {
 			updates.Tokens[entityModelKey{EntityID: entry.APIKey, Model: entry.Model}] += entry.Spend
 		}
 
-		// User spend is an independent cumulative projection.
-		if entry.UserID != "" {
+		// User spend includes team-bound events when configured.
+		if entry.UserID != "" && (includeTeamSpendInUserSpend || entry.BillingTeamID == "") {
 			updates.Users[entityModelKey{EntityID: entry.UserID, Model: entry.Model}] += entry.Spend
 		}
 

--- a/internal/litellmdb/spendlog/spend_updater_test.go
+++ b/internal/litellmdb/spendlog/spend_updater_test.go
@@ -40,7 +40,7 @@ func TestAggregateSpendUpdates_AllEntities(t *testing.T) {
 		},
 	}
 
-	result := aggregateSpendUpdates(batch)
+	result := aggregateSpendUpdates(batch, true)
 
 	// Token aggregation
 	assert.Equal(t, 15.0, result.Tokens[entityModelKey{EntityID: "token-1", Model: "model-1"}])
@@ -66,7 +66,7 @@ func TestAggregateSpendUpdates_AllEntities(t *testing.T) {
 // TestAggregateSpendUpdates_EmptyBatch tests empty batch
 func TestAggregateSpendUpdates_EmptyBatch(t *testing.T) {
 	batch := []*models.SpendLogEntry{}
-	result := aggregateSpendUpdates(batch)
+	result := aggregateSpendUpdates(batch, true)
 
 	assert.Empty(t, result.Tokens)
 	assert.Empty(t, result.Users)
@@ -79,7 +79,7 @@ func TestAggregateSpendUpdates_EmptyBatch(t *testing.T) {
 
 // TestAggregateSpendUpdates_NilBatch tests nil batch
 func TestAggregateSpendUpdates_NilBatch(t *testing.T) {
-	result := aggregateSpendUpdates(nil)
+	result := aggregateSpendUpdates(nil, true)
 	// Function returns initialized empty map, not nil
 	assert.Empty(t, result.Tokens)
 }
@@ -107,7 +107,7 @@ func TestAggregateSpendUpdates_PartialEntities(t *testing.T) {
 		},
 	}
 
-	result := aggregateSpendUpdates(batch)
+	result := aggregateSpendUpdates(batch, true)
 
 	// Token aggregation works
 	assert.Equal(t, 15.0, result.Tokens[entityModelKey{EntityID: "token-1"}])
@@ -142,7 +142,7 @@ func TestAggregateSpendUpdates_TeamMember(t *testing.T) {
 		},
 	}
 
-	result := aggregateSpendUpdates(batch)
+	result := aggregateSpendUpdates(batch, true)
 
 	assert.Equal(t, 10.0, result.Users[entityModelKey{EntityID: "user-1"}])
 	assert.Equal(t, 5.0, result.Users[entityModelKey{EntityID: "user-2"}])
@@ -169,7 +169,7 @@ func TestAggregateSpendUpdates_OrganizationMembership(t *testing.T) {
 		},
 	}
 
-	result := aggregateSpendUpdates(batch)
+	result := aggregateSpendUpdates(batch, true)
 	assert.Equal(t, 15.0, result.Orgs[entityModelKey{EntityID: "org-1"}])
 	assert.Equal(t, 10.0, result.OrganizationMembers[organizationMemberKey{OrganizationID: "org-1", UserID: "user-1"}])
 	assert.Equal(t, 5.0, result.OrganizationMembers[organizationMemberKey{OrganizationID: "org-1", UserID: "user-2"}])
@@ -319,7 +319,7 @@ func TestAggregateSpendUpdatesPreservesZeroSpendModelAndCompositeIDs(t *testing.
 		Spend:          0,
 	}
 
-	updates := aggregateSpendUpdates([]*models.SpendLogEntry{entry})
+	updates := aggregateSpendUpdates([]*models.SpendLogEntry{entry}, true)
 
 	for _, present := range []bool{
 		hasEntityModelKey(updates.Tokens, entityModelKey{EntityID: entry.APIKey, Model: entry.Model}),
@@ -430,7 +430,7 @@ func TestAggregateSpendUpdates_BillingTeamIDDrivesRouting(t *testing.T) {
 				Spend:          tt.spend,
 			}}
 
-			result := aggregateSpendUpdates(batch)
+			result := aggregateSpendUpdates(batch, true)
 
 			userKey := entityModelKey{EntityID: tt.userID, Model: "model-1"}
 			if tt.wantUserUpdated {
@@ -482,7 +482,7 @@ func TestAggregateSpendUpdatesUpdatesUserAndTeamCounters(t *testing.T) {
 		},
 	}
 
-	result := aggregateSpendUpdates(batch)
+	result := aggregateSpendUpdates(batch, true)
 
 	assert.Equal(t, 7.0, result.Tokens[entityModelKey{EntityID: "token-synthetic", Model: "model-1"}])
 	assert.Equal(t, 4.0, result.Tokens[entityModelKey{EntityID: "token-team", Model: "model-1"}])
@@ -497,6 +497,33 @@ func TestAggregateSpendUpdatesUpdatesUserAndTeamCounters(t *testing.T) {
 
 	assert.Equal(t, 4.0, result.TeamMembers[teamMemberKey{TeamID: "team-real", UserID: "user-shared"}])
 	assert.Len(t, result.TeamMembers, 1)
+}
+
+func TestAggregateSpendUpdatesCanExcludeTeamSpendFromUserSpend(t *testing.T) {
+	batch := []*models.SpendLogEntry{
+		{
+			APIKey:        "token-team",
+			UserID:        "user-1",
+			TeamID:        "team-1",
+			BillingTeamID: "team-1",
+			Model:         "model-1",
+			Spend:         4.0,
+		},
+		{
+			APIKey: "token-personal",
+			UserID: "user-1",
+			Model:  "model-1",
+			Spend:  7.0,
+		},
+	}
+
+	result := aggregateSpendUpdates(batch, false)
+
+	assert.Equal(t, 4.0, result.Tokens[entityModelKey{EntityID: "token-team", Model: "model-1"}])
+	assert.Equal(t, 7.0, result.Tokens[entityModelKey{EntityID: "token-personal", Model: "model-1"}])
+	assert.Equal(t, 7.0, result.Users[entityModelKey{EntityID: "user-1", Model: "model-1"}])
+	assert.Equal(t, 4.0, result.Teams[entityModelKey{EntityID: "team-1", Model: "model-1"}])
+	assert.Equal(t, 4.0, result.TeamMembers[teamMemberKey{TeamID: "team-1", UserID: "user-1"}])
 }
 
 func hasEntityModelKey(updates map[entityModelKey]float64, key entityModelKey) bool {

--- a/internal/litellmdb/spendlog/spend_updater_test.go
+++ b/internal/litellmdb/spendlog/spend_updater_test.go
@@ -46,8 +46,8 @@ func TestAggregateSpendUpdates_AllEntities(t *testing.T) {
 	assert.Equal(t, 15.0, result.Tokens[entityModelKey{EntityID: "token-1", Model: "model-1"}])
 	assert.Equal(t, 3.0, result.Tokens[entityModelKey{EntityID: "token-2"}])
 
-	// Personal user aggregation
-	assert.NotContains(t, result.Users, entityModelKey{EntityID: "user-1", Model: "model-1"})
+	// User aggregation
+	assert.Equal(t, 15.0, result.Users[entityModelKey{EntityID: "user-1", Model: "model-1"}])
 	assert.Equal(t, 3.0, result.Users[entityModelKey{EntityID: "user-2"}])
 
 	// Team aggregation
@@ -144,7 +144,8 @@ func TestAggregateSpendUpdates_TeamMember(t *testing.T) {
 
 	result := aggregateSpendUpdates(batch)
 
-	assert.Empty(t, result.Users)
+	assert.Equal(t, 10.0, result.Users[entityModelKey{EntityID: "user-1"}])
+	assert.Equal(t, 5.0, result.Users[entityModelKey{EntityID: "user-2"}])
 	assert.Equal(t, 15.0, result.Teams[entityModelKey{EntityID: "team-1"}])
 
 	// Team membership should aggregate by team:user
@@ -327,7 +328,7 @@ func TestAggregateSpendUpdatesPreservesZeroSpendModelAndCompositeIDs(t *testing.
 	} {
 		assert.True(t, present, "zero-spend rows must still create their model counter key")
 	}
-	assert.False(t, hasEntityModelKey(updates.Users, entityModelKey{EntityID: entry.UserID, Model: entry.Model}))
+	assert.True(t, hasEntityModelKey(updates.Users, entityModelKey{EntityID: entry.UserID, Model: entry.Model}))
 	_, teamMemberPresent := updates.TeamMembers[teamMemberKey{TeamID: entry.BillingTeamID, UserID: entry.UserID}]
 	assert.True(t, teamMemberPresent)
 	_, organizationMemberPresent := updates.OrganizationMembers[organizationMemberKey{
@@ -352,64 +353,67 @@ func TestAggregateSpendUpdates_BillingTeamIDDrivesRouting(t *testing.T) {
 		orgID         string
 		spend         float64
 
-		wantUserCharged       bool
+		wantUserUpdated       bool
 		wantTeamCharged       bool
 		wantTeamMemberCharged bool
 		wantOrgMemberCharged  bool
 	}{
 		{
-			name:            "no team at all: personal balance charged",
+			name:            "no team",
 			userID:          "user-1",
 			teamID:          "",
 			billingTeamID:   "",
 			spend:           10,
-			wantUserCharged: true,
+			wantUserUpdated: true,
 		},
 		{
-			name:            "credential-name attribution only (the bug case): personal balance still charged",
+			name:            "synthetic team attribution",
 			userID:          "user-1",
 			teamID:          "air-ru01", // credential_name_as_team_id fallback
 			billingTeamID:   "",         // token has no real team
 			spend:           10,
-			wantUserCharged: true,
+			wantUserUpdated: true,
 		},
 		{
-			name:                  "real team, no credential fallback in play: team charged, not personal",
+			name:                  "real team",
 			userID:                "user-1",
 			teamID:                "team-1",
 			billingTeamID:         "team-1",
 			spend:                 10,
+			wantUserUpdated:       true,
 			wantTeamCharged:       true,
 			wantTeamMemberCharged: true,
 		},
 		{
-			name:                  "real team even though credential_name_as_team_id is enabled: real TeamID always wins over the synthetic fallback",
+			name:                  "real team with credential attribution enabled",
 			userID:                "user-1",
 			teamID:                "team-1", // TokenInfo.TeamID was non-empty, so proxy_log.go never substitutes credName
 			billingTeamID:         "team-1",
 			spend:                 10,
+			wantUserUpdated:       true,
 			wantTeamCharged:       true,
 			wantTeamMemberCharged: true,
 		},
 		{
-			name:                  "real team plus org membership: both charged, personal balance untouched",
+			name:                  "real team with organization membership",
 			userID:                "user-1",
 			teamID:                "team-1",
 			billingTeamID:         "team-1",
 			orgID:                 "org-1",
 			spend:                 10,
+			wantUserUpdated:       true,
 			wantTeamCharged:       true,
 			wantTeamMemberCharged: true,
 			wantOrgMemberCharged:  true,
 		},
 		{
-			name:                 "credential-name attribution plus org membership: org still charged, personal balance still charged, no phantom team",
+			name:                 "synthetic team attribution with organization membership",
 			userID:               "user-1",
 			teamID:               "air-ru01",
 			billingTeamID:        "",
 			orgID:                "org-1",
 			spend:                10,
-			wantUserCharged:      true,
+			wantUserUpdated:      true,
 			wantOrgMemberCharged: true,
 		},
 	}
@@ -429,7 +433,7 @@ func TestAggregateSpendUpdates_BillingTeamIDDrivesRouting(t *testing.T) {
 			result := aggregateSpendUpdates(batch)
 
 			userKey := entityModelKey{EntityID: tt.userID, Model: "model-1"}
-			if tt.wantUserCharged {
+			if tt.wantUserUpdated {
 				assert.Equal(t, tt.spend, result.Users[userKey])
 			} else {
 				assert.NotContains(t, result.Users, userKey)
@@ -459,22 +463,18 @@ func TestAggregateSpendUpdates_BillingTeamIDDrivesRouting(t *testing.T) {
 	}
 }
 
-// TestAggregateSpendUpdates_MixedBatchRoutesEachEntryIndependently guards
-// against a routing decision leaking across entries when a single batch mixes
-// a personal key (credential-name attribution only) with a real team key —
-// exactly what a shared AIR instance with one provider credential produces.
-func TestAggregateSpendUpdates_MixedBatchRoutesEachEntryIndependently(t *testing.T) {
+func TestAggregateSpendUpdatesUpdatesUserAndTeamCounters(t *testing.T) {
 	batch := []*models.SpendLogEntry{
 		{
-			APIKey: "token-personal",
-			UserID: "user-personal",
-			TeamID: "air-ru01", // synthetic attribution, no real team
+			APIKey: "token-synthetic",
+			UserID: "user-shared",
+			TeamID: "air-ru01",
 			Model:  "model-1",
 			Spend:  7.0,
 		},
 		{
 			APIKey:        "token-team",
-			UserID:        "user-team-member",
+			UserID:        "user-shared",
 			TeamID:        "team-real",
 			BillingTeamID: "team-real",
 			Model:         "model-1",
@@ -484,13 +484,18 @@ func TestAggregateSpendUpdates_MixedBatchRoutesEachEntryIndependently(t *testing
 
 	result := aggregateSpendUpdates(batch)
 
-	assert.Equal(t, 7.0, result.Users[entityModelKey{EntityID: "user-personal", Model: "model-1"}])
-	assert.NotContains(t, result.Users, entityModelKey{EntityID: "user-team-member", Model: "model-1"})
+	assert.Equal(t, 7.0, result.Tokens[entityModelKey{EntityID: "token-synthetic", Model: "model-1"}])
+	assert.Equal(t, 4.0, result.Tokens[entityModelKey{EntityID: "token-team", Model: "model-1"}])
+	assert.Len(t, result.Tokens, 2)
 
+	assert.Equal(t, 11.0, result.Users[entityModelKey{EntityID: "user-shared", Model: "model-1"}])
+	assert.Len(t, result.Users, 1)
+
+	assert.NotContains(t, result.Teams, entityModelKey{EntityID: "air-ru01", Model: "model-1"})
 	assert.Equal(t, 4.0, result.Teams[entityModelKey{EntityID: "team-real", Model: "model-1"}])
-	assert.Len(t, result.Teams, 1, "the synthetic credential-name team must not appear")
+	assert.Len(t, result.Teams, 1)
 
-	assert.Equal(t, 4.0, result.TeamMembers[teamMemberKey{TeamID: "team-real", UserID: "user-team-member"}])
+	assert.Equal(t, 4.0, result.TeamMembers[teamMemberKey{TeamID: "team-real", UserID: "user-shared"}])
 	assert.Len(t, result.TeamMembers, 1)
 }
 


### PR DESCRIPTION
## Problem

Spend events from team-bound keys update key, team, membership, daily, and raw spend data. `LiteLLM_UserTable.spend` remains stale and diverges from daily user spend.

## Change

Update the cumulative user spend projection for every event with a user ID. Preserve real team and membership routing through `BillingTeamID`. Keep budget enforcement unchanged.

Add `litellm_db.include_team_spend_in_user_spend`. The default value `true` applies the cumulative user update to team-bound events. Set it to `false` to retain the current production behavior. Personal user, key, team, membership, organization, daily, and raw spend updates remain unchanged.

Extend aggregation coverage for personal keys, synthetic team attribution, real teams, organizations, zero spend, mixed batches, and both switch values.

## Verification

`go test ./...`

`go test -race ./internal/litellmdb/spendlog ./internal/proxy`

`golangci-lint run ./cmd/server ./internal/config ./internal/litellmdb/models ./internal/litellmdb/spendlog`