### PR TITLE
Fix billing price lookup for provider-prefixed model aliases (openrouter/gpt-5-mini, openrouter/gpt-4.1, yandex/gpt-5.1)

### DIFF
--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -104,10 +104,28 @@ func NewModelPriceRegistry() *ModelPriceRegistry {
 	}
 }
 
-// GetPrice returns the price for a model, or nil if not found
+// GetPrice returns the price for a model, or nil if not found. Tries the raw
+// (case/whitespace-folded, unsplit) key before the normalized one — see
+// priceForCandidateLocked.
 func (r *ModelPriceRegistry) GetPrice(modelName string) *ModelPrice {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	return r.priceForCandidateLocked(modelName)
+}
+
+// priceForCandidateLocked resolves a single candidate against the registry.
+// It tries the raw form first (case/whitespace-folded only, "/" kept intact)
+// and falls back to the normalized form (provider prefix stripped). A price
+// entry deliberately keyed "provider/model" (e.g. "openrouter/gpt-5-mini")
+// is only reachable via its raw form, since its normalized form collides
+// with an unrelated sibling's own entry (e.g. plain "gpt-5-mini") — see
+// LoadModelPrices, which indexes such entries under both keys.
+func (r *ModelPriceRegistry) priceForCandidateLocked(modelName string) *ModelPrice {
+	if raw := strings.ToLower(strings.TrimSpace(modelName)); raw != "" {
+		if price := r.prices[raw]; price != nil {
+			return price
+		}
+	}
 	return r.prices[NormalizeModelName(modelName)]
 }
 
@@ -122,7 +140,7 @@ func (r *ModelPriceRegistry) GetPriceAny(modelNames ...string) (string, *ModelPr
 		if modelName == "" {
 			continue
 		}
-		if price := r.prices[NormalizeModelName(modelName)]; price != nil {
+		if price := r.priceForCandidateLocked(modelName); price != nil {
 			return modelName, price
 		}
 	}

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -105,45 +105,79 @@ func NewModelPriceRegistry() *ModelPriceRegistry {
 }
 
 // GetPrice returns the price for a model, or nil if not found. Tries the raw
-// (case/whitespace-folded, unsplit) key before the normalized one — see
-// priceForCandidateLocked.
+// (case/whitespace-folded, unsplit) key before the normalized one, so a
+// price entry deliberately keyed "provider/model" stays reachable under its
+// own name even when it would otherwise collide with an unrelated sibling's
+// normalized form — see rawPriceLocked / NormalizeModelName.
 func (r *ModelPriceRegistry) GetPrice(modelName string) *ModelPrice {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.priceForCandidateLocked(modelName)
-}
-
-// priceForCandidateLocked resolves a single candidate against the registry.
-// It tries the raw form first (case/whitespace-folded only, "/" kept intact)
-// and falls back to the normalized form (provider prefix stripped). A price
-// entry deliberately keyed "provider/model" (e.g. "openrouter/gpt-5-mini")
-// is only reachable via its raw form, since its normalized form collides
-// with an unrelated sibling's own entry (e.g. plain "gpt-5-mini") — see
-// LoadModelPrices, which indexes such entries under both keys.
-func (r *ModelPriceRegistry) priceForCandidateLocked(modelName string) *ModelPrice {
-	if raw := strings.ToLower(strings.TrimSpace(modelName)); raw != "" {
-		if price := r.prices[raw]; price != nil {
-			return price
-		}
+	if price := r.rawPriceLocked(modelName); price != nil {
+		return price
 	}
 	return r.prices[NormalizeModelName(modelName)]
 }
 
+// rawPriceLocked resolves a candidate against its exact (case/whitespace-
+// folded, unsplit — "/" kept intact) key only. An exact match is
+// unambiguous evidence of a deliberately-created price entry: nobody names
+// a price key "provider/model" by coincidence.
+func (r *ModelPriceRegistry) rawPriceLocked(modelName string) *ModelPrice {
+	raw := strings.ToLower(strings.TrimSpace(modelName))
+	if raw == "" {
+		return nil
+	}
+	return r.prices[raw]
+}
+
 // GetPriceAny looks up prices for multiple candidate model names under a
-// single read lock, returning the first match in the given priority order.
-// This avoids a concurrent Update() straddling two map generations, which
-// can happen when callers issue separate GetPrice calls per candidate.
+// single read lock, returning the first match. This avoids a concurrent
+// Update() straddling two map generations, which can happen when callers
+// issue separate GetPrice calls per candidate.
+//
+// Matching runs in two passes across the full candidate list, not
+// raw-then-normalized per candidate:
+//
+//  1. Exact/raw match, trying every candidate in the given priority order.
+//  2. Provider-prefix-stripped (normalized) fallback, same priority order,
+//     only reached if no candidate had its own raw entry.
+//
+// This ordering matters: an earlier per-candidate "raw-then-normalized"
+// scheme let a higher-priority candidate's lossy normalized form (e.g.
+// publicModelID "openrouter/gpt-5-mini" stripping to "gpt-5-mini") win
+// over a lower-priority candidate's own unambiguous raw entry (modelID
+// "gpt-5-mini-or"), silently billing at an unrelated sibling model's price.
+// Trying raw matches for ALL candidates before ever falling back to
+// normalization for ANY of them closes that hole for every candidate at
+// once, without needing a dedicated raw-keyed price entry for every
+// provider-prefixed alias — the alias-resolved modelID's own entry is
+// reached directly. A public alias that must be billed differently from
+// its resolved modelID still needs its own explicit raw-keyed price entry
+// (there's no way to infer billing intent from a string alone) but that's
+// the correct, intentional case — see
+// "gemini-3-flash-preview-highlimits" in client_a.libsonnet.
 func (r *ModelPriceRegistry) GetPriceAny(modelNames ...string) (string, *ModelPrice) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+
 	for _, modelName := range modelNames {
 		if modelName == "" {
 			continue
 		}
-		if price := r.priceForCandidateLocked(modelName); price != nil {
+		if price := r.rawPriceLocked(modelName); price != nil {
 			return modelName, price
 		}
 	}
+
+	for _, modelName := range modelNames {
+		if modelName == "" {
+			continue
+		}
+		if price := r.prices[NormalizeModelName(modelName)]; price != nil {
+			return modelName, price
+		}
+	}
+
 	return "", nil
 }
 

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -14,6 +14,7 @@ import (
 	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
 	"github.com/mixaill76/auto_ai_router/internal/scope"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -1445,6 +1446,64 @@ func TestModelPriceRegistry_GetPrice_NotFound(t *testing.T) {
 
 	result = registry.GetPrice("claude-3-opus")
 	assert.Nil(t, result, "GetPrice should return nil for a model not in the registry")
+}
+
+func TestModelPriceRegistry_GetPriceAny_RawKeyedProviderPrefixWinsOverNormalizedSibling(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// Mirrors LoadModelPrices' output for a price file containing both
+	// "gpt-5-mini" and "openrouter/gpt-5-mini": the provider-prefixed entry
+	// is indexed under its own raw key in addition to the shared normalized
+	// key ("gpt-5-mini"), which the plain entry occupies.
+	registry.Update(map[string]*ModelPrice{
+		"gpt-5-mini":            {InputCostPerToken: 0.000000225},
+		"openrouter/gpt-5-mini": {InputCostPerToken: 0.000000325},
+	})
+
+	// publicModelID="openrouter/gpt-5-mini", modelID="gpt-5-mini-or", realModelID="gpt-5-mini"
+	matched, price := registry.GetPriceAny("openrouter/gpt-5-mini", "gpt-5-mini-or", "gpt-5-mini")
+	require.NotNil(t, price)
+	assert.Equal(t, "openrouter/gpt-5-mini", matched)
+	assert.Equal(t, 0.000000325, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_NormalizedFallbackStillWinsWhenNoRawMatch(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// Mirrors the highlimits case: only the plain, normalized-form price
+	// entry exists. The first candidate ("gemini-3-flash-preview-highlimits")
+	// has no raw-keyed entry of its own, so it must fall through to the
+	// normalized form of the *second* candidate rather than matching nothing.
+	registry.Update(map[string]*ModelPrice{
+		"gemini-3-flash-preview": {InputCostPerToken: 0.00000045},
+	})
+
+	matched, price := registry.GetPriceAny("gemini-3-flash-preview-highlimits", "gemini-3-flash-preview", "gemini-3-flash-preview")
+	require.NotNil(t, price)
+	assert.Equal(t, "gemini-3-flash-preview", matched)
+	assert.Equal(t, 0.00000045, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_SkipsEmptyCandidates(t *testing.T) {
+	registry := NewModelPriceRegistry()
+	registry.Update(map[string]*ModelPrice{
+		"gpt-4": {InputCostPerToken: 0.00003},
+	})
+
+	matched, price := registry.GetPriceAny("", "gpt-4", "")
+	require.NotNil(t, price)
+	assert.Equal(t, "gpt-4", matched)
+}
+
+func TestModelPriceRegistry_GetPriceAny_NoMatch(t *testing.T) {
+	registry := NewModelPriceRegistry()
+	registry.Update(map[string]*ModelPrice{
+		"gpt-4": {InputCostPerToken: 0.00003},
+	})
+
+	matched, price := registry.GetPriceAny("claude-3-opus", "unknown-model")
+	assert.Nil(t, price)
+	assert.Empty(t, matched)
 }
 
 func TestUpdateDBModels_PreservesStaticAndMapsDB(t *testing.T) {

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -1448,37 +1448,94 @@ func TestModelPriceRegistry_GetPrice_NotFound(t *testing.T) {
 	assert.Nil(t, result, "GetPrice should return nil for a model not in the registry")
 }
 
-func TestModelPriceRegistry_GetPriceAny_RawKeyedProviderPrefixWinsOverNormalizedSibling(t *testing.T) {
+func TestModelPriceRegistry_GetPriceAny_RawKeyedProviderPrefixWinsEvenIfALowerPriorityCandidateAlsoHasARawMatch(t *testing.T) {
 	registry := NewModelPriceRegistry()
 
-	// Mirrors LoadModelPrices' output for a price file containing both
-	// "gpt-5-mini" and "openrouter/gpt-5-mini": the provider-prefixed entry
-	// is indexed under its own raw key in addition to the shared normalized
-	// key ("gpt-5-mini"), which the plain entry occupies.
+	// Both "openrouter/gpt-5-mini" (publicModelID, checked first) and
+	// "gpt-5-mini-or" (modelID, checked second) have their own raw entry
+	// here. Priority order among raw matches must still be preserved:
+	// publicModelID wins, since a public alias with its own deliberately
+	// distinct price must be able to override the canonical model's price.
 	registry.Update(map[string]*ModelPrice{
 		"gpt-5-mini":            {InputCostPerToken: 0.000000225},
-		"openrouter/gpt-5-mini": {InputCostPerToken: 0.000000325},
+		"gpt-5-mini-or":         {InputCostPerToken: 0.000000325},
+		"openrouter/gpt-5-mini": {InputCostPerToken: 0.000000999},
 	})
 
-	// publicModelID="openrouter/gpt-5-mini", modelID="gpt-5-mini-or", realModelID="gpt-5-mini"
 	matched, price := registry.GetPriceAny("openrouter/gpt-5-mini", "gpt-5-mini-or", "gpt-5-mini")
 	require.NotNil(t, price)
 	assert.Equal(t, "openrouter/gpt-5-mini", matched)
+	assert.Equal(t, 0.000000999, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_ModelIDRawMatchWinsOverPublicModelIDNormalizedCollision(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// The core fix this test locks in: publicModelID ("openrouter/gpt-5-mini")
+	// has NO raw entry of its own and would normalize down to "gpt-5-mini",
+	// colliding with an unrelated sibling. modelID ("gpt-5-mini-or") has its
+	// own unambiguous raw entry. Raw matches are tried for every candidate
+	// (pass 1) before normalization is attempted for any of them (pass 2),
+	// so modelID's raw entry must win — without needing a dedicated
+	// raw-keyed price entry for "openrouter/gpt-5-mini" in the price file.
+	registry.Update(map[string]*ModelPrice{
+		"gpt-5-mini":    {InputCostPerToken: 0.000000225},
+		"gpt-5-mini-or": {InputCostPerToken: 0.000000325},
+	})
+
+	matched, price := registry.GetPriceAny("openrouter/gpt-5-mini", "gpt-5-mini-or", "gpt-5-mini")
+	require.NotNil(t, price)
+	assert.Equal(t, "gpt-5-mini-or", matched)
 	assert.Equal(t, 0.000000325, price.InputCostPerToken)
 }
 
-func TestModelPriceRegistry_GetPriceAny_NormalizedFallbackStillWinsWhenNoRawMatch(t *testing.T) {
+func TestModelPriceRegistry_GetPriceAny_NormalizedFallbackOnlyUsedWhenNoCandidateHasARawMatch(t *testing.T) {
 	registry := NewModelPriceRegistry()
 
-	// Mirrors the highlimits case: only the plain, normalized-form price
-	// entry exists. The first candidate ("gemini-3-flash-preview-highlimits")
-	// has no raw-keyed entry of its own, so it must fall through to the
-	// normalized form of the *second* candidate rather than matching nothing.
+	// None of the three candidates has its own raw entry; only pass 2
+	// (normalized, provider-prefix-stripped) finds anything, via realModelID.
+	registry.Update(map[string]*ModelPrice{
+		"gemini-2.5-pro": {InputCostPerToken: 0.00000045},
+	})
+
+	matched, price := registry.GetPriceAny("google/gemini-2.5-pro-alias", "gemini-2.5-pro-canonical", "vertex_ai/gemini-2.5-pro")
+	require.NotNil(t, price)
+	assert.Equal(t, "vertex_ai/gemini-2.5-pro", matched)
+	assert.Equal(t, 0.00000045, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_HighlimitsStyleAliasNeedsItsOwnRawKeyToStayDistinctFromCanonicalModel(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// Mirrors gemini-3-flash-preview-highlimits: publicModelID is the
+	// client-facing exposedName, modelID is the alias-resolved canonical
+	// model. Without a raw entry for the exposedName itself, pass 1 would
+	// find modelID's own (generic, cheaper) entry first, silently losing
+	// the highlimits-specific price — this is exactly why services must
+	// carry a raw-keyed "google/gemini-3-flash-preview-highlimits" entry
+	// (see llmarena/services#278), not a code-only guarantee.
+	registry.Update(map[string]*ModelPrice{
+		"gemini-3-flash-preview":                   {InputCostPerToken: 0.00000045},
+		"google/gemini-3-flash-preview-highlimits": {InputCostPerToken: 0.00000099},
+	})
+
+	matched, price := registry.GetPriceAny("google/gemini-3-flash-preview-highlimits", "gemini-3-flash-preview", "gemini-3-flash-preview")
+	require.NotNil(t, price)
+	assert.Equal(t, "google/gemini-3-flash-preview-highlimits", matched)
+	assert.Equal(t, 0.00000099, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_HighlimitsStyleAliasSilentlyLosesItsOwnPriceWithoutTheRawKey(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// Same setup as above but WITHOUT the raw-keyed exposedName entry —
+	// documents the regression this class of alias would hit if the
+	// companion services price-file change were ever skipped.
 	registry.Update(map[string]*ModelPrice{
 		"gemini-3-flash-preview": {InputCostPerToken: 0.00000045},
 	})
 
-	matched, price := registry.GetPriceAny("gemini-3-flash-preview-highlimits", "gemini-3-flash-preview", "gemini-3-flash-preview")
+	matched, price := registry.GetPriceAny("google/gemini-3-flash-preview-highlimits", "gemini-3-flash-preview", "gemini-3-flash-preview")
 	require.NotNil(t, price)
 	assert.Equal(t, "gemini-3-flash-preview", matched)
 	assert.Equal(t, 0.00000045, price.InputCostPerToken)
@@ -1506,25 +1563,25 @@ func TestModelPriceRegistry_GetPriceAny_NoMatch(t *testing.T) {
 	assert.Empty(t, matched)
 }
 
-// The following four tests use real production price values from
-// services' apps/prices/{client_a,default}.libsonnet (as of 2026-08-19) to
-// document two more live instances of the same alias-collision bug class as
+// The following two tests use real production price values from services'
+// apps/prices/{client_a,default}.libsonnet (as of 2026-08-19) to document
+// two more live instances of the same alias-collision bug class as
 // openrouter/gpt-5-mini, found while auditing the full price lists:
 //   - client_a (Avito): openrouter/gpt-4.1 -> gpt-4.1-or
-//   - default (vsellm):  yandex/gpt-5.1 -> yandexgpt-5.1, which collides with
-//     OpenAI's own unrelated "gpt-5.1" entry in the same price file.
+//   - default (vsellm):  yandex/gpt-5.1 -> yandexgpt-5.1, which collided
+//     with OpenAI's own unrelated "gpt-5.1" entry in the same price file.
 //
-// Each pair has a "WithoutServicesFix" test proving the Go-side fix alone is
-// NOT sufficient — the price file also needs a raw-keyed entry matching the
-// exact public alias string — and a "OnceRawKeyAdded" test proving the fix
-// is complete once that entry exists.
+// Unlike the earlier per-candidate raw-then-normalized design, the two-pass
+// scheme fixes both automatically — modelID's own raw entry is found in
+// pass 1 before publicModelID's colliding normalized form is ever tried in
+// pass 2 — with no companion services price-file change needed for either.
 
-func TestModelPriceRegistry_GetPriceAny_OpenRouterGPT41CollidesWithPlainGPT41WithoutServicesFix(t *testing.T) {
+func TestModelPriceRegistry_GetPriceAny_OpenRouterGPT41ResolvesCorrectlyWithNoServicesChangeNeeded(t *testing.T) {
 	registry := NewModelPriceRegistry()
 
 	// Real client_a.libsonnet values: 'gpt-4.1' (plain, discounted) vs
 	// 'gpt-4.1-or' (openrouter route, no discount, higher rate). No entry is
-	// keyed "openrouter/gpt-4.1" yet, so the raw-key lookup can't help.
+	// keyed "openrouter/gpt-4.1" — modelID's own raw entry resolves this.
 	registry.Update(map[string]*ModelPrice{
 		"gpt-4.1":    {InputCostPerToken: 0.0000018, OutputCostPerToken: 0.0000072, CacheReadInputTokenCost: 0.00000045},
 		"gpt-4.1-or": {InputCostPerToken: 0.0000026, OutputCostPerToken: 0.0000104, CacheReadInputTokenCost: 0.00000065},
@@ -1532,32 +1589,16 @@ func TestModelPriceRegistry_GetPriceAny_OpenRouterGPT41CollidesWithPlainGPT41Wit
 
 	matched, price := registry.GetPriceAny("openrouter/gpt-4.1", "gpt-4.1-or", "gpt-4.1-or")
 	require.NotNil(t, price)
-	assert.Equal(t, "openrouter/gpt-4.1", matched)
-	// Documents the bug: resolves to the wrong, plain gpt-4.1 price.
-	assert.Equal(t, 0.0000018, price.InputCostPerToken)
-}
-
-func TestModelPriceRegistry_GetPriceAny_OpenRouterGPT41ResolvesCorrectlyOnceRawKeyAdded(t *testing.T) {
-	registry := NewModelPriceRegistry()
-
-	registry.Update(map[string]*ModelPrice{
-		"gpt-4.1":            {InputCostPerToken: 0.0000018, OutputCostPerToken: 0.0000072, CacheReadInputTokenCost: 0.00000045},
-		"gpt-4.1-or":         {InputCostPerToken: 0.0000026, OutputCostPerToken: 0.0000104, CacheReadInputTokenCost: 0.00000065},
-		"openrouter/gpt-4.1": {InputCostPerToken: 0.0000026, OutputCostPerToken: 0.0000104, CacheReadInputTokenCost: 0.00000065},
-	})
-
-	matched, price := registry.GetPriceAny("openrouter/gpt-4.1", "gpt-4.1-or", "gpt-4.1-or")
-	require.NotNil(t, price)
-	assert.Equal(t, "openrouter/gpt-4.1", matched)
+	assert.Equal(t, "gpt-4.1-or", matched)
 	assert.Equal(t, 0.0000026, price.InputCostPerToken)
 }
 
-func TestModelPriceRegistry_GetPriceAny_YandexGPT51CollidesWithOpenAIGPT51WithoutServicesFix(t *testing.T) {
+func TestModelPriceRegistry_GetPriceAny_YandexGPT51ResolvesCorrectlyWithNoServicesChangeNeeded(t *testing.T) {
 	registry := NewModelPriceRegistry()
 
 	// Real default.libsonnet values: OpenAI's own 'gpt-5.1' (tiered
 	// input/output) vs Yandex's 'yandexgpt-5.1' (flat rate). No entry is
-	// keyed "yandex/gpt-5.1" yet.
+	// keyed "yandex/gpt-5.1" — modelID's own raw entry resolves this.
 	registry.Update(map[string]*ModelPrice{
 		"gpt-5.1":       {InputCostPerToken: 0.000001625, OutputCostPerToken: 0.000013, CacheReadInputTokenCost: 0.0000001625},
 		"yandexgpt-5.1": {InputCostPerToken: 0.0000122353, OutputCostPerToken: 0.0000122353, CacheReadInputTokenCost: 0.0000122353},
@@ -1565,24 +1606,7 @@ func TestModelPriceRegistry_GetPriceAny_YandexGPT51CollidesWithOpenAIGPT51Withou
 
 	matched, price := registry.GetPriceAny("yandex/gpt-5.1", "yandexgpt-5.1", "yandexgpt-5.1")
 	require.NotNil(t, price)
-	assert.Equal(t, "yandex/gpt-5.1", matched)
-	// Documents the bug: resolves to OpenAI's unrelated gpt-5.1 price —
-	// input cost alone is off by ~7.5x from the correct Yandex rate.
-	assert.Equal(t, 0.000001625, price.InputCostPerToken)
-}
-
-func TestModelPriceRegistry_GetPriceAny_YandexGPT51ResolvesCorrectlyOnceRawKeyAdded(t *testing.T) {
-	registry := NewModelPriceRegistry()
-
-	registry.Update(map[string]*ModelPrice{
-		"gpt-5.1":        {InputCostPerToken: 0.000001625, OutputCostPerToken: 0.000013, CacheReadInputTokenCost: 0.0000001625},
-		"yandexgpt-5.1":  {InputCostPerToken: 0.0000122353, OutputCostPerToken: 0.0000122353, CacheReadInputTokenCost: 0.0000122353},
-		"yandex/gpt-5.1": {InputCostPerToken: 0.0000122353, OutputCostPerToken: 0.0000122353, CacheReadInputTokenCost: 0.0000122353},
-	})
-
-	matched, price := registry.GetPriceAny("yandex/gpt-5.1", "yandexgpt-5.1", "yandexgpt-5.1")
-	require.NotNil(t, price)
-	assert.Equal(t, "yandex/gpt-5.1", matched)
+	assert.Equal(t, "yandexgpt-5.1", matched)
 	assert.Equal(t, 0.0000122353, price.InputCostPerToken)
 }
 

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -1506,6 +1506,86 @@ func TestModelPriceRegistry_GetPriceAny_NoMatch(t *testing.T) {
 	assert.Empty(t, matched)
 }
 
+// The following four tests use real production price values from
+// services' apps/prices/{client_a,default}.libsonnet (as of 2026-08-19) to
+// document two more live instances of the same alias-collision bug class as
+// openrouter/gpt-5-mini, found while auditing the full price lists:
+//   - client_a (Avito): openrouter/gpt-4.1 -> gpt-4.1-or
+//   - default (vsellm):  yandex/gpt-5.1 -> yandexgpt-5.1, which collides with
+//     OpenAI's own unrelated "gpt-5.1" entry in the same price file.
+//
+// Each pair has a "WithoutServicesFix" test proving the Go-side fix alone is
+// NOT sufficient — the price file also needs a raw-keyed entry matching the
+// exact public alias string — and a "OnceRawKeyAdded" test proving the fix
+// is complete once that entry exists.
+
+func TestModelPriceRegistry_GetPriceAny_OpenRouterGPT41CollidesWithPlainGPT41WithoutServicesFix(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// Real client_a.libsonnet values: 'gpt-4.1' (plain, discounted) vs
+	// 'gpt-4.1-or' (openrouter route, no discount, higher rate). No entry is
+	// keyed "openrouter/gpt-4.1" yet, so the raw-key lookup can't help.
+	registry.Update(map[string]*ModelPrice{
+		"gpt-4.1":    {InputCostPerToken: 0.0000018, OutputCostPerToken: 0.0000072, CacheReadInputTokenCost: 0.00000045},
+		"gpt-4.1-or": {InputCostPerToken: 0.0000026, OutputCostPerToken: 0.0000104, CacheReadInputTokenCost: 0.00000065},
+	})
+
+	matched, price := registry.GetPriceAny("openrouter/gpt-4.1", "gpt-4.1-or", "gpt-4.1-or")
+	require.NotNil(t, price)
+	assert.Equal(t, "openrouter/gpt-4.1", matched)
+	// Documents the bug: resolves to the wrong, plain gpt-4.1 price.
+	assert.Equal(t, 0.0000018, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_OpenRouterGPT41ResolvesCorrectlyOnceRawKeyAdded(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	registry.Update(map[string]*ModelPrice{
+		"gpt-4.1":            {InputCostPerToken: 0.0000018, OutputCostPerToken: 0.0000072, CacheReadInputTokenCost: 0.00000045},
+		"gpt-4.1-or":         {InputCostPerToken: 0.0000026, OutputCostPerToken: 0.0000104, CacheReadInputTokenCost: 0.00000065},
+		"openrouter/gpt-4.1": {InputCostPerToken: 0.0000026, OutputCostPerToken: 0.0000104, CacheReadInputTokenCost: 0.00000065},
+	})
+
+	matched, price := registry.GetPriceAny("openrouter/gpt-4.1", "gpt-4.1-or", "gpt-4.1-or")
+	require.NotNil(t, price)
+	assert.Equal(t, "openrouter/gpt-4.1", matched)
+	assert.Equal(t, 0.0000026, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_YandexGPT51CollidesWithOpenAIGPT51WithoutServicesFix(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	// Real default.libsonnet values: OpenAI's own 'gpt-5.1' (tiered
+	// input/output) vs Yandex's 'yandexgpt-5.1' (flat rate). No entry is
+	// keyed "yandex/gpt-5.1" yet.
+	registry.Update(map[string]*ModelPrice{
+		"gpt-5.1":       {InputCostPerToken: 0.000001625, OutputCostPerToken: 0.000013, CacheReadInputTokenCost: 0.0000001625},
+		"yandexgpt-5.1": {InputCostPerToken: 0.0000122353, OutputCostPerToken: 0.0000122353, CacheReadInputTokenCost: 0.0000122353},
+	})
+
+	matched, price := registry.GetPriceAny("yandex/gpt-5.1", "yandexgpt-5.1", "yandexgpt-5.1")
+	require.NotNil(t, price)
+	assert.Equal(t, "yandex/gpt-5.1", matched)
+	// Documents the bug: resolves to OpenAI's unrelated gpt-5.1 price —
+	// input cost alone is off by ~7.5x from the correct Yandex rate.
+	assert.Equal(t, 0.000001625, price.InputCostPerToken)
+}
+
+func TestModelPriceRegistry_GetPriceAny_YandexGPT51ResolvesCorrectlyOnceRawKeyAdded(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	registry.Update(map[string]*ModelPrice{
+		"gpt-5.1":        {InputCostPerToken: 0.000001625, OutputCostPerToken: 0.000013, CacheReadInputTokenCost: 0.0000001625},
+		"yandexgpt-5.1":  {InputCostPerToken: 0.0000122353, OutputCostPerToken: 0.0000122353, CacheReadInputTokenCost: 0.0000122353},
+		"yandex/gpt-5.1": {InputCostPerToken: 0.0000122353, OutputCostPerToken: 0.0000122353, CacheReadInputTokenCost: 0.0000122353},
+	})
+
+	matched, price := registry.GetPriceAny("yandex/gpt-5.1", "yandexgpt-5.1", "yandexgpt-5.1")
+	require.NotNil(t, price)
+	assert.Equal(t, "yandex/gpt-5.1", matched)
+	assert.Equal(t, 0.0000122353, price.InputCostPerToken)
+}
+
 func TestUpdateDBModels_PreservesStaticAndMapsDB(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/models/price_loader.go
+++ b/internal/models/price_loader.go
@@ -80,12 +80,15 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 
 		// A price entry deliberately keyed "provider/model" (e.g.
 		// "openrouter/gpt-5-mini") normalizes to the same bare name as an
-		// unrelated sibling model's own entry (e.g. plain "gpt-5-mini"),
-		// so GetPriceAny's normalized-only lookup can never reach it — the
-		// unrelated sibling always wins first. Keep it reachable by also
-		// indexing it under its raw (case/whitespace-folded, unsplit) key,
-		// which GetPriceAny tries before falling back to normalization.
-		// Never overwrites an existing entry under that raw key.
+		// unrelated sibling model's own entry (e.g. plain "gpt-5-mini").
+		// Index it under its raw (case/whitespace-folded, unsplit) key too
+		// so it stays reachable on its own terms: GetPriceAny tries an
+		// exact/raw match for every billing candidate before it ever falls
+		// back to normalization for any of them (see GetPriceAny), so a
+		// candidate whose raw form matches here always wins over one that
+		// only matches this entry's unrelated sibling by coincidence of
+		// normalization. Never overwrites an existing entry under that raw
+		// key.
 		if raw := strings.ToLower(strings.TrimSpace(fullName)); raw != normalized {
 			if _, exists := normalizedPrices[raw]; !exists {
 				normalizedPrices[raw] = price

--- a/internal/models/price_loader.go
+++ b/internal/models/price_loader.go
@@ -77,6 +77,25 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 		}
 		normalizedSources[normalized] = fullName
 		normalizedPrices[normalized] = price
+
+		// A price entry deliberately keyed "provider/model" (e.g.
+		// "openrouter/gpt-5-mini") normalizes to the same bare name as an
+		// unrelated sibling model's own entry (e.g. plain "gpt-5-mini"),
+		// so GetPriceAny's normalized-only lookup can never reach it — the
+		// unrelated sibling always wins first. Keep it reachable by also
+		// indexing it under its raw (case/whitespace-folded, unsplit) key,
+		// which GetPriceAny tries before falling back to normalization.
+		// Never overwrites an existing entry under that raw key.
+		if raw := strings.ToLower(strings.TrimSpace(fullName)); raw != normalized {
+			if _, exists := normalizedPrices[raw]; !exists {
+				normalizedPrices[raw] = price
+			} else {
+				slog.Warn("raw model name collision: keeping existing entry",
+					"raw_name", raw,
+					"new_entry", fullName,
+				)
+			}
+		}
 	}
 
 	return normalizedPrices, nil

--- a/internal/models/price_loader_test.go
+++ b/internal/models/price_loader_test.go
@@ -216,6 +216,61 @@ func TestLoadModelPrices_NormalizesModelNames(t *testing.T) {
 	assert.GreaterOrEqual(t, len(prices), 1)
 }
 
+func TestLoadModelPrices_IndexesProviderPrefixedEntryUnderRawKeyToo(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "prices.json")
+
+	// "openrouter/gpt-5-mini" normalizes to the same bare name as the
+	// unrelated sibling entry "gpt-5-mini", so it must remain reachable
+	// under its own raw key as well.
+	pricesJSON := `{
+		"gpt-5-mini": {"input_cost_per_token": 0.000000225},
+		"openrouter/gpt-5-mini": {"input_cost_per_token": 0.000000325}
+	}`
+	err := os.WriteFile(filePath, []byte(pricesJSON), 0644)
+	require.NoError(t, err)
+
+	prices, err := LoadModelPrices("file://" + filePath)
+	require.NoError(t, err)
+
+	// The raw-keyed entry must always resolve to its own value, regardless
+	// of which entry the (unordered) JSON map is processed first.
+	raw := prices["openrouter/gpt-5-mini"]
+	require.NotNil(t, raw)
+	assert.Equal(t, 0.000000325, raw.InputCostPerToken)
+
+	// The shared normalized key ("gpt-5-mini") is last-writer-wins between
+	// the two colliding entries — pre-existing, order-dependent behavior
+	// this fix doesn't change — so only assert it's populated with one of
+	// the two known values, not which one.
+	bare := prices["gpt-5-mini"]
+	require.NotNil(t, bare)
+	assert.Contains(t, []float64{0.000000225, 0.000000325}, bare.InputCostPerToken)
+}
+
+func TestLoadModelPrices_RawKeyCollisionKeepsExistingEntry(t *testing.T) {
+	tmpDir := t.TempDir()
+	filePath := filepath.Join(tmpDir, "prices.json")
+
+	// Two raw JSON keys that fold to the same raw key must not panic or
+	// silently overwrite each other with a nil/inconsistent entry: exactly
+	// one of the two source values must win (map iteration order over the
+	// parsed JSON is unspecified, so we can't assert which).
+	pricesJSON := `{
+		"openrouter/gpt-5-mini": {"input_cost_per_token": 0.000000325},
+		"OpenRouter/GPT-5-Mini": {"input_cost_per_token": 0.000000999}
+	}`
+	err := os.WriteFile(filePath, []byte(pricesJSON), 0644)
+	require.NoError(t, err)
+
+	prices, err := LoadModelPrices("file://" + filePath)
+	require.NoError(t, err)
+
+	raw := prices["openrouter/gpt-5-mini"]
+	require.NotNil(t, raw)
+	assert.Contains(t, []float64{0.000000325, 0.000000999}, raw.InputCostPerToken)
+}
+
 func TestLoadFromFile_SizeLimit(t *testing.T) {
 	tmpDir := t.TempDir()
 	filePath := filepath.Join(tmpDir, "large.json")


### PR DESCRIPTION
## Problem

`openrouter/gpt-5-mini` (internally aliased to `gpt-5-mini-or`, which has
its own, distinct — and higher — price entry) was being billed at the
plain `gpt-5-mini` rate instead. Same structural bug confirmed live for
`openrouter/gpt-4.1` → `gpt-4.1-or` and `yandex/gpt-5.1` → `yandexgpt-5.1`
(the latter colliding with an unrelated OpenAI `gpt-5.1` entry in the same
price file — ~4x underbilling when it fires).

Verified against real production traffic (2026-08-19): 23,209 of 23,209
requests billed via `openrouter/gpt-5-mini` were wrong (100%), vs 109 of
109 requests billed via the internal `gpt-5-mini-or` name directly were
correct (100%) — a $28.87/day shortfall on this one model alone.

## Root cause

`lookupBillingModelPrice` calls `registry.GetPriceAny(publicModelID,
modelID, realModelID)`, trying each candidate in priority order. Each
candidate was resolved via "raw match, else normalized (provider-prefix-
stripped) match" *before moving to the next candidate*. That let a
higher-priority candidate's lossy normalized form (`publicModelID`
`"openrouter/gpt-5-mini"` → stripped to `"gpt-5-mini"`) win over a
lower-priority candidate's own unambiguous raw entry (`modelID`
`"gpt-5-mini-or"`, which has its own valid price row) — silently billing
at an unrelated sibling model's price.

## Fix

`GetPriceAny` now runs two full passes across **all** candidates, in
priority order, instead of raw-then-normalized per candidate:

1. **Pass 1 — raw/exact match only**, trying `publicModelID`, `modelID`,
   `realModelID` in that order.
2. **Pass 2 — normalized (provider-prefix-stripped) fallback**, same
   order, only reached if nothing matched by raw.

This fixes all three known cases automatically, **with no price-file
change needed** for any of them — `modelID`'s own raw entry
(`gpt-5-mini-or`, `gpt-4.1-or`, `yandexgpt-5.1`) is found in pass 1 before
`publicModelID`'s colliding normalized form is ever tried in pass 2.

`LoadModelPrices` also indexes each price entry under its raw
(case/whitespace-folded, unsplit) key in addition to the normalized one,
so a price entry deliberately keyed `"provider/model"` stays reachable
under its own name.

### Why not just reorder candidates (see #139)?

Reordering to try `modelID` before `publicModelID` also fixes these three
cases, but it silently reverses the *existing, tested* priority contract
that a public alias may have its own price distinct from its resolved
canonical model — see `TestEstimateRequestCostPrefersPublicModelPriceOverDistinctModelIDPrice`,
which documents exactly that: a client-facing alias priced *cheaper* than
its canonical model must still win. `gemini-3-flash-preview-highlimits`
relies on this today (currently priced identically to
`gemini-3-flash-preview`, but tracked separately in `spend_logs_metadata`
specifically so it *can* diverge). A blanket reorder would silently
re-collapse that distinction the moment anyone gives it a different price,
with no warning — the same bug class we're fixing here, just moved.

The two-pass design preserves that contract: any candidate matched via its
own **raw** key still wins in priority order (publicModelID > modelID >
realModelID) over one only reachable via **normalized** fallback,
regardless of which pass finds it. A public alias that genuinely needs a
distinct price still needs its own raw-keyed price entry — that's
unavoidable (there's no way to infer billing intent from a string alone)
and is the *correct*, explicit way to express it, not a workaround. See
the companion price-file change for `gemini-3-flash-preview-highlimits`:
llmarena/services#278.

## Testing

- `internal/models/manager_test.go`: tests covering — raw match priority
  order preserved when multiple candidates have raw entries; modelID's raw
  match winning over publicModelID's normalized collision (the core fix);
  normalized fallback still working when no candidate has a raw match;
  the highlimits-style case (needs its own raw key, documented regression
  test for what happens without it); real production values for
  `openrouter/gpt-4.1` and `yandex/gpt-5.1` resolving correctly with no
  price-file change.
- `internal/models/price_loader_test.go`: raw-key indexing in
  `LoadModelPrices`, including collision handling.
- `go build ./...`, `go vet ./...`, and `go test ./...` (full repo) all
  pass.

## Follow-up

Companion services PR (no code change needed for the three fixed models,
only for the intentionally-distinct highlimits alias):
llmarena/services#278