### PR TITLE
feat(billing): add 512k full-session pricing tier

### DIFF
--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -205,13 +205,13 @@ The same logic applies to output tokens using `output_cost_per_token_above_200k_
 
 Cache prices follow LiteLLM's full-session semantics: when `prompt_tokens > 200_000`, all cache read/write tokens use the matching `*_above_200k_tokens` rate. The 32k/128k/256k/272k full-session cache fields take precedence over the 200k tier whenever configured, with the highest exceeded threshold winning (see "Long-context pricing" below).
 
-### Long-context pricing (32k / 128k / 256k / 272k full-session tiers)
+### Long-context pricing (32k / 128k / 256k / 272k / 512k full-session tiers)
 
 When the prompt exceeds one of these thresholds, the matching `*_above_<N>k_tokens` rate applies to the **full session** rather than only the tokens beyond the threshold — the prompt size selects the tier for regular input, output, cache reads, and cache writes. At exactly the threshold, base rates still apply (the check is strictly "greater than").
 
-272k was added first for models such as GPT-5.6; 32k/128k/256k were added for Alibaba Cloud models (Qwen 3.x, GLM) whose published pricing is a flat rate per input-length bracket (e.g. 0–32k / 32k–128k / 128k–256k / >256k) rather than an incremental rate for the overflow.
+272k was added first for models such as GPT-5.6; 32k/128k/256k were added for Alibaba Cloud models (Qwen 3.x, GLM) whose published pricing is a flat rate per input-length bracket (e.g. 0–32k / 32k–128k / 128k–256k / >256k) rather than an incremental rate for the overflow. 512k was added for MiniMax-M3, whose pricing depends on total input token count with a 512k threshold.
 
-A price entry may configure any subset of these four thresholds (e.g. only 32k and 256k, skipping 128k). For each cost component (input, output, cache read, cache write) independently, AIR picks the **highest configured threshold that the prompt exceeds**, in descending order 272k → 256k → 128k → 32k, and skips any threshold whose rate field isn't set. If none of the four apply, cost calculation falls back to the 200k proportional tier described above, then to the base rate.
+A price entry may configure any subset of these five thresholds (e.g. only 32k and 256k, skipping 128k). For each cost component (input, output, cache read, cache write) independently, AIR picks the **highest configured threshold that the prompt exceeds**, in descending order 512k → 272k → 256k → 128k → 32k, and skips any threshold whose rate field isn't set. If none of the five apply, cost calculation falls back to the 200k proportional tier described above, then to the base rate.
 
 Example: a model with only `input_cost_per_token_above_128k_tokens` and `input_cost_per_token_above_256k_tokens` set bills a 150k-token prompt at the 128k rate and a 300k-token prompt at the 256k rate; a 100k-token prompt still uses the base rate.
 

--- a/internal/litellmdb/model_table/model_table.go
+++ b/internal/litellmdb/model_table/model_table.go
@@ -435,6 +435,12 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	if p.OutputCostPerTokenAbove272kTokens != nil {
 		price.OutputCostPerTokenAbove272k = *p.OutputCostPerTokenAbove272kTokens
 	}
+	if p.InputCostPerTokenAbove512kTokens != nil {
+		price.InputCostPerTokenAbove512k = *p.InputCostPerTokenAbove512kTokens
+	}
+	if p.OutputCostPerTokenAbove512kTokens != nil {
+		price.OutputCostPerTokenAbove512k = *p.OutputCostPerTokenAbove512kTokens
+	}
 	if p.InputCostPerAudioToken != nil {
 		price.InputCostPerAudioToken = *p.InputCostPerAudioToken
 	}
@@ -485,6 +491,12 @@ func convertPricingToModelPrice(p *queries.CustomPricingLiteLLMParams) *manager.
 	}
 	if p.CacheCreationInputTokenCostAbove272kTokens != nil {
 		price.CacheCreationInputTokenCostAbove272k = *p.CacheCreationInputTokenCostAbove272kTokens
+	}
+	if p.CacheReadInputTokenCostAbove512kTokens != nil {
+		price.CacheReadInputTokenCostAbove512k = *p.CacheReadInputTokenCostAbove512kTokens
+	}
+	if p.CacheCreationInputTokenCostAbove512kTokens != nil {
+		price.CacheCreationInputTokenCostAbove512k = *p.CacheCreationInputTokenCostAbove512kTokens
 	}
 	if p.CacheReadInputAudioTokenCost != nil {
 		price.CacheReadInputAudioTokenCost = *p.CacheReadInputAudioTokenCost

--- a/internal/litellmdb/queries/model_table.go
+++ b/internal/litellmdb/queries/model_table.go
@@ -13,6 +13,7 @@ type CustomPricingLiteLLMParams struct {
 	OutputCostPerTokenAbove200kTokens *float64 `json:"output_cost_per_token_above_200k_tokens,omitempty"`
 	OutputCostPerTokenAbove256kTokens *float64 `json:"output_cost_per_token_above_256k_tokens,omitempty"`
 	OutputCostPerTokenAbove272kTokens *float64 `json:"output_cost_per_token_above_272k_tokens,omitempty"`
+	OutputCostPerTokenAbove512kTokens *float64 `json:"output_cost_per_token_above_512k_tokens,omitempty"`
 
 	InputCostPerSecond  *float64 `json:"input_cost_per_second,omitempty"`
 	OutputCostPerSecond *float64 `json:"output_cost_per_second,omitempty"`
@@ -28,6 +29,8 @@ type CustomPricingLiteLLMParams struct {
 	CacheCreationInputTokenCostAbove200kTokens         *float64 `json:"cache_creation_input_token_cost_above_200k_tokens,omitempty"`
 	CacheReadInputTokenCostAbove256kTokens             *float64 `json:"cache_read_input_token_cost_above_256k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove256kTokens         *float64 `json:"cache_creation_input_token_cost_above_256k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove512kTokens             *float64 `json:"cache_read_input_token_cost_above_512k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove512kTokens         *float64 `json:"cache_creation_input_token_cost_above_512k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove1hr                *float64 `json:"cache_creation_input_token_cost_above_1hr,omitempty"`
 	CacheCreationInputTokenCostAbove1hrAbove200kTokens *float64 `json:"cache_creation_input_token_cost_above_1hr_above_200k_tokens,omitempty"`
 	CacheReadInputTokenCostAbove272kTokens             *float64 `json:"cache_read_input_token_cost_above_272k_tokens,omitempty"`
@@ -39,6 +42,7 @@ type CustomPricingLiteLLMParams struct {
 	InputCostPerTokenAbove200kTokens *float64 `json:"input_cost_per_token_above_200k_tokens,omitempty"`
 	InputCostPerTokenAbove256kTokens *float64 `json:"input_cost_per_token_above_256k_tokens,omitempty"`
 	InputCostPerTokenAbove272kTokens *float64 `json:"input_cost_per_token_above_272k_tokens,omitempty"`
+	InputCostPerTokenAbove512kTokens *float64 `json:"input_cost_per_token_above_512k_tokens,omitempty"`
 
 	InputCostPerAudioToken                    *float64 `json:"input_cost_per_audio_token,omitempty"`
 	InputCostPerAudioPerSecond                *float64 `json:"input_cost_per_audio_per_second,omitempty"`

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -55,6 +55,11 @@ type ModelPrice struct {
 	CacheReadInputTokenCostAbove256k     float64 `json:"cache_read_input_token_cost_above_256k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove256k float64 `json:"cache_creation_input_token_cost_above_256k_tokens,omitempty"`
 
+	InputCostPerTokenAbove512k           float64 `json:"input_cost_per_token_above_512k_tokens,omitempty"`
+	OutputCostPerTokenAbove512k          float64 `json:"output_cost_per_token_above_512k_tokens,omitempty"`
+	CacheReadInputTokenCostAbove512k     float64 `json:"cache_read_input_token_cost_above_512k_tokens,omitempty"`
+	CacheCreationInputTokenCostAbove512k float64 `json:"cache_creation_input_token_cost_above_512k_tokens,omitempty"`
+
 	// Audio tokens (can be more specific than regular tokens)
 	InputCostPerAudioToken  float64 `json:"input_cost_per_audio_token,omitempty"`
 	OutputCostPerAudioToken float64 `json:"output_cost_per_audio_token,omitempty"`

--- a/internal/models/price_calculator.go
+++ b/internal/models/price_calculator.go
@@ -14,6 +14,7 @@ const (
 	tokenTiering128kThreshold = 128_000
 	tokenTiering256kThreshold = 256_000
 	tokenTiering272kThreshold = 272_000
+	tokenTiering512kThreshold = 512_000
 )
 
 // fullSessionTier describes one "Alibaba Cloud style" pricing bracket: once
@@ -47,6 +48,13 @@ type fullSessionTier struct {
 // separate proportional-only handling further down in CalculateTokenCosts.
 func fullSessionTiers(price *ModelPrice) []fullSessionTier {
 	tiers := []fullSessionTier{
+		{
+			threshold:         tokenTiering512kThreshold,
+			inputRate:         price.InputCostPerTokenAbove512k,
+			outputRate:        price.OutputCostPerTokenAbove512k,
+			cacheReadRate:     price.CacheReadInputTokenCostAbove512k,
+			cacheCreationRate: price.CacheCreationInputTokenCostAbove512k,
+		},
 		{
 			threshold:         tokenTiering272kThreshold,
 			inputRate:         price.InputCostPerTokenAbove272k,

--- a/internal/models/price_calculator_test.go
+++ b/internal/models/price_calculator_test.go
@@ -1042,6 +1042,46 @@ func TestCalculateTokenCosts_272kTakesPrecedenceOver256k(t *testing.T) {
 	assert.InDelta(t, 252.0, costs.InputCost, 1e-9) // 280_000 * 0.0009, not the 256k rate
 }
 
+func TestCalculateTokenCosts_512kTakesPrecedenceOver272k(t *testing.T) {
+	usage := &converter.TokenUsage{PromptTokens: 600_000} // above both 272k and 512k
+	price := &ModelPrice{
+		InputCostPerToken:          0.01,
+		InputCostPerTokenAbove272k: 0.001,
+		InputCostPerTokenAbove512k: 0.0005,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 300.0, costs.InputCost, 1e-9) // 600_000 * 0.0005, not the 272k rate
+}
+
+func TestCalculateTokenCosts_512kOnly(t *testing.T) {
+	// MiniMax-M3 style: only 512k tier configured, no 272k/256k/128k/32k
+	price := &ModelPrice{
+		InputCostPerToken:          0.002,
+		InputCostPerTokenAbove512k: 0.001,
+	}
+
+	tests := []struct {
+		name         string
+		promptTokens int
+		wantInput    float64
+	}{
+		{"below_512k_uses_base_rate", 400_000, 800.0},    // 400_000 * 0.002
+		{"above_512k_uses_512k_rate", 600_000, 600.0},    // 600_000 * 0.001
+		{"exactly_512k_uses_base_rate", 512_000, 1024.0}, // 512_000 * 0.002 (threshold is exclusive)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			costs := CalculateTokenCosts(&converter.TokenUsage{PromptTokens: tt.promptTokens}, price)
+			require.NotNil(t, costs)
+			assert.InDelta(t, tt.wantInput, costs.InputCost, 1e-9)
+		})
+	}
+}
+
 func TestCalculateTokenCosts_CacheTierOverridesBaseCacheRate(t *testing.T) {
 	// Mirrors qwen3-vl-flash: a non-zero BASE cache_read rate is configured
 	// alongside a tiered one. The base rate must not "win" once the prompt


### PR DESCRIPTION
## Problem

MiniMax-M3 pricing depends on total input token count with a 512k threshold. The router previously only supported 32k/128k/256k/272k tiers, so requests with >512k context could not be correctly tariffied.

## Solution

Add 512k as a new full-session tier (same semantics as 272k: the entire request is billed at the tier rate once the prompt exceeds 512k tokens).

**Tier ordering:** 512k → 272k → 256k → 128k → 32k

## Changes

- `price_calculator.go`: new threshold constant + tier entry
- `manager.go`: ModelPrice gains 4 new fields (input/output/cache read/cache creation above 512k)
- `litellmdb`: DB query struct and mapping updated
- `pricing.md`: documentation updated
- `price_calculator_test.go`: 2 new tests

## Usage

Add to a price entry in `client_a.libsonnet`:

```jsonnet
'MiniMax-M3': {
  input_cost_per_token: <base_rate>,
  output_cost_per_token: <base_rate>,
  input_cost_per_token_above_512k_tokens: <512k_rate>,
  output_cost_per_token_above_512k_tokens: <512k_rate>,
}
```

Or via LiteLLM DB: `input_cost_per_token_above_512k_tokens`, `output_cost_per_token_above_512k_tokens`, `cache_read_input_token_cost_above_512k_tokens`, `cache_creation_input_token_cost_above_512k_tokens`.