### PR TITLE
Log client-facing public model alias in spend_logs_metadata

### DIFF
--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -315,7 +315,7 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 	return string(jsonBytes)
 }
 
-func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRequest bool) string {
+func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRequest bool, modelID, publicModelID string) string {
 	var doc map[string]interface{}
 	if json.Unmarshal([]byte(metadata), &doc) != nil {
 		doc = make(map[string]interface{})
@@ -330,6 +330,17 @@ func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRe
 	spendMetadata["is_proxy_request"] = isProxyRequest
 	if providerResponseID != "" {
 		spendMetadata["provider_response_id"] = providerResponseID
+	}
+	// Only set when the client used a public alias (e.g. a "-highlimits"
+	// pricing tier) that differs from the model billing was resolved
+	// against, so spend rows for aliased models can be told apart after
+	// the fact. Deliberately kept out of model_map_information: in
+	// upstream LiteLLM that field's value is a model_info/pricing object
+	// resolved via litellm.model_cost, not an identifier string, and
+	// overloading it risks a type mismatch for any future consumer that
+	// parses it against that contract.
+	if publicModelID != "" && publicModelID != modelID {
+		spendMetadata["public_model_name"] = publicModelID
 	}
 	encoded, err := json.Marshal(doc)
 	if err != nil {

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -271,6 +271,42 @@ func TestBuildMetadata(t *testing.T) {
 	})
 }
 
+func TestAddAIRSpendMetadata(t *testing.T) {
+	t.Run("no_alias", func(t *testing.T) {
+		result := addAIRSpendMetadata("{}", "event-1", "", false, "gpt-4o", "gpt-4o")
+		var m map[string]interface{}
+		err := json.Unmarshal([]byte(result), &m)
+		require.NoError(t, err)
+
+		spendMetadata, ok := m["spend_logs_metadata"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "event-1", spendMetadata["air_event_id"])
+		assert.NotContains(t, spendMetadata, "public_model_name")
+	})
+
+	t.Run("with_public_alias", func(t *testing.T) {
+		result := addAIRSpendMetadata("{}", "event-2", "", false, "gemini-3-flash-preview", "google/gemini-3-flash-preview-highlimits")
+		var m map[string]interface{}
+		err := json.Unmarshal([]byte(result), &m)
+		require.NoError(t, err)
+
+		spendMetadata, ok := m["spend_logs_metadata"].(map[string]interface{})
+		require.True(t, ok)
+		assert.Equal(t, "google/gemini-3-flash-preview-highlimits", spendMetadata["public_model_name"])
+	})
+
+	t.Run("empty_public_model_id", func(t *testing.T) {
+		result := addAIRSpendMetadata("{}", "event-3", "", false, "gpt-4o", "")
+		var m map[string]interface{}
+		err := json.Unmarshal([]byte(result), &m)
+		require.NoError(t, err)
+
+		spendMetadata, ok := m["spend_logs_metadata"].(map[string]interface{})
+		require.True(t, ok)
+		assert.NotContains(t, spendMetadata, "public_model_name")
+	})
+}
+
 func TestExtractEndUser(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -346,7 +346,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	requesterIP := getClientIP(logCtx.Request)
 	overheadMs := float64(time.Since(logCtx.StartTime).Microseconds()) / 1000.0
 	metadata := buildMetadata(hashedToken, logCtx.TokenInfo, logCtx.ErrorMsg, logCtx.HTTPStatus, logCtx.TokenUsage, requesterIP, tokenCosts, logCtx.ModelID, overheadMs, kafkaFallbackReason)
-	metadata = addAIRSpendMetadata(metadata, logCtx.RequestID, logCtx.ClientResponseID, logCtx.IsProxyRequest)
+	metadata = addAIRSpendMetadata(metadata, logCtx.RequestID, logCtx.ClientResponseID, logCtx.IsProxyRequest, logCtx.ModelID, logCtx.PublicModelID)
 
 	var completionStartTime *time.Time
 	if !logCtx.CompletionStartTime.IsZero() {


### PR DESCRIPTION
## Summary
When a client calls a model through a public alias (e.g. `google/gemini-3-flash-preview-highlimits`, which intentionally bills at a different rate via `resolveBillingPrice`'s public-alias-first price lookup added in #95), only the resolved model name ends up in the DB — there's no way to tell after the fact which alias the client actually used.

Considered writing this into `model_map_information.model_map_value`, but that field is reserved in upstream LiteLLM for a model_info/pricing object (resolved via `litellm.model_cost`), not an identifier string — it's always been `nil` in AIR so nothing breaks today, but overloading its type is a landmine for any future consumer (dashboard, analytics) that parses it against the upstream contract.

Instead this writes `public_model_name` into `spend_logs_metadata` — the existing pocket already used for AIR-specific fields (`air_event_id`, `accounting_eligible`, `is_proxy_request`, `provider_response_id`) — via `addAIRSpendMetadata`, which already has everything needed at the call site.

- `addAIRSpendMetadata` now takes `modelID`/`publicModelID` and sets `spend_logs_metadata.public_model_name = publicModelID` only when it differs from the resolved `modelID` (left unset for the common no-alias case).
- Cost is computed before this runs, so billing is untouched — logging-only addition.
- `ModelGroup`/`model_map_information` are not touched at all, so no risk to the daily spend aggregators that key off `ModelGroup` (`gemini-3-flash-preview`, `gpt-4.1`, `gpt-5-mini` are the only three model identities affected today).

## Test plan
- `go build ./...`
- `go vet ./...`
- `go test ./internal/proxy/...` — added `TestAddAIRSpendMetadata` (no_alias / with_public_alias / empty_public_model_id), all existing tests pass unmodified