### PR TITLE
fix(billing): use modelID-first for billing price lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ _LiteLLM_*.csv
 Locust_*.html
 air_mock_*.json
 mock-go
+responses.db

--- a/internal/proxy/billing_price.go
+++ b/internal/proxy/billing_price.go
@@ -3,11 +3,11 @@ package proxy
 import "github.com/mixaill76/auto_ai_router/internal/models"
 
 // lookupBillingModelPrice resolves the price row to bill a request against.
-// Candidates are tried strictly in the order publicModelID, modelID,
-// realModelID (client-facing alias first, provider deployment name last) —
-// callers must preserve this argument order, since it IS the priority
-// contract; passing the strings in a different order silently changes which
-// price wins.
+// Candidates are tried strictly in the order modelID, publicModelID,
+// realModelID — the alias-resolved canonical name takes priority over the
+// raw client-facing name, because provider-prefixed publicModelID values
+// (e.g. "openrouter/gpt-5-mini") normalise to a stripped key ("gpt-5-mini")
+// that may collide with a cheaper sibling entry, causing under-billing.
 func lookupBillingModelPrice(registry *models.ModelPriceRegistry, publicModelID, modelID, realModelID string) (string, *models.ModelPrice) {
 	if registry == nil {
 		return modelID, nil
@@ -17,7 +17,7 @@ func lookupBillingModelPrice(registry *models.ModelPriceRegistry, publicModelID,
 		realModelID = ""
 	}
 
-	if matchedID, modelPrice := registry.GetPriceAny(publicModelID, modelID, realModelID); modelPrice != nil {
+	if matchedID, modelPrice := registry.GetPriceAny(modelID, publicModelID, realModelID); modelPrice != nil {
 		return matchedID, modelPrice
 	}
 

--- a/internal/proxy/billing_price_test.go
+++ b/internal/proxy/billing_price_test.go
@@ -1,0 +1,84 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupBillingModelPrice_ModelIDFirst(t *testing.T) {
+	registry := models.NewModelPriceRegistry()
+	registry.Update(map[string]*models.ModelPrice{
+		"gpt-5-mini":    {InputCostPerToken: 2.25e-07, OutputCostPerToken: 1.8e-06},
+		"gpt-5-mini-or": {InputCostPerToken: 3.25e-07, OutputCostPerToken: 2.6e-06},
+	})
+
+	tests := []struct {
+		name           string
+		publicModelID  string
+		modelID        string
+		realModelID    string
+		wantModelID    string
+		wantInputCost  float64
+	}{
+		{
+			name:          "openrouter/gpt-5-mini resolves to gpt-5-mini-or (not gpt-5-mini)",
+			publicModelID: "openrouter/gpt-5-mini",
+			modelID:       "gpt-5-mini-or",
+			realModelID:   "gpt-5-mini",
+			wantModelID:   "gpt-5-mini-or",
+			wantInputCost: 3.25e-07,
+		},
+		{
+			name:          "openai/gpt-5-mini resolves to gpt-5-mini",
+			publicModelID: "openai/gpt-5-mini",
+			modelID:       "gpt-5-mini",
+			realModelID:   "gpt-5-mini",
+			wantModelID:   "gpt-5-mini",
+			wantInputCost: 2.25e-07,
+		},
+		{
+			name:          "plain modelID when no publicModelID",
+			publicModelID: "",
+			modelID:       "gpt-5-mini-or",
+			realModelID:   "",
+			wantModelID:   "gpt-5-mini-or",
+			wantInputCost: 3.25e-07,
+		},
+		{
+			name:          "realModelID used as fallback",
+			publicModelID: "",
+			modelID:       "unknown-model",
+			realModelID:   "gpt-5-mini",
+			wantModelID:   "gpt-5-mini",
+			wantInputCost: 2.25e-07,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotModelID, gotPrice := lookupBillingModelPrice(registry, tt.publicModelID, tt.modelID, tt.realModelID)
+			assert.Equal(t, tt.wantModelID, gotModelID)
+			assert.NotNil(t, gotPrice)
+			assert.Equal(t, tt.wantInputCost, gotPrice.InputCostPerToken)
+		})
+	}
+}
+
+func TestLookupBillingModelPrice_NilRegistry(t *testing.T) {
+	gotModelID, gotPrice := lookupBillingModelPrice(nil, "openrouter/gpt-5-mini", "gpt-5-mini-or", "")
+	assert.Equal(t, "gpt-5-mini-or", gotModelID)
+	assert.Nil(t, gotPrice)
+}
+
+func TestLookupBillingModelPrice_DeduplicatesModelIDAndRealModelID(t *testing.T) {
+	registry := models.NewModelPriceRegistry()
+	registry.Update(map[string]*models.ModelPrice{
+		"gpt-5-mini": {InputCostPerToken: 2.25e-07},
+	})
+
+	gotModelID, gotPrice := lookupBillingModelPrice(registry, "", "gpt-5-mini", "gpt-5-mini")
+	assert.Equal(t, "gpt-5-mini", gotModelID)
+	assert.NotNil(t, gotPrice)
+}

--- a/internal/proxy/budget_enforcement_test.go
+++ b/internal/proxy/budget_enforcement_test.go
@@ -77,12 +77,13 @@ func TestEstimateRequestCostUsesPublicModelPriceBeforeRealModelPrice(t *testing.
 	assert.InDelta(t, 0.10, cost, 0.000000001)
 }
 
-// TestEstimateRequestCostPrefersPublicModelPriceOverDistinctModelIDPrice
-// covers the 3-way-divergent case (PublicModelID != ModelID != RealModelID,
-// all three priced) that the earlier two-ID-collision tests couldn't
-// distinguish: it proves PublicModelID wins specifically over ModelID, not
-// just over RealModelID.
-func TestEstimateRequestCostPrefersPublicModelPriceOverDistinctModelIDPrice(t *testing.T) {
+// TestEstimateRequestCostPrefersModelIDOverPublicModelPrice verifies that
+// modelID (the alias-resolved canonical name) takes billing priority over
+// publicModelID (the raw client-facing name). This is critical for
+// provider-prefixed models like "openrouter/gpt-5-mini" where
+// NormalizeModelName strips the prefix and collides with a cheaper sibling
+// entry ("gpt-5-mini" vs "gpt-5-mini-or").
+func TestEstimateRequestCostPrefersModelIDOverPublicModelPrice(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	registry := routermodels.NewModelPriceRegistry()
 	registry.Update(map[string]*routermodels.ModelPrice{
@@ -107,7 +108,8 @@ func TestEstimateRequestCostPrefersPublicModelPriceOverDistinctModelIDPrice(t *t
 	)
 
 	require.True(t, ok)
-	assert.InDelta(t, 0.10, cost, 0.000000001)
+	// modelID (gpt-5.2-chat, cost 0.5) is now preferred over publicModelID
+	assert.InDelta(t, 5.0, cost, 0.000000001)
 }
 
 // TestResolveBillingPriceCachesAcrossCalls verifies budget reservation and


### PR DESCRIPTION
## Problem

`NormalizeModelName` strips provider prefixes (e.g. `openrouter/gpt-5-mini` → `gpt-5-mini`), causing provider-prefixed models to be billed at the wrong sibling entry's price.

**Example:** `openrouter/gpt-5-mini` aliases to `gpt-5-mini-or` but was billed as `gpt-5-mini` (31% undercharge):
- Expected: input 3.25e-07, output 2.6e-06 (`gpt-5-mini-or` prices)
- Actual: input 2.25e-07, output 1.8e-06 (`gpt-5-mini` prices)

Verified with 50 test requests via `litellm.data-light.ru/v1` — all 50 confirmed wrong pricing.

## Fix

Change `lookupBillingModelPrice` to try `modelID` (the alias-resolved canonical name) before `publicModelID` (the raw client-facing name).

**Before:** `GetPriceAny(publicModelID, modelID, realModelID)`
**After:** `GetPriceAny(modelID, publicModelID, realModelID)`

This ensures:
- `openrouter/gpt-5-mini` → `modelID = gpt-5-mini-or` found first ✅
- `openai/gpt-5-mini` → `modelID = gpt-5-mini` found first ✅
- All other models → same behavior (modelID = normalized publicModelID)

## Tradeoff

If `gemini-3-flash-preview-highlimits` prices diverge from `gemini-3-flash-preview` in the future, the model alias config should be updated. Currently they have identical prices.

## Changes

- `internal/proxy/billing_price.go`: reorder candidates in `lookupBillingModelPrice`
- `internal/proxy/billing_price_test.go`: new tests covering the openrouter prefix case
- `internal/proxy/budget_enforcement_test.go`: update test to reflect new priority order