### PR TITLE
fix: fall back to local prompt-token estimate on partial-zero provider usage

### DIFF
--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -997,6 +997,15 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 	fallbackCompletion := totalTokens
 
 	providerUsage := false
+	// Tracked separately from providerUsage: some providers (e.g. CometAPI's Anthropic-
+	// compatible streaming) send a syntactically valid usage object whose message_start
+	// carries a placeholder usage:{input_tokens:0,output_tokens:0} while output tokens
+	// land correctly later via message_delta. Gating the local tiktoken fallback on the
+	// coarse providerUsage flag silently accepts that placeholder zero as truth and never
+	// estimates prompt tokens for the request. Gate per-field instead, so a provider that
+	// reports some fields but not others still gets a fallback for the missing one.
+	providerReportedPromptTokens := false
+	providerReportedCompletionTokens := false
 	if len(lastChunk) > 0 {
 		extractor := getStreamUsageExtractor(providerName)
 		if audioInputAlreadyExcludesCachedAudio {
@@ -1006,9 +1015,11 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 			providerUsage = true
 			if usageInfo.PromptTokens > 0 {
 				logCtx.TokenUsage.PromptTokens = usageInfo.PromptTokens
+				providerReportedPromptTokens = true
 			}
 			if usageInfo.CompletionTokens > 0 {
 				logCtx.TokenUsage.CompletionTokens = usageInfo.CompletionTokens
+				providerReportedCompletionTokens = true
 			}
 
 			if usageInfo.CachedTokens > 0 {
@@ -1070,7 +1081,19 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 		}
 	}
 
-	if !providerUsage && logCtx.TokenUsage.PromptTokens == 0 {
+	// explicitZeroUsage: the provider sent a usage object and reported BOTH fields as zero
+	// together (e.g. a filtered/cancelled request that legitimately produced nothing) — a
+	// coherent signal, trusted as-is, same as before this fix.
+	//
+	// Any other zero PromptTokens is distrusted and falls back to the local estimate:
+	//   - no usage object arrived at all (original behavior, unchanged), or
+	//   - the usage object reported a genuine non-zero CompletionTokens alongside a zero
+	//     PromptTokens — internally inconsistent (a real completion cannot be produced from
+	//     zero input) and matches the CometAPI bug: message_start's placeholder
+	//     usage:{input_tokens:0,output_tokens:0} sometimes never gets a real input count even
+	//     though output tokens land correctly later via message_delta.
+	explicitZeroUsage := providerUsage && !providerReportedPromptTokens && !providerReportedCompletionTokens
+	if !providerReportedPromptTokens && !explicitZeroUsage && logCtx.TokenUsage.PromptTokens == 0 {
 		logCtx.TokenUsage.PromptTokens = logCtx.promptTokensEstimate()
 	}
 	if !providerUsage && logCtx.TokenUsage.CompletionTokens == 0 {

--- a/internal/proxy/stream_test.go
+++ b/internal/proxy/stream_test.go
@@ -1106,6 +1106,76 @@ func TestHandleStreamingWithTokens_CombinedUsageAndDone(t *testing.T) {
 	assert.Equal(t, 5, logCtx.TokenUsage.CompletionTokens, "CompletionTokens should be 5 (extracted from usage, not total_tokens = 105)")
 }
 
+// TestHandleStreamingWithTokens_PartialZeroUsage_FallsBackForMissingField verifies that when
+// a provider sends a usage object with some fields correctly populated and others as a bogus
+// zero (observed from CometAPI's Anthropic-compatible streaming: message_start carries
+// usage:{input_tokens:0,output_tokens:0} as a placeholder while output tokens land correctly
+// via message_delta), the local tiktoken estimate fills in only the missing field. Before this
+// fix, providerUsage was a single flag for "did any usage arrive at all", so a genuinely-sent
+// completion_tokens value silently suppressed the prompt-token fallback too, permanently
+// under-billing the request's input tokens.
+func TestHandleStreamingWithTokens_PartialZeroUsage_FallsBackForMissingField(t *testing.T) {
+	upstreamServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+
+		chunks := []string{
+			"data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
+			"data: {\"choices\":[],\"usage\":{\"prompt_tokens\":0,\"completion_tokens\":6,\"total_tokens\":6}}\n\n",
+			"data: [DONE]\n\n",
+		}
+
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			http.Error(w, "Streaming not supported", http.StatusInternalServerError)
+			return
+		}
+
+		for _, chunk := range chunks {
+			_, _ = fmt.Fprint(w, chunk)
+			flusher.Flush()
+			time.Sleep(1 * time.Millisecond)
+		}
+	}))
+	defer upstreamServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeProxy, upstreamServer.URL, "upstream-key-1").
+		WithRequestTimeout(5 * time.Second).
+		Build()
+
+	resp, err := http.Get(upstreamServer.URL)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	w := httptest.NewRecorder()
+
+	logCtx := &RequestLogContext{
+		RequestID:              "test-request-partial-zero-usage",
+		promptTokensEstimateFn: func() int { return 12 }, // local tiktoken fallback estimate
+		TokenUsage:             &converter.TokenUsage{},
+		Credential: &config.CredentialConfig{
+			Name: "test",
+			Type: config.ProviderTypeOpenAI,
+		},
+		Request: httptest.NewRequest("POST", "/v1/chat/completions", nil),
+	}
+
+	err = prx.handleStreamingWithTokens(w, resp, "test", "gpt-4o-mini", logCtx)
+	require.NoError(t, err)
+
+	assert.True(t, logCtx.Logged, "logCtx should be marked as logged")
+	assert.NotNil(t, logCtx.TokenUsage, "TokenUsage should not be nil")
+
+	// PromptTokens: the provider reported 0, which is treated as "not reported" — the local
+	// estimate must fill it in instead of silently billing zero input tokens.
+	assert.Equal(t, 12, logCtx.TokenUsage.PromptTokens,
+		"PromptTokens should fall back to the local estimate when the provider's usage object reports 0")
+	// CompletionTokens: the provider genuinely reported 6 — must NOT be touched by the fallback.
+	assert.Equal(t, 6, logCtx.TokenUsage.CompletionTokens,
+		"CompletionTokens should keep the provider-reported value, not the fallback")
+}
+
 // TestTokenCapturingWriter_CumulativeTokens verifies that tokenCapturingWriter does NOT
 // accumulate total_tokens across chunks. Vertex/Gemini include a cumulative total_tokens in
 // every streaming chunk; naively adding them up multiplies the real count by N (the number of


### PR DESCRIPTION
## Summary
- Streaming usage extraction in `finalizeStreamingLog` gated the local tiktoken fallback on a single `providerUsage` flag, true the moment *any* usage object arrived — regardless of whether individual fields inside it were actually populated.
- CometAPI's Anthropic-compatible streaming sometimes sends `message_start` with a placeholder `usage:{input_tokens:0,output_tokens:0}` that's never corrected, while output tokens land correctly later via `message_delta`. Since *some* usage data arrived, `providerUsage` stayed true and the prompt-token fallback never fired — the request was billed with 0 input tokens despite a real, successful completion.
- Now tracks per-field whether the provider actually reported a positive value (`providerReportedPromptTokens` / `providerReportedCompletionTokens`), and only distrusts a zero `PromptTokens` when the *same* usage object also reported a genuine non-zero `CompletionTokens` — that combination is internally inconsistent (a real completion can't come from zero input) and matches the CometAPI pattern above.
- When the provider reports **both** fields as zero together (e.g. a filtered/cancelled request that legitimately produced nothing), that zero is still trusted as-is — preserves the existing behavior covered by `TestFinalizeStreamingLogKeepsExplicitZeroProviderUsage`.

## Verification
- Reproduced directly against CometAPI's raw SSE (`/v1/messages`, bypassing this router entirely): `message_start` usage stub observed on 8/15 and 5/15 repeats across separate runs.
- Reproduced through this router's own local build (this branch's parent commit) pointed at CometAPI: claude-sonnet-4.5/4.6/5 lost input-token billing on 53%/20%/47% of streaming Responses API requests.
- Traced back from live production traffic via spend-log request IDs — confirmed the affected calls were served by the `cometapi01` credential (not Bedrock).
- After this fix, same local build + same test conditions: **0/45** zero-input cases.
- `go test ./...` passes; added `TestHandleStreamingWithTokens_PartialZeroUsage_FallsBackForMissingField` covering the new mixed-zero case, existing `TestFinalizeStreamingLogKeepsExplicitZeroProviderUsage` still passes unmodified.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Live repro against CometAPI directly (before/after)
- [x] Live repro through a local router build talking to CometAPI (before/after)
- [x] Cross-checked affected production request IDs against LiteLLM spend logs to confirm the provider