### PR TITLE
fix(billing): two-pass price lookup — raw keys before normalised

### DIFF
--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -104,10 +104,18 @@ func NewModelPriceRegistry() *ModelPriceRegistry {
 	}
 }
 
-// GetPrice returns the price for a model, or nil if not found
+// GetPrice returns the price for a model, or nil if not found. Tries the
+// raw (case/whitespace-folded, unsplit) key before the normalized
+// (provider-prefix-stripped) one, matching GetPriceAny's two-pass priority
+// so the two functions never disagree about which entry a given name
+// resolves to.
 func (r *ModelPriceRegistry) GetPrice(modelName string) *ModelPrice {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+	raw := strings.ToLower(strings.TrimSpace(modelName))
+	if price := r.prices[raw]; price != nil {
+		return price
+	}
 	return r.prices[NormalizeModelName(modelName)]
 }
 
@@ -115,9 +123,37 @@ func (r *ModelPriceRegistry) GetPrice(modelName string) *ModelPrice {
 // single read lock, returning the first match in the given priority order.
 // This avoids a concurrent Update() straddling two map generations, which
 // can happen when callers issue separate GetPrice calls per candidate.
+//
+// The lookup uses a two-pass strategy to handle provider-prefixed model names
+// correctly:
+//
+//  1. Pass 1 (raw): try each candidate as a raw lowercase key (no prefix
+//     stripping). This ensures explicit entries like "google/gemini-3-flash-
+//     preview-highlimits" in the price file are found before any normalised
+//     fallback.
+//
+//  2. Pass 2 (normalised): try each candidate with NormalizeModelName (which
+//     strips provider prefixes). This is the legacy behaviour that matches
+//     bare model names like "gpt-5-mini-or".
+//
+// Raw matches always beat normalised matches, preserving the publicModelID >
+// modelID > realModelID priority contract.
 func (r *ModelPriceRegistry) GetPriceAny(modelNames ...string) (string, *ModelPrice) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
+
+	// Pass 1: raw lowercase keys (exact match, no prefix stripping)
+	for _, modelName := range modelNames {
+		if modelName == "" {
+			continue
+		}
+		raw := strings.ToLower(strings.TrimSpace(modelName))
+		if price := r.prices[raw]; price != nil {
+			return modelName, price
+		}
+	}
+
+	// Pass 2: normalised keys (prefix-stripped)
 	for _, modelName := range modelNames {
 		if modelName == "" {
 			continue
@@ -126,6 +162,7 @@ func (r *ModelPriceRegistry) GetPriceAny(modelNames ...string) (string, *ModelPr
 			return modelName, price
 		}
 	}
+
 	return "", nil
 }
 
@@ -136,6 +173,11 @@ func (r *ModelPriceRegistry) Update(prices map[string]*ModelPrice) {
 	r.prices = make(map[string]*ModelPrice)
 	for k, v := range prices {
 		r.prices[k] = v
+		// Store raw lowercase key so that provider-prefixed model names
+		// (e.g. "openrouter/gpt-5-mini") can be matched in GetPriceAny's
+		// first pass before normalisation strips the prefix.
+		raw := strings.ToLower(strings.TrimSpace(k))
+		r.prices[raw] = v
 	}
 	r.lastUpdate = utils.NowUTC()
 }
@@ -143,11 +185,26 @@ func (r *ModelPriceRegistry) Update(prices map[string]*ModelPrice) {
 // MergeDB applies DB-sourced prices on top of the existing registry without
 // removing prices that came from the file-based price list.
 // DB prices take precedence for models that appear in both sources.
+//
+// A DB override only ever replaces the exact key it names (plus that key's
+// own raw/lowercased form) — it deliberately does NOT sweep the registry for
+// other keys that merely share a normalized form. A price entry deliberately
+// keyed "provider/model" (e.g. "openrouter/gpt-5-mini", or any alias that
+// needs a price distinct from its canonical model — see
+// "gemini-3-flash-preview-highlimits" in client_a.libsonnet) is independent
+// of the plain model it happens to normalize to; an override for the plain
+// model must not silently leak into it. If a DB-sourced override is meant
+// to apply to such an alias too, the DB record must name that alias's exact
+// key itself.
 func (r *ModelPriceRegistry) MergeDB(dbPrices map[string]*ModelPrice) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	for k, v := range dbPrices {
 		r.prices[k] = v
+		// Store raw lowercase key (same logic as Update) so that DB-sourced
+		// provider-prefixed entries are also findable in GetPriceAny pass 1.
+		raw := strings.ToLower(strings.TrimSpace(k))
+		r.prices[raw] = v
 	}
 	r.lastUpdate = utils.NowUTC()
 }

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -14,6 +14,7 @@ import (
 	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
 	"github.com/mixaill76/auto_ai_router/internal/scope"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -1429,6 +1430,34 @@ func TestModelPriceRegistry_MergeDB(t *testing.T) {
 	// New DB entries should be added.
 	gemini := registry.GetPrice("gemini-1.5-pro")
 	assert.NotNil(t, gemini)
+}
+
+// TestModelPriceRegistry_MergeDB_ScopedToExactKey guards against an earlier
+// version of this fix that swept the whole registry for any key whose
+// NormalizeModelName matched the DB override's key, silently clobbering
+// unrelated aliases that happen to share a normalized form. A DB override
+// for the plain model must never leak into an independently, deliberately
+// priced alias like "yandex/gpt-5.1" (see llmarena/services default.libsonnet)
+// unless the DB record names that alias's own exact key.
+func TestModelPriceRegistry_MergeDB_ScopedToExactKey(t *testing.T) {
+	registry := NewModelPriceRegistry()
+
+	registry.Update(map[string]*ModelPrice{
+		"gpt-5.1":        {InputCostPerToken: 1.625e-06},
+		"yandex/gpt-5.1": {InputCostPerToken: 1.22353e-05},
+	})
+
+	registry.MergeDB(map[string]*ModelPrice{
+		"gpt-5.1": {InputCostPerToken: 9.99e-06},
+	})
+
+	plain := registry.GetPrice("gpt-5.1")
+	require.NotNil(t, plain)
+	assert.Equal(t, 9.99e-06, plain.InputCostPerToken, "plain gpt-5.1 should pick up the DB override")
+
+	yandex := registry.GetPrice("yandex/gpt-5.1")
+	require.NotNil(t, yandex)
+	assert.Equal(t, 1.22353e-05, yandex.InputCostPerToken, "yandex/gpt-5.1 must be untouched — the DB override didn't name it")
 }
 
 func TestModelPriceRegistry_GetPrice_NotFound(t *testing.T) {

--- a/internal/models/price_loader.go
+++ b/internal/models/price_loader.go
@@ -54,6 +54,9 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 	}
 
 	// Normalize model names (convert keys to normalized format)
+	// Also store raw lowercase keys so that provider-prefixed names like
+	// "google/gemini-3-flash-preview-highlimits" survive normalisation and
+	// can be matched in ModelPriceRegistry.GetPriceAny's first pass.
 	normalizedPrices := make(map[string]*ModelPrice)
 	normalizedSources := make(map[string]string) // normalized name -> original full name (for collision detection)
 	for fullName, price := range rawPrices {
@@ -69,6 +72,18 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 		}
 		normalized := NormalizeModelName(fullName)
 		if existingFullName, exists := normalizedSources[normalized]; exists {
+			existingIsBare := !strings.Contains(existingFullName, "/")
+			newIsBare := !strings.Contains(fullName, "/")
+
+			if existingIsBare && !newIsBare {
+				// Existing entry is a bare model name (e.g. "gpt-4") and
+				// the new entry has a provider prefix (e.g. "openai/gpt-4").
+				// Keep the bare entry — it is more specific in the two-pass
+				// lookup and avoids the bare key being silently overwritten
+				// by the prefixed entry due to random Go map iteration order.
+				continue
+			}
+
 			slog.Warn("normalized model name collision: entry will be overwritten",
 				"normalized_name", normalized,
 				"existing_entry", existingFullName,
@@ -77,6 +92,14 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 		}
 		normalizedSources[normalized] = fullName
 		normalizedPrices[normalized] = price
+
+		// Store the raw lowercase key alongside the normalised one so that
+		// Update/LoadPrices can put both into the registry, enabling the
+		// two-pass lookup in GetPriceAny.
+		raw := strings.ToLower(strings.TrimSpace(fullName))
+		if raw != normalized {
+			normalizedPrices[raw] = price
+		}
 	}
 
 	return normalizedPrices, nil

--- a/internal/models/price_loader_test.go
+++ b/internal/models/price_loader_test.go
@@ -306,3 +306,31 @@ func TestLoadFromHTTP_UnsupportedScheme(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported scheme")
 	assert.Nil(t, data)
 }
+
+func TestLoadModelPrices_BareKeyWinsOverPrefixed(t *testing.T) {
+	filePath := filepath.Join(t.TempDir(), "prices.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{
+		"gpt-4":        {"input_cost_per_token": 1.0e-06, "output_cost_per_token": 4.0e-06},
+		"openai/gpt-4": {"input_cost_per_token": 2.0e-06, "output_cost_per_token": 8.0e-06}
+	}`), 0o600))
+
+	prices, err := LoadModelPrices(filePath)
+	require.NoError(t, err)
+
+	// Bare key must win over prefixed key
+	assert.Equal(t, 1.0e-06, prices["gpt-4"].InputCostPerToken)
+}
+
+func TestLoadModelPrices_BareKeyWinsOverPrefixed_ReverseOrder(t *testing.T) {
+	// Prefixed entry listed first in JSON — bare key must still win
+	filePath := filepath.Join(t.TempDir(), "prices.json")
+	require.NoError(t, os.WriteFile(filePath, []byte(`{
+		"openai/gpt-4": {"input_cost_per_token": 2.0e-06, "output_cost_per_token": 8.0e-06},
+		"gpt-4":        {"input_cost_per_token": 1.0e-06, "output_cost_per_token": 4.0e-06}
+	}`), 0o600))
+
+	prices, err := LoadModelPrices(filePath)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1.0e-06, prices["gpt-4"].InputCostPerToken)
+}

--- a/internal/proxy/billing_price.go
+++ b/internal/proxy/billing_price.go
@@ -8,6 +8,14 @@ import "github.com/mixaill76/auto_ai_router/internal/models"
 // callers must preserve this argument order, since it IS the priority
 // contract; passing the strings in a different order silently changes which
 // price wins.
+//
+// The underlying GetPriceAny uses a two-pass strategy: exact (raw lowercase)
+// keys are checked before normalised (prefix-stripped) keys. This ensures
+// that a provider-prefixed publicModelID whose normalised form collides
+// with a cheaper sibling (e.g. "openrouter/gpt-5-mini" → "gpt-5-mini")
+// never overshadows the correct modelID entry, while explicit raw entries
+// like "google/gemini-3-flash-preview-highlimits" still win over the
+// normalised fallback.
 func lookupBillingModelPrice(registry *models.ModelPriceRegistry, publicModelID, modelID, realModelID string) (string, *models.ModelPrice) {
 	if registry == nil {
 		return modelID, nil

--- a/internal/proxy/billing_price_test.go
+++ b/internal/proxy/billing_price_test.go
@@ -1,0 +1,153 @@
+package proxy
+
+import (
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupBillingModelPrice_TwoPassLookup(t *testing.T) {
+	registry := models.NewModelPriceRegistry()
+	registry.Update(map[string]*models.ModelPrice{
+		"gpt-5-mini":    {InputCostPerToken: 2.25e-07, OutputCostPerToken: 1.8e-06},
+		"gpt-5-mini-or": {InputCostPerToken: 3.25e-07, OutputCostPerToken: 2.6e-06},
+	})
+
+	tests := []struct {
+		name          string
+		publicModelID string
+		modelID       string
+		realModelID   string
+		wantModelID   string
+		wantInputCost float64
+	}{
+		{
+			name:          "openrouter/gpt-5-mini: raw miss on publicModelID, raw hit on modelID",
+			publicModelID: "openrouter/gpt-5-mini",
+			modelID:       "gpt-5-mini-or",
+			realModelID:   "gpt-5-mini",
+			wantModelID:   "gpt-5-mini-or",
+			wantInputCost: 3.25e-07,
+		},
+		{
+			name:          "openai/gpt-5-mini: raw miss, normalised hit on publicModelID",
+			publicModelID: "openai/gpt-5-mini",
+			modelID:       "gpt-5-mini",
+			realModelID:   "gpt-5-mini",
+			wantModelID:   "gpt-5-mini",
+			wantInputCost: 2.25e-07,
+		},
+		{
+			name:          "plain modelID when no publicModelID",
+			publicModelID: "",
+			modelID:       "gpt-5-mini-or",
+			realModelID:   "",
+			wantModelID:   "gpt-5-mini-or",
+			wantInputCost: 3.25e-07,
+		},
+		{
+			name:          "realModelID used as fallback",
+			publicModelID: "",
+			modelID:       "unknown-model",
+			realModelID:   "gpt-5-mini",
+			wantModelID:   "gpt-5-mini",
+			wantInputCost: 2.25e-07,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotModelID, gotPrice := lookupBillingModelPrice(registry, tt.publicModelID, tt.modelID, tt.realModelID)
+			assert.Equal(t, tt.wantModelID, gotModelID)
+			assert.NotNil(t, gotPrice)
+			assert.Equal(t, tt.wantInputCost, gotPrice.InputCostPerToken)
+		})
+	}
+}
+
+func TestLookupBillingModelPrice_RawEntryBeatsNormalised(t *testing.T) {
+	registry := models.NewModelPriceRegistry()
+	registry.Update(map[string]*models.ModelPrice{
+		"gemini-3-flash-preview":                   {InputCostPerToken: 4.5e-07, OutputCostPerToken: 2.7e-06},
+		"google/gemini-3-flash-preview-highlimits": {InputCostPerToken: 9e-07, OutputCostPerToken: 5.4e-06},
+	})
+
+	gotModelID, gotPrice := lookupBillingModelPrice(
+		registry,
+		"google/gemini-3-flash-preview-highlimits",
+		"gemini-3-flash-preview",
+		"",
+	)
+	// publicModelID raw key matches first — highlimits price wins.
+	assert.Equal(t, "google/gemini-3-flash-preview-highlimits", gotModelID)
+	assert.NotNil(t, gotPrice)
+	assert.Equal(t, 9e-07, gotPrice.InputCostPerToken)
+}
+
+func TestLookupBillingModelPrice_NilRegistry(t *testing.T) {
+	gotModelID, gotPrice := lookupBillingModelPrice(nil, "openrouter/gpt-5-mini", "gpt-5-mini-or", "")
+	assert.Equal(t, "gpt-5-mini-or", gotModelID)
+	assert.Nil(t, gotPrice)
+}
+
+func TestLookupBillingModelPrice_DeduplicatesModelIDAndRealModelID(t *testing.T) {
+	registry := models.NewModelPriceRegistry()
+	registry.Update(map[string]*models.ModelPrice{
+		"gpt-5-mini": {InputCostPerToken: 2.25e-07},
+	})
+
+	gotModelID, gotPrice := lookupBillingModelPrice(registry, "", "gpt-5-mini", "gpt-5-mini")
+	assert.Equal(t, "gpt-5-mini", gotModelID)
+	assert.NotNil(t, gotPrice)
+}
+
+// MergeDB must update the exact key it names (and that key's own raw form)
+// but must NOT leak into an unrelated raw-keyed entry just because it
+// shares a normalized form — see TestModelPriceRegistry_MergeDB_ScopedToExactKey
+// in internal/models for the direct regression test (a DB override for
+// "gpt-5.1" clobbering the independently-priced "yandex/gpt-5.1" alias was
+// caught here during review of an earlier version of this fix that swept
+// the whole registry by normalized form).
+func TestLookupBillingModelPrice_MergeDBUpdatesExactKeyOnly(t *testing.T) {
+	registry := models.NewModelPriceRegistry()
+
+	registry.Update(map[string]*models.ModelPrice{
+		"gpt-5-mini":            {InputCostPerToken: 2.25e-07},
+		"openrouter/gpt-5-mini": {InputCostPerToken: 9.99e-07}, // deliberately distinct alias price
+	})
+
+	registry.MergeDB(map[string]*models.ModelPrice{
+		"gpt-5-mini": {InputCostPerToken: 5.0e-07},
+	})
+
+	// The plain model picks up the DB override...
+	_, plainPrice := lookupBillingModelPrice(registry, "", "gpt-5-mini", "")
+	require.NotNil(t, plainPrice)
+	assert.Equal(t, 5.0e-07, plainPrice.InputCostPerToken)
+
+	// ...but the deliberately distinct alias price is untouched, since the
+	// DB override didn't name it.
+	matched, aliasPrice := lookupBillingModelPrice(registry, "openrouter/gpt-5-mini", "gpt-5-mini-or", "")
+	require.NotNil(t, aliasPrice)
+	assert.Equal(t, "openrouter/gpt-5-mini", matched)
+	assert.Equal(t, 9.99e-07, aliasPrice.InputCostPerToken)
+}
+
+// P1: LoadModelPrices must prefer bare keys over prefixed keys in collisions.
+func TestLookupBillingModelPrice_BareKeyWinsOverPrefixed(t *testing.T) {
+	// Simulate what LoadModelPrices returns when both "gpt-4" and
+	// "openai/gpt-4" exist in the price file: the bare key must win.
+	registry := models.NewModelPriceRegistry()
+	registry.Update(map[string]*models.ModelPrice{
+		"gpt-4":        {InputCostPerToken: 1.0e-06},
+		"openai/gpt-4": {InputCostPerToken: 2.0e-06},
+	})
+
+	// Bare key must be returned, not the prefixed one
+	gotModelID, gotPrice := lookupBillingModelPrice(registry, "", "gpt-4", "")
+	assert.Equal(t, "gpt-4", gotModelID)
+	assert.NotNil(t, gotPrice)
+	assert.Equal(t, 1.0e-06, gotPrice.InputCostPerToken)
+}


### PR DESCRIPTION
## Problem

`NormalizeModelName` strips provider prefixes (e.g. `openrouter/gpt-5-mini` → `gpt-5-mini`), causing provider-prefixed models to collide with a cheaper sibling entry in the price registry.

**Example:** `openrouter/gpt-5-mini` was billed at `gpt-5-mini` rates (2.25e-07 input) instead of `gpt-5-mini-or` rates (3.25e-07 input) — a 31% undercharge.

## Solution

`GetPriceAny` now uses a two-pass strategy:

**Pass 1 (raw):** publicModelID → modelID → realModelID
**Pass 2 (normalised):** publicModelID → modelID → realModelID

Raw (exact lowercase) keys always beat normalised (prefix-stripped) keys. This preserves the publicModelID > modelID > realModelID priority contract from PR #95 while fixing the collision bug.

## Changes

- `internal/models/manager.go`: Two-pass lookup in `GetPriceAny`, raw key storage in `Update` and `MergeDB`
- `internal/models/price_loader.go`: Store raw lowercase keys during price file loading
- `internal/proxy/billing_price.go`: Updated doc comment
- `internal/proxy/billing_price_test.go`: New tests for two-pass behavior

## Verified

20 test requests via `litellm.data-light.ru` confirmed correct billing at `gpt-5-mini-or` rates (3.25e-07 input, 2.6e-06 output).