### PR TITLE
feat: add protected tenant admission boundary

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -249,6 +249,7 @@ func main() {
 		StrictAllTeamModelsACL:     cfg.Server.StrictAllTeamModelsACL,
 		ResponseHeaderMode:         cfg.Server.ResponseHeaders.Mode,
 		CredentialNameAsTeamID:     cfg.Server.CredentialNameAsTeamID,
+		ProtectedTenants:           cfg.ProtectedTenants,
 
 		BudgetReserver:                   budgetReserver,
 		KeyRateLimiter:                   keyRateLimiter,
@@ -662,10 +663,10 @@ func initializeModelManager(
 		modelManager.SetClientModelIDs(cfg.ClientModelIDs)
 	}
 	if len(cfg.PublicModelAlias) > 0 {
-		modelManager.SetPublicModelAliases(cfg.PublicModelAlias)
+		modelManager.SetScopedPublicModelAliases(cfg.PublicModelAlias)
 	}
 	if len(cfg.AcceptedModelAlias) > 0 {
-		modelManager.SetAcceptedModelAliases(cfg.AcceptedModelAlias)
+		modelManager.SetScopedAcceptedModelAliases(cfg.AcceptedModelAlias)
 	}
 
 	// Initialize rate limiters for each model

--- a/cmd/server/main_test.go
+++ b/cmd/server/main_test.go
@@ -90,9 +90,11 @@ func TestInitializeModelManagerRegistersAcceptedModelAliases(t *testing.T) {
 		Models: []config.ModelRPMConfig{{
 			Name: "backend-chat", Credential: "provider", RPM: 7, TPM: 70,
 		}},
-		ModelAlias:         map[string]string{"public/chat": "backend-chat"},
-		ClientModelIDs:     []string{"public/chat"},
-		AcceptedModelAlias: map[string]string{"legacy-chat": "public/chat"},
+		ModelAlias:     map[string]string{"public/chat": "backend-chat"},
+		ClientModelIDs: []string{"public/chat"},
+		AcceptedModelAlias: map[string]config.ClientModelAliasConfig{
+			"legacy-chat": {Target: "public/chat"},
+		},
 	}
 	logger := slog.New(slog.DiscardHandler)
 	_, limiter, bal, _ := initializeBalancer(cfg, logger, nil, nil)

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -235,8 +235,23 @@ models:
 #   "openai/gpt-4o-mini": "gpt-4o-mini"
 # public_model_alias:
 #   "gpt-4o-mini": "openai/gpt-4o-mini"
+#   "cloud-legacy-chat":
+#     target: "openai/gpt-4o-mini"
+#     scopes: ["cloud-ru"]
 # accepted_model_alias:
 #   "legacy-gpt-4o-mini": "openai/gpt-4o-mini"
+#
+# Optional fail-closed policy for selected verified organizations. Protected
+# keys must carry exact configured model IDs and explicit allowed_routes in the
+# LiteLLM DB. required_scopes are reserved to the listed organizations. The
+# master key is an explicit administrative exception to these client policies.
+# protected_tenants:
+#   - name: "cloud-ru"
+#     organization_ids: ["os.environ/CLOUD_RU_ORGANIZATION_ID"]
+#     hostnames: ["api.cloud.example"]
+#     required_scopes: ["cloud-ru"]
+#     require_model_acl: true
+#     require_route_acl: true
 
 # Optional: Redis/Valkey backend for distributed rate limiting and response storage.
 # When enabled, all replicas share a single counter namespace — RPM/TPM limits are
@@ -272,5 +287,3 @@ litellm_db:
   log_batch_size: 100  # Spend log batch size (default: 100)
   log_flush_interval: 5s  # Spend log flush interval (default: 5s)
   log_workers: 4  # Parallel queue-draining writer workers (default: 4)
-  log_retry_attempts: 3  # Spend log retry attempts (default: 3)
-  log_retry_delay: 1s  # Spend log retry delay (default: 1s)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,8 +1,10 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"log/slog"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -160,23 +162,149 @@ func (m *ModelRPMConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type Config struct {
-	Server             ServerConfig       `yaml:"server"`
-	Fail2Ban           Fail2BanConfig     `yaml:"fail2ban,omitempty"`
-	Credentials        []CredentialConfig `yaml:"credentials"`
-	Monitoring         MonitoringConfig   `yaml:"monitoring"`
-	Models             []ModelRPMConfig   `yaml:"models,omitempty"`
-	ModelAlias         map[string]string  `yaml:"model_alias,omitempty"`
-	ClientModelIDs     []string           `yaml:"client_model_ids,omitempty"`
-	PublicModelAlias   map[string]string  `yaml:"public_model_alias,omitempty"`
-	AcceptedModelAlias map[string]string  `yaml:"accepted_model_alias,omitempty"`
-	LiteLLMDB          LiteLLMDBConfig    `yaml:"litellm_db,omitempty"`
-	Redis              RedisConfig        `yaml:"redis,omitempty"`
-	OTEL               OTELConfig         `yaml:"otel,omitempty"`
-	Kafka              KafkaConfig        `yaml:"kafka,omitempty"`
+	Server             ServerConfig                      `yaml:"server"`
+	Fail2Ban           Fail2BanConfig                    `yaml:"fail2ban,omitempty"`
+	Credentials        []CredentialConfig                `yaml:"credentials"`
+	Monitoring         MonitoringConfig                  `yaml:"monitoring"`
+	Models             []ModelRPMConfig                  `yaml:"models,omitempty"`
+	ModelAlias         map[string]string                 `yaml:"model_alias,omitempty"`
+	ClientModelIDs     []string                          `yaml:"client_model_ids,omitempty"`
+	PublicModelAlias   map[string]ClientModelAliasConfig `yaml:"public_model_alias,omitempty"`
+	AcceptedModelAlias map[string]ClientModelAliasConfig `yaml:"accepted_model_alias,omitempty"`
+	ProtectedTenants   []ProtectedTenantConfig           `yaml:"protected_tenants,omitempty"`
+	LiteLLMDB          LiteLLMDBConfig                   `yaml:"litellm_db,omitempty"`
+	Redis              RedisConfig                       `yaml:"redis,omitempty"`
+	OTEL               OTELConfig                        `yaml:"otel,omitempty"`
+	Kafka              KafkaConfig                       `yaml:"kafka,omitempty"`
 	// ModelTemplates stores x-model-templates entries as raw interface{} so that
 	// both single-model mappings and lists of models can be defined as YAML anchors
 	// without type errors. The actual model data is extracted via anchor expansion.
 	ModelTemplates map[string]interface{} `yaml:"x-model-templates,omitempty"`
+}
+
+// ProtectedTenantConfig enables fail-closed admission rules for selected
+// organizations without changing the legacy semantics of every other key.
+// Organization identity always comes from the verified LiteLLM hierarchy.
+type ProtectedTenantConfig struct {
+	Name            string   `yaml:"name"`
+	OrganizationIDs []string `yaml:"organization_ids"`
+	Hostnames       []string `yaml:"hostnames,omitempty"`
+	RequiredScopes  []string `yaml:"required_scopes,omitempty"`
+	RequireModelACL bool     `yaml:"require_model_acl,omitempty"`
+	RequireRouteACL bool     `yaml:"require_route_acl,omitempty"`
+}
+
+func (c *ProtectedTenantConfig) normalize() {
+	c.Name = strings.TrimSpace(resolveEnvString(c.Name))
+	c.OrganizationIDs = resolveEnvStringList(c.OrganizationIDs)
+	c.RequiredScopes = resolveEnvScopeList(c.RequiredScopes)
+	hostnames := make([]string, 0, len(c.Hostnames))
+	for _, hostname := range c.Hostnames {
+		hostname = normalizeProtectedTenantHostname(resolveEnvString(hostname))
+		if hostname != "" {
+			hostnames = append(hostnames, hostname)
+		}
+	}
+	c.Hostnames = scope.NormalizeList(hostnames)
+}
+
+func normalizeProtectedTenantHostname(hostport string) string {
+	hostport = strings.TrimSpace(hostport)
+	if host, _, err := net.SplitHostPort(hostport); err == nil {
+		hostport = host
+	}
+	hostport = strings.TrimPrefix(strings.TrimSuffix(hostport, "]"), "[")
+	return strings.ToLower(strings.TrimSuffix(hostport, "."))
+}
+
+func resolveEnvStringList(values []string) []string {
+	seen := make(map[string]struct{}, len(values))
+	resolved := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(resolveEnvString(value))
+		if value == "" {
+			continue
+		}
+		if _, duplicate := seen[value]; duplicate {
+			continue
+		}
+		seen[value] = struct{}{}
+		resolved = append(resolved, value)
+	}
+	return resolved
+}
+
+func (c ProtectedTenantConfig) validate() error {
+	if strings.TrimSpace(c.Name) == "" {
+		return errors.New("protected tenant name is required")
+	}
+	if len(c.OrganizationIDs) == 0 {
+		return fmt.Errorf("protected tenant %q requires at least one organization_id", c.Name)
+	}
+	for _, organizationID := range c.OrganizationIDs {
+		if strings.TrimSpace(organizationID) == "" {
+			return fmt.Errorf("protected tenant %q contains an empty organization_id", c.Name)
+		}
+	}
+	return nil
+}
+
+// ClientModelAliasConfig describes an additional client-facing name for a
+// canonical public model. It accepts a legacy scalar target or a scoped object.
+type ClientModelAliasConfig struct {
+	Target       string   `yaml:"target"`
+	Scopes       []string `yaml:"scopes,omitempty"`
+	DeniedScopes []string `yaml:"denied_scopes,omitempty"`
+}
+
+func (a ClientModelAliasConfig) ScopeExpression() *scope.Expression {
+	return scope.FromScopes(a.Scopes, a.DeniedScopes)
+}
+
+// UnmarshalYAML keeps the old `alias: target` syntax backward compatible and
+// adds `target`, `scopes`, and `denied_scopes`/`forbidden_scopes` object fields.
+func (a *ClientModelAliasConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil {
+		return fmt.Errorf("model alias must be a target string or object")
+	}
+	switch value.Kind {
+	case yaml.ScalarNode:
+		if value.Tag != "!!str" {
+			return fmt.Errorf("model alias target must be a string")
+		}
+		a.Target = resolveEnvString(value.Value)
+	case yaml.MappingNode:
+		type rawAlias struct {
+			Target          string   `yaml:"target"`
+			Scopes          []string `yaml:"scopes,omitempty"`
+			DeniedScopes    []string `yaml:"denied_scopes,omitempty"`
+			ForbiddenScopes []string `yaml:"forbidden_scopes,omitempty"`
+		}
+		var raw rawAlias
+		if err := value.Decode(&raw); err != nil {
+			return err
+		}
+		a.Target = resolveEnvString(raw.Target)
+		a.Scopes = resolveEnvScopeList(raw.Scopes)
+		a.DeniedScopes = resolveEnvScopeList(append(raw.DeniedScopes, raw.ForbiddenScopes...))
+	default:
+		return fmt.Errorf("model alias must be a target string or object")
+	}
+	if a.Target == "" {
+		return fmt.Errorf("model alias target must not be empty")
+	}
+	return nil
+}
+
+func resolveEnvScopeList(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	resolved := make([]string, 0, len(values))
+	for _, value := range values {
+		resolved = append(resolved, resolveEnvString(value))
+	}
+	return scope.NormalizeList(resolved)
 }
 
 // UnmarshalYAML implements custom unmarshaling for Config with YAML anchor/alias support.
@@ -190,20 +318,21 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 
 	// Then unmarshal the resolved data into Config
 	type RawConfig struct {
-		Server             ServerConfig           `yaml:"server"`
-		Fail2Ban           Fail2BanConfig         `yaml:"fail2ban,omitempty"`
-		Credentials        []CredentialConfig     `yaml:"credentials"`
-		Monitoring         MonitoringConfig       `yaml:"monitoring"`
-		Models             []ModelRPMConfig       `yaml:"models,omitempty"`
-		ModelAlias         map[string]string      `yaml:"model_alias,omitempty"`
-		ClientModelIDs     []string               `yaml:"client_model_ids,omitempty"`
-		PublicModelAlias   map[string]string      `yaml:"public_model_alias,omitempty"`
-		AcceptedModelAlias map[string]string      `yaml:"accepted_model_alias,omitempty"`
-		LiteLLMDB          LiteLLMDBConfig        `yaml:"litellm_db,omitempty"`
-		Redis              RedisConfig            `yaml:"redis,omitempty"`
-		OTEL               OTELConfig             `yaml:"otel,omitempty"`
-		Kafka              KafkaConfig            `yaml:"kafka,omitempty"`
-		ModelTemplates     map[string]interface{} `yaml:"x-model-templates,omitempty"`
+		Server             ServerConfig                      `yaml:"server"`
+		Fail2Ban           Fail2BanConfig                    `yaml:"fail2ban,omitempty"`
+		Credentials        []CredentialConfig                `yaml:"credentials"`
+		Monitoring         MonitoringConfig                  `yaml:"monitoring"`
+		Models             []ModelRPMConfig                  `yaml:"models,omitempty"`
+		ModelAlias         map[string]string                 `yaml:"model_alias,omitempty"`
+		ClientModelIDs     []string                          `yaml:"client_model_ids,omitempty"`
+		PublicModelAlias   map[string]ClientModelAliasConfig `yaml:"public_model_alias,omitempty"`
+		AcceptedModelAlias map[string]ClientModelAliasConfig `yaml:"accepted_model_alias,omitempty"`
+		ProtectedTenants   []ProtectedTenantConfig           `yaml:"protected_tenants,omitempty"`
+		LiteLLMDB          LiteLLMDBConfig                   `yaml:"litellm_db,omitempty"`
+		Redis              RedisConfig                       `yaml:"redis,omitempty"`
+		OTEL               OTELConfig                        `yaml:"otel,omitempty"`
+		Kafka              KafkaConfig                       `yaml:"kafka,omitempty"`
+		ModelTemplates     map[string]interface{}            `yaml:"x-model-templates,omitempty"`
 	}
 
 	var raw RawConfig
@@ -221,6 +350,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	c.ClientModelIDs = raw.ClientModelIDs
 	c.PublicModelAlias = raw.PublicModelAlias
 	c.AcceptedModelAlias = raw.AcceptedModelAlias
+	c.ProtectedTenants = raw.ProtectedTenants
 	c.LiteLLMDB = raw.LiteLLMDB
 	c.Redis = raw.Redis
 	c.OTEL = raw.OTEL
@@ -1390,18 +1520,27 @@ func Load(path string) (*Config, error) {
 		cfg.ClientModelIDs = resolved
 	}
 	if cfg.PublicModelAlias != nil {
-		resolved := make(map[string]string, len(cfg.PublicModelAlias))
-		for alias, target := range cfg.PublicModelAlias {
-			resolved[resolveEnvString(alias)] = resolveEnvString(target)
+		resolved := make(map[string]ClientModelAliasConfig, len(cfg.PublicModelAlias))
+		for alias, definition := range cfg.PublicModelAlias {
+			definition.Target = resolveEnvString(definition.Target)
+			definition.Scopes = resolveEnvScopeList(definition.Scopes)
+			definition.DeniedScopes = resolveEnvScopeList(definition.DeniedScopes)
+			resolved[resolveEnvString(alias)] = definition
 		}
 		cfg.PublicModelAlias = resolved
 	}
 	if cfg.AcceptedModelAlias != nil {
-		resolved := make(map[string]string, len(cfg.AcceptedModelAlias))
-		for alias, target := range cfg.AcceptedModelAlias {
-			resolved[resolveEnvString(alias)] = resolveEnvString(target)
+		resolved := make(map[string]ClientModelAliasConfig, len(cfg.AcceptedModelAlias))
+		for alias, definition := range cfg.AcceptedModelAlias {
+			definition.Target = resolveEnvString(definition.Target)
+			definition.Scopes = resolveEnvScopeList(definition.Scopes)
+			definition.DeniedScopes = resolveEnvScopeList(definition.DeniedScopes)
+			resolved[resolveEnvString(alias)] = definition
 		}
 		cfg.AcceptedModelAlias = resolved
+	}
+	for index := range cfg.ProtectedTenants {
+		cfg.ProtectedTenants[index].normalize()
 	}
 
 	if cfg.Credentials == nil {
@@ -1416,10 +1555,10 @@ func Load(path string) (*Config, error) {
 		cfg.ModelAlias = map[string]string{}
 	}
 	if cfg.PublicModelAlias == nil {
-		cfg.PublicModelAlias = map[string]string{}
+		cfg.PublicModelAlias = map[string]ClientModelAliasConfig{}
 	}
 	if cfg.AcceptedModelAlias == nil {
-		cfg.AcceptedModelAlias = map[string]string{}
+		cfg.AcceptedModelAlias = map[string]ClientModelAliasConfig{}
 	}
 
 	// Extract models from credentials and add to main Models list
@@ -1785,18 +1924,58 @@ func (c *Config) Validate() error {
 			}
 			clientIDs[modelID] = struct{}{}
 		}
-		for label, aliases := range map[string]map[string]string{
+		for label, aliases := range map[string]map[string]ClientModelAliasConfig{
 			"public_model_alias":   c.PublicModelAlias,
 			"accepted_model_alias": c.AcceptedModelAlias,
 		} {
-			for alias, target := range aliases {
-				if _, exists := clientIDs[target]; !exists {
-					return fmt.Errorf("%s %q targets %q outside client_model_ids", label, alias, target)
+			for alias, definition := range aliases {
+				if alias == "" {
+					return fmt.Errorf("%s must not contain an empty alias", label)
+				}
+				if definition.Target == "" {
+					return fmt.Errorf("%s %q has an empty target", label, alias)
+				}
+				if _, exists := clientIDs[definition.Target]; !exists {
+					return fmt.Errorf("%s %q targets %q outside client_model_ids", label, alias, definition.Target)
 				}
 				if _, collision := clientIDs[alias]; collision {
 					return fmt.Errorf("%s %q collides with client_model_ids", label, alias)
 				}
 			}
+		}
+	}
+
+	protectedNames := make(map[string]struct{}, len(c.ProtectedTenants))
+	protectedOrganizations := make(map[string]string)
+	protectedHostnames := make(map[string]string)
+	protectedScopes := make(map[string]string)
+	for index := range c.ProtectedTenants {
+		policy := &c.ProtectedTenants[index]
+		policy.normalize()
+		if err := policy.validate(); err != nil {
+			return err
+		}
+		if _, duplicate := protectedNames[policy.Name]; duplicate {
+			return fmt.Errorf("duplicate protected tenant name %q", policy.Name)
+		}
+		protectedNames[policy.Name] = struct{}{}
+		for _, organizationID := range policy.OrganizationIDs {
+			if owner, duplicate := protectedOrganizations[organizationID]; duplicate {
+				return fmt.Errorf("organization_id %q belongs to protected tenants %q and %q", organizationID, owner, policy.Name)
+			}
+			protectedOrganizations[organizationID] = policy.Name
+		}
+		for _, hostname := range policy.Hostnames {
+			if owner, duplicate := protectedHostnames[hostname]; duplicate {
+				return fmt.Errorf("hostname %q belongs to protected tenants %q and %q", hostname, owner, policy.Name)
+			}
+			protectedHostnames[hostname] = policy.Name
+		}
+		for _, requiredScope := range policy.RequiredScopes {
+			if owner, duplicate := protectedScopes[requiredScope]; duplicate {
+				return fmt.Errorf("required scope %q belongs to protected tenants %q and %q", requiredScope, owner, policy.Name)
+			}
+			protectedScopes[requiredScope] = policy.Name
 		}
 	}
 

--- a/internal/config/protected_tenant_test.go
+++ b/internal/config/protected_tenant_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestProtectedTenantConfigYAML(t *testing.T) {
+	var cfg Config
+	require.NoError(t, yaml.Unmarshal([]byte(`
+protected_tenants:
+  - name: cloud-ru
+    organization_ids: [org-cloud]
+    hostnames: [API.CLOUD.EXAMPLE.:443]
+    required_scopes: [cloud-ru]
+    require_model_acl: true
+    require_route_acl: true
+`), &cfg))
+	require.Len(t, cfg.ProtectedTenants, 1)
+	policy := cfg.ProtectedTenants[0]
+	policy.normalize()
+	assert.Equal(t, "cloud-ru", policy.Name)
+	assert.Equal(t, []string{"org-cloud"}, policy.OrganizationIDs)
+	assert.Equal(t, []string{"api.cloud.example"}, policy.Hostnames)
+	assert.Equal(t, []string{"cloud-ru"}, policy.RequiredScopes)
+	assert.True(t, policy.RequireModelACL)
+	assert.True(t, policy.RequireRouteACL)
+}
+
+func TestProtectedTenantConfigValidation(t *testing.T) {
+	t.Run("organization required", func(t *testing.T) {
+		policy := ProtectedTenantConfig{Name: "cloud-ru"}
+		assert.ErrorContains(t, policy.validate(), "organization_id")
+	})
+
+	t.Run("name required", func(t *testing.T) {
+		policy := ProtectedTenantConfig{OrganizationIDs: []string{"org-cloud"}}
+		assert.ErrorContains(t, policy.validate(), "name")
+	})
+}

--- a/internal/config/public_model_alias_test.go
+++ b/internal/config/public_model_alias_test.go
@@ -34,7 +34,60 @@ public_model_alias:
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{"openai/gpt-4.1": "gpt-4.1"}, cfg.ModelAlias)
 	assert.Equal(t, []string{"openai/gpt-4.1"}, cfg.ClientModelIDs)
-	assert.Equal(t, map[string]string{"gpt-4.1": "openai/gpt-4.1"}, cfg.PublicModelAlias)
+	assert.Equal(t, map[string]ClientModelAliasConfig{
+		"gpt-4.1": {Target: "openai/gpt-4.1"},
+	}, cfg.PublicModelAlias)
+}
+
+func TestLoadScopedClientModelAliases(t *testing.T) {
+	t.Setenv("ALIAS_SCOPE", "Cloud-RU")
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+server:
+  port: 8080
+  master_key: sk-test
+credentials:
+  - name: provider
+    type: openai
+    api_key: sk-provider
+    base_url: https://provider.invalid
+monitoring: {}
+client_model_ids: [public/chat]
+public_model_alias:
+  cloud-chat:
+    target: public/chat
+    scopes: [os.environ/ALIAS_SCOPE]
+    denied_scopes: [suspended]
+    forbidden_scopes: [legacy]
+accepted_model_alias:
+  old-chat: public/chat
+`), 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, ClientModelAliasConfig{
+		Target:       "public/chat",
+		Scopes:       []string{"cloud-ru"},
+		DeniedScopes: []string{"suspended", "legacy"},
+	}, cfg.PublicModelAlias["cloud-chat"])
+	assert.Equal(t, ClientModelAliasConfig{Target: "public/chat"}, cfg.AcceptedModelAlias["old-chat"])
+}
+
+func TestLoadClientModelAliasObjectFailsFastWithoutTarget(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(`
+server:
+  port: 8080
+  master_key: sk-test
+credentials: []
+monitoring: {}
+public_model_alias:
+  broken:
+    scopes: [cloud-ru]
+`), 0o600))
+
+	_, err := Load(path)
+	require.ErrorContains(t, err, "model alias target must not be empty")
 }
 
 func TestClientModelIDsFailClosedOnDuplicateAndOutOfSurfaceAlias(t *testing.T) {

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -179,14 +179,29 @@ func PrintConfig(logger *slog.Logger, cfg *Config) {
 	}
 	if len(cfg.PublicModelAlias) > 0 {
 		logger.Info("public_model_alias", "total_count", len(cfg.PublicModelAlias))
-		for alias, target := range cfg.PublicModelAlias {
-			logger.Info("  public alias", "from", alias, "to", target)
+		for alias, definition := range cfg.PublicModelAlias {
+			logger.Info("  public alias", "from", alias, "to", definition.Target,
+				"scopes", definition.Scopes, "denied_scopes", definition.DeniedScopes)
 		}
 	}
 	if len(cfg.AcceptedModelAlias) > 0 {
 		logger.Info("accepted_model_alias", "total_count", len(cfg.AcceptedModelAlias))
-		for alias, target := range cfg.AcceptedModelAlias {
-			logger.Info("  accepted alias", "from", alias, "to", target)
+		for alias, definition := range cfg.AcceptedModelAlias {
+			logger.Info("  accepted alias", "from", alias, "to", definition.Target,
+				"scopes", definition.Scopes, "denied_scopes", definition.DeniedScopes)
+		}
+	}
+	if len(cfg.ProtectedTenants) > 0 {
+		logger.Info("protected_tenants", "total_count", len(cfg.ProtectedTenants))
+		for _, policy := range cfg.ProtectedTenants {
+			logger.Info("  protected tenant",
+				"name", policy.Name,
+				"organization_ids", policy.OrganizationIDs,
+				"hostnames", policy.Hostnames,
+				"required_scopes", policy.RequiredScopes,
+				"require_model_acl", policy.RequireModelACL,
+				"require_route_acl", policy.RequireRouteACL,
+			)
 		}
 	}
 

--- a/internal/litellmdb/auth/auth.go
+++ b/internal/litellmdb/auth/auth.go
@@ -191,7 +191,7 @@ func (a *Authenticator) fetchTokenFromDB(ctx context.Context, hashedToken string
 	var tokenTPMLimit, tokenRPMLimit *int64
 	var expires *time.Time
 	var blocked *bool
-	var tokenModels []string
+	var tokenModels, tokenAllowedRoutes []string
 	var tokenMetadata []byte
 
 	// ============ User fields ============
@@ -240,6 +240,7 @@ func (a *Authenticator) fetchTokenFromDB(ctx context.Context, hashedToken string
 		&expires,
 		&blocked,
 		&tokenModels,
+		&tokenAllowedRoutes,
 		&tokenMetadata,
 
 		// User
@@ -311,13 +312,12 @@ func (a *Authenticator) fetchTokenFromDB(ctx context.Context, hashedToken string
 	if teamID != nil {
 		info.TeamID = *teamID
 	}
-	if orgID != nil {
-		info.OrganizationID = *orgID
-	}
+	info.OrganizationID = resolveOrganizationID(orgID, teamOrganizationID)
 	if blocked != nil {
 		info.Blocked = *blocked
 	}
 	info.Models = tokenModels
+	info.AllowedRoutes = tokenAllowedRoutes
 	info.Metadata = decodeMetadata(tokenMetadata)
 
 	info.MaxBudget = tokenMaxBudget
@@ -379,6 +379,20 @@ func (a *Authenticator) fetchTokenFromDB(ctx context.Context, hashedToken string
 	)
 
 	return &info, nil
+}
+
+// resolveOrganizationID mirrors the hierarchy JOIN: an organization assigned
+// directly to the key wins, otherwise an existing team's organization is the
+// effective tenant. A dangling team contributes no organization because its
+// LEFT JOIN fields are nil.
+func resolveOrganizationID(tokenOrganizationID, teamOrganizationID *string) string {
+	if tokenOrganizationID != nil {
+		return *tokenOrganizationID
+	}
+	if teamOrganizationID != nil {
+		return *teamOrganizationID
+	}
+	return ""
 }
 
 func decodeMetadata(raw []byte) map[string]interface{} {

--- a/internal/litellmdb/auth/auth_test.go
+++ b/internal/litellmdb/auth/auth_test.go
@@ -99,6 +99,40 @@ func TestMaskToken(t *testing.T) {
 	}
 }
 
+func TestResolveOrganizationID(t *testing.T) {
+	tokenOrg := "org-from-token"
+	teamOrg := "org-from-team"
+
+	tests := []struct {
+		name     string
+		tokenOrg *string
+		teamOrg  *string
+		want     string
+	}{
+		{
+			name:     "token organization takes precedence",
+			tokenOrg: &tokenOrg,
+			teamOrg:  &teamOrg,
+			want:     tokenOrg,
+		},
+		{
+			name:    "team organization is the fallback",
+			teamOrg: &teamOrg,
+			want:    teamOrg,
+		},
+		{
+			name: "missing joined team has no organization fallback",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, resolveOrganizationID(tt.tokenOrg, tt.teamOrg))
+		})
+	}
+}
+
 func TestTokenInfo_IsExpired(t *testing.T) {
 	t.Run("nil expires - not expired", func(t *testing.T) {
 		info := &models.TokenInfo{Expires: nil}

--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -298,6 +298,7 @@ func (t *TokenInfo) Clone() *TokenInfo {
 	}
 	clone := *t
 	clone.Models = append([]string(nil), t.Models...)
+	clone.AllowedRoutes = append([]string(nil), t.AllowedRoutes...)
 	clone.UserModels = append([]string(nil), t.UserModels...)
 	clone.TeamModels = append([]string(nil), t.TeamModels...)
 	clone.TeamMemberModels = append([]string(nil), t.TeamMemberModels...)

--- a/internal/litellmdb/models/models_test.go
+++ b/internal/litellmdb/models/models_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // ==================== DefaultConfig Tests ====================
@@ -455,6 +456,17 @@ func TestTokenInfo_checkOrganizationMemberBudget_Exceeded(t *testing.T) {
 	}
 
 	assert.True(t, token.checkOrganizationMemberBudget())
+}
+
+func TestTokenInfoCloneCopiesAllowedRoutes(t *testing.T) {
+	original := &TokenInfo{AllowedRoutes: []string{"/v1/chat/completions", "/v1/models"}}
+
+	cloned := original.Clone()
+	require.NotNil(t, cloned)
+	require.Equal(t, original.AllowedRoutes, cloned.AllowedRoutes)
+
+	cloned.AllowedRoutes[0] = "/v1/embeddings"
+	assert.Equal(t, "/v1/chat/completions", original.AllowedRoutes[0])
 }
 
 // ==================== Validate Tests ====================

--- a/internal/litellmdb/queries/queries_test.go
+++ b/internal/litellmdb/queries/queries_test.go
@@ -337,7 +337,7 @@ func TestQueryContainsRequiredFields(t *testing.T) {
 // with "number of field descriptions must equal number of destinations" when
 // the SELECT list and the Scan call drift apart, so any column added here has
 // to land in both places at once.
-const tokenHierarchyScanColumns = 45
+const tokenHierarchyScanColumns = 46
 
 func TestTokenValidationQueryColumnCountMatchesScan(t *testing.T) {
 	selectList := QueryValidateTokenWithHierarchy
@@ -361,5 +361,6 @@ func TestTokenValidationQueryColumnCountMatchesScan(t *testing.T) {
 func TestTokenValidationQueryLoadsModelAccessHierarchy(t *testing.T) {
 	assert.Contains(t, QueryValidateTokenWithHierarchy, `LEFT JOIN "LiteLLM_UserTable" u ON t.user_id = u.user_id`)
 	assert.Contains(t, QueryValidateTokenWithHierarchy, "t.models as token_models")
+	assert.Contains(t, QueryValidateTokenWithHierarchy, "t.allowed_routes as token_allowed_routes")
 	assert.Contains(t, QueryValidateTokenWithHierarchy, "t.metadata as token_metadata")
 }

--- a/internal/litellmdb/queries/verification_token.go
+++ b/internal/litellmdb/queries/verification_token.go
@@ -20,6 +20,7 @@ SELECT
   t.expires,
   t.blocked as token_blocked,
   t.models as token_models,
+  t.allowed_routes as token_allowed_routes,
   t.metadata as token_metadata,
 
   -- ============ User ============

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -282,6 +282,11 @@ const (
 	scopedAllModelsCacheSize = 256
 )
 
+type clientModelAlias struct {
+	target     string
+	expression *scope.Expression
+}
+
 // Manager handles model discovery and mapping
 type Manager struct {
 	mu                           sync.RWMutex
@@ -299,8 +304,8 @@ type Manager struct {
 	modelAliases                 map[string]string            // alias -> real model name (from model_alias config)
 	clientModelIDs               map[string]struct{}          // exact advertised canonical client IDs
 	clientModelSurfaceConfigured bool                         // distinguishes an omitted boundary from an explicit empty boundary
-	publicModelAliases           map[string]string            // client alias -> canonical LiteLLM public deployment identity
-	acceptedModelAliases         map[string]string            // accepted client alias -> canonical model, hidden from discovery
+	publicModelAliases           map[string]clientModelAlias  // visible client alias -> canonical public identity + tenant scope
+	acceptedModelAliases         map[string]clientModelAlias  // accepted client alias -> canonical model + tenant scope, hidden from discovery
 	modelRealNames               map[string]string            // alias name -> real model name (global, no specific credential)
 	modelRealNamesPerCred        map[string]map[string]string // credential -> alias -> real model name (for credential-specific entries)
 	credentialMappingsReady      bool                         // true after static/DB credential mappings have been initialized
@@ -327,8 +332,8 @@ func New(logger *slog.Logger, defaultModelsRPM int, staticModels []config.ModelR
 		dbModelNames:                make(map[string]bool),
 		modelAliases:                make(map[string]string),
 		clientModelIDs:              make(map[string]struct{}),
-		publicModelAliases:          make(map[string]string),
-		acceptedModelAliases:        make(map[string]string),
+		publicModelAliases:          make(map[string]clientModelAlias),
+		acceptedModelAliases:        make(map[string]clientModelAlias),
 		modelRealNames:              make(map[string]string),
 		modelRealNamesPerCred:       make(map[string]map[string]string),
 		modelPassthroughResponses:   make(map[string]*bool),
@@ -667,15 +672,29 @@ func (m *Manager) SetClientModelIDs(modelIDs []string) {
 // create cycles for common short backend names (for example
 // gpt-4.1 -> openai/gpt-4.1 -> gpt-4.1).
 func (m *Manager) SetPublicModelAliases(aliases map[string]string) {
+	definitions := make(map[string]config.ClientModelAliasConfig, len(aliases))
+	for alias, target := range aliases {
+		definitions[alias] = config.ClientModelAliasConfig{Target: target}
+	}
+	m.SetScopedPublicModelAliases(definitions)
+}
+
+// SetScopedPublicModelAliases installs public aliases with optional tenant
+// scope restrictions. SetPublicModelAliases is the legacy unrestricted wrapper.
+func (m *Manager) SetScopedPublicModelAliases(aliases map[string]config.ClientModelAliasConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.publicModelAliases = make(map[string]string, len(aliases))
-	for alias, target := range aliases {
+	m.publicModelAliases = make(map[string]clientModelAlias, len(aliases))
+	for alias, definition := range aliases {
+		target := definition.Target
 		if alias == "" || target == "" || alias == target {
 			m.logger.Warn("Invalid public model alias, skipping", "alias", alias, "target", target)
 			continue
 		}
-		m.publicModelAliases[alias] = target
+		m.publicModelAliases[alias] = clientModelAlias{
+			target:     target,
+			expression: scope.NormalizeExpression(definition.ScopeExpression()),
+		}
 		m.logger.Info("Registered public model alias", "alias", alias, "target", target)
 	}
 	m.allModels = nil
@@ -683,15 +702,29 @@ func (m *Manager) SetPublicModelAliases(aliases map[string]string) {
 }
 
 func (m *Manager) SetAcceptedModelAliases(aliases map[string]string) {
+	definitions := make(map[string]config.ClientModelAliasConfig, len(aliases))
+	for alias, target := range aliases {
+		definitions[alias] = config.ClientModelAliasConfig{Target: target}
+	}
+	m.SetScopedAcceptedModelAliases(definitions)
+}
+
+// SetScopedAcceptedModelAliases installs hidden compatibility aliases with
+// optional tenant scope restrictions. The legacy setter is unrestricted.
+func (m *Manager) SetScopedAcceptedModelAliases(aliases map[string]config.ClientModelAliasConfig) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.acceptedModelAliases = make(map[string]string, len(aliases))
-	for alias, target := range aliases {
+	m.acceptedModelAliases = make(map[string]clientModelAlias, len(aliases))
+	for alias, definition := range aliases {
+		target := definition.Target
 		if alias == "" || target == "" || alias == target {
 			m.logger.Warn("Invalid accepted model alias, skipping", "alias", alias, "target", target)
 			continue
 		}
-		m.acceptedModelAliases[alias] = target
+		m.acceptedModelAliases[alias] = clientModelAlias{
+			target:     target,
+			expression: scope.NormalizeExpression(definition.ScopeExpression()),
+		}
 		m.logger.Info("Registered accepted model alias", "alias", alias, "target", target)
 	}
 	m.allModels = nil
@@ -699,25 +732,38 @@ func (m *Manager) SetAcceptedModelAliases(aliases map[string]string) {
 }
 
 func (m *Manager) clientAliasTargetLocked(modelID string) (string, bool, bool) {
-	publicTarget, publicConfigured := m.publicModelAliases[modelID]
-	acceptedTarget, acceptedConfigured := m.acceptedModelAliases[modelID]
-	if publicConfigured && acceptedConfigured && publicTarget != acceptedTarget {
+	return m.clientAliasTargetScopedLocked(modelID, scope.AdminContext())
+}
+
+func (m *Manager) clientAliasTargetScopedLocked(modelID string, visibility scope.Context) (string, bool, bool) {
+	publicAlias, publicConfigured := m.publicModelAliases[modelID]
+	acceptedAlias, acceptedConfigured := m.acceptedModelAliases[modelID]
+	if publicConfigured && acceptedConfigured && publicAlias.target != acceptedAlias.target {
 		return modelID, true, false
 	}
+	if publicConfigured && acceptedConfigured {
+		allowed := visibility.AllowsExpression(publicAlias.expression) ||
+			visibility.AllowsExpression(acceptedAlias.expression)
+		return publicAlias.target, true, allowed
+	}
 	if publicConfigured {
-		return publicTarget, true, true
+		return publicAlias.target, true, visibility.AllowsExpression(publicAlias.expression)
 	}
 	if acceptedConfigured {
-		return acceptedTarget, true, true
+		return acceptedAlias.target, true, visibility.AllowsExpression(acceptedAlias.expression)
 	}
 	return modelID, false, true
 }
 
 func (m *Manager) IsClientModelIDRoutable(modelID string) bool {
+	return m.IsClientModelIDRoutableScoped(modelID, scope.AdminContext())
+}
+
+func (m *Manager) IsClientModelIDRoutableScoped(modelID string, visibility scope.Context) bool {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	if target, aliased, unambiguous := m.clientAliasTargetLocked(modelID); aliased {
-		if !unambiguous || !m.publicModelAliasTargetActiveLocked(target) {
+	if target, aliased, allowed := m.clientAliasTargetScopedLocked(modelID, visibility); aliased {
+		if !allowed || !m.clientModelTargetVisibleLocked(target, visibility) {
 			return false
 		}
 		if m.clientModelSurfaceConfigured {
@@ -731,21 +777,44 @@ func (m *Manager) IsClientModelIDRoutable(modelID string) bool {
 			return false
 		}
 	}
-	_, routable := m.clientCanonicalRouteTargetLocked(modelID)
-	return routable
+	return m.clientModelTargetVisibleLocked(modelID, visibility)
 }
 
 func (m *Manager) ResolvePublicModelAlias(modelID string) (string, bool, error) {
+	return m.ResolvePublicModelAliasScoped(modelID, scope.AdminContext())
+}
+
+// ResolvePublicModelAliasScoped resolves a client alias only when both its
+// canonical target and its own tenant-scope expression are available.
+func (m *Manager) ResolvePublicModelAliasScoped(modelID string, visibility scope.Context) (string, bool, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	target, aliased, unambiguous := m.clientAliasTargetLocked(modelID)
+	target, aliased, allowed := m.clientAliasTargetScopedLocked(modelID, visibility)
 	if !aliased {
 		return modelID, false, nil
 	}
-	if !unambiguous || !m.publicModelAliasTargetActiveLocked(target) {
+	if !allowed || !m.clientModelTargetVisibleLocked(target, visibility) {
 		return modelID, false, fmt.Errorf("public model alias %q is not routable", modelID)
 	}
 	return target, true, nil
+}
+
+func (m *Manager) clientModelTargetVisibleLocked(modelID string, visibility scope.Context) bool {
+	routeTarget, active := m.clientCanonicalRouteTargetLocked(modelID)
+	if !active {
+		return false
+	}
+	visibleCredentials := m.visibleCredentialNamesLocked(visibility)
+	hasCredentialInventory := m.credentialsConfigured
+	for _, credentialName := range m.modelToCredentials[routeTarget] {
+		if hasCredentialInventory && !visibleCredentials[credentialName] {
+			continue
+		}
+		if m.modelScopeAllowsLocked(routeTarget, credentialName, visibility) {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Manager) clientCanonicalRouteTargetLocked(modelID string) (string, bool) {
@@ -1439,7 +1508,7 @@ func (m *Manager) GetClientModels() ModelsResponse {
 	response := m.GetAllModels()
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	response.Data = m.projectClientModelCatalogLocked(response.Data)
+	response.Data = m.projectClientModelCatalogLocked(response.Data, scope.AdminContext())
 	return response
 }
 
@@ -1462,7 +1531,7 @@ func (m *Manager) GetAllModelsScoped(visibility scope.Context) ModelsResponse {
 	}
 	scopedResponse := ModelsResponse{
 		Object: response.Object,
-		Data:   m.projectClientModelCatalogLocked(filtered),
+		Data:   m.projectClientModelCatalogLocked(filtered, visibility),
 	}
 	m.scopedAllModelsCache.Add(m.scopedAllModelsCacheKeyLocked(visibility), allModelsCache{
 		response:  copyModelsResponse(scopedResponse),
@@ -1577,11 +1646,12 @@ func (m *Manager) currentModelsLocked(response ModelsResponse, visibleCredential
 // projectClientModelCatalogLocked is the single public boundary used by both
 // unscoped and key-scoped discovery. Its input must already contain only
 // internal models visible through the selected credentials/scopes.
-func (m *Manager) projectClientModelCatalogLocked(internalModels []Model) []Model {
+func (m *Manager) projectClientModelCatalogLocked(internalModels []Model, visibility scope.Context) []Model {
 	activePublicAliases := make(map[string]string, len(m.publicModelAliases))
-	for alias, target := range m.publicModelAliases {
-		if m.publicModelAliasTargetActiveLocked(target) {
-			activePublicAliases[alias] = target
+	for alias, definition := range m.publicModelAliases {
+		if visibility.AllowsExpression(definition.expression) &&
+			m.publicModelAliasTargetActiveLocked(definition.target) {
+			activePublicAliases[alias] = definition.target
 		}
 	}
 	var models []Model
@@ -1599,7 +1669,7 @@ func (m *Manager) projectClientModelCatalogLocked(internalModels []Model) []Mode
 	return hideAcceptedModelAliases(models, m.acceptedModelAliases)
 }
 
-func hideAcceptedModelAliases(models []Model, aliases map[string]string) []Model {
+func hideAcceptedModelAliases(models []Model, aliases map[string]clientModelAlias) []Model {
 	if len(aliases) == 0 {
 		return models
 	}
@@ -2490,9 +2560,10 @@ func (m *Manager) GetAllModelsWithAccessGroupsScoped(visibility scope.Context) M
 	}
 	activeAliases := activePublicModelAliases(availableTargets, m.modelAliases)
 	activeDeploymentAliases := make(map[string]string, len(m.publicModelAliases))
-	for alias, target := range m.publicModelAliases {
-		if m.publicModelAliasTargetActiveLocked(target) {
-			activeDeploymentAliases[alias] = target
+	for alias, definition := range m.publicModelAliases {
+		if visibility.AllowsExpression(definition.expression) &&
+			m.publicModelAliasTargetActiveLocked(definition.target) {
+			activeDeploymentAliases[alias] = definition.target
 		}
 	}
 

--- a/internal/models/manager_test.go
+++ b/internal/models/manager_test.go
@@ -146,6 +146,93 @@ func TestAcceptedModelAliasRoutesWithoutDiscovery(t *testing.T) {
 	assert.Equal(t, []string{"openai/gpt-4.1"}, responseModelIDs(manager.GetClientModels()))
 }
 
+func TestScopedPublicModelAliasDoesNotHideCanonicalAvailability(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	credential := config.CredentialConfig{Name: "provider", Type: config.ProviderTypeOpenAI}
+	manager := New(logger, 100, []config.ModelRPMConfig{{Name: "backend", Credential: credential.Name}})
+	manager.SetModelAliases(map[string]string{"public/chat": "backend"})
+	manager.SetClientModelIDs([]string{"public/chat"})
+	manager.SetScopedPublicModelAliases(map[string]config.ClientModelAliasConfig{
+		"cloud-chat": {Target: "public/chat", Scopes: []string{"cloud-ru"}},
+	})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+
+	public := scope.PublicContext()
+	cloud := scope.NewContext([]string{"cloud-ru"}, nil)
+	assert.Equal(t, []string{"public/chat"}, responseModelIDs(manager.GetAllModelsScoped(public)))
+	assert.Equal(t, []string{"cloud-chat", "public/chat"}, responseModelIDs(manager.GetAllModelsScoped(cloud)))
+	assert.True(t, manager.IsClientModelIDRoutableScoped("public/chat", public))
+	assert.False(t, manager.IsClientModelIDRoutableScoped("cloud-chat", public))
+	assert.True(t, manager.IsClientModelIDRoutableScoped("cloud-chat", cloud))
+
+	canonical, aliased, err := manager.ResolvePublicModelAliasScoped("cloud-chat", public)
+	assert.Error(t, err)
+	assert.False(t, aliased)
+	assert.Equal(t, "cloud-chat", canonical)
+	canonical, aliased, err = manager.ResolvePublicModelAliasScoped("cloud-chat", cloud)
+	require.NoError(t, err)
+	assert.True(t, aliased)
+	assert.Equal(t, "public/chat", canonical)
+}
+
+func TestScopedPublicModelAliasRequiresVisibleTargetCredential(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	credential := config.CredentialConfig{
+		Name: "provider", Type: config.ProviderTypeOpenAI, Scopes: []string{"provider-private"},
+	}
+	manager := New(logger, 100, []config.ModelRPMConfig{{Name: "backend", Credential: credential.Name}})
+	manager.SetModelAliases(map[string]string{"public/chat": "backend"})
+	manager.SetClientModelIDs([]string{"public/chat"})
+	manager.SetScopedPublicModelAliases(map[string]config.ClientModelAliasConfig{
+		"cloud-chat": {Target: "public/chat", Scopes: []string{"cloud-ru"}},
+	})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+
+	aliasOnly := scope.NewContext([]string{"cloud-ru"}, nil)
+	assert.False(t, manager.IsClientModelIDRoutableScoped("public/chat", aliasOnly),
+		"canonical IDs must not bypass credential visibility")
+	assert.False(t, manager.IsClientModelIDRoutableScoped("cloud-chat", aliasOnly))
+	_, _, err := manager.ResolvePublicModelAliasScoped("cloud-chat", aliasOnly)
+	assert.Error(t, err)
+	assert.Empty(t, responseModelIDs(manager.GetAllModelsScoped(aliasOnly)))
+
+	fullyVisible := scope.NewContext([]string{"cloud-ru", "provider-private"}, nil)
+	assert.True(t, manager.IsClientModelIDRoutableScoped("public/chat", fullyVisible))
+	assert.True(t, manager.IsClientModelIDRoutableScoped("cloud-chat", fullyVisible))
+	_, aliased, err := manager.ResolvePublicModelAliasScoped("cloud-chat", fullyVisible)
+	require.NoError(t, err)
+	assert.True(t, aliased)
+
+	manager.SetCredentials([]config.CredentialConfig{})
+	assert.False(t, manager.IsClientModelIDRoutableScoped("cloud-chat", fullyVisible),
+		"an authoritative empty credential inventory must not reuse stale routes")
+	assert.Empty(t, responseModelIDs(manager.GetAllModelsScoped(fullyVisible)))
+}
+
+func TestScopedAcceptedModelAliasIsHiddenAndFailsClosedOutsideScope(t *testing.T) {
+	logger := slog.New(slog.DiscardHandler)
+	credential := config.CredentialConfig{Name: "provider", Type: config.ProviderTypeOpenAI}
+	manager := New(logger, 100, []config.ModelRPMConfig{{Name: "backend", Credential: credential.Name}})
+	manager.SetModelAliases(map[string]string{"public/chat": "backend"})
+	manager.SetClientModelIDs([]string{"public/chat"})
+	manager.SetScopedAcceptedModelAliases(map[string]config.ClientModelAliasConfig{
+		"legacy-chat": {Target: "public/chat", Scopes: []string{"cloud-ru"}},
+	})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+
+	cloud := scope.NewContext([]string{"cloud-ru"}, nil)
+	other := scope.NewContext([]string{"other"}, nil)
+	assert.Equal(t, []string{"public/chat"}, responseModelIDs(manager.GetAllModelsScoped(cloud)))
+	assert.Equal(t, []string{"public/chat"}, responseModelIDs(manager.GetAllModelsScoped(other)))
+	assert.True(t, manager.IsClientModelIDRoutableScoped("legacy-chat", cloud))
+	assert.False(t, manager.IsClientModelIDRoutableScoped("legacy-chat", other))
+	_, _, err := manager.ResolvePublicModelAliasScoped("legacy-chat", other)
+	assert.Error(t, err)
+}
+
 func TestGetAllModelsWithAccessGroupsScoped_FiltersAliasesByScope(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	manager := New(logger, 100, []config.ModelRPMConfig{

--- a/internal/proxy/client_auth_test.go
+++ b/internal/proxy/client_auth_test.go
@@ -50,15 +50,81 @@ func (m *clientAuthTestDB) ValidateToken(_ context.Context, rawToken string) (*d
 	if info == nil {
 		return nil, litellmdb.ErrTokenNotFound
 	}
-	clone := *info
-	clone.Models = append([]string(nil), info.Models...)
-	clone.UserModels = append([]string(nil), info.UserModels...)
-	clone.TeamModels = append([]string(nil), info.TeamModels...)
-	clone.TeamMemberModels = append([]string(nil), info.TeamMemberModels...)
+	clone := info.Clone()
 	if err := clone.Validate(""); err != nil {
 		return nil, err
 	}
-	return &clone, nil
+	return clone, nil
+}
+
+func TestProtectedTenantAdmissionAndScopedAliasBeforeProvider(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstreamCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-cloud","object":"chat.completion","created":1,"model":"backend-chat","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	db := &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"cloud-key": {
+			Token:          "cloud-hash",
+			OrganizationID: "org-cloud",
+			Models:         []string{"cloud/legacy-chat"},
+			AllowedRoutes:  []string{"POST /v1/chat/completions"},
+			Metadata:       map[string]interface{}{"air_scopes": []string{"cloud-ru"}},
+		},
+		"other-key": {Token: "other-hash", OrganizationID: "org-other"},
+	}}
+	prx := newClientAuthTestProxy(t, db, upstream.URL, config.ProviderTypeOpenAI, "provider-key")
+	prx.protectedTenants = []config.ProtectedTenantConfig{{
+		Name:            "cloud-ru",
+		OrganizationIDs: []string{"org-cloud"},
+		Hostnames:       []string{"api.cloud.example"},
+		RequiredScopes:  []string{"cloud-ru"},
+		RequireModelACL: true,
+		RequireRouteACL: true,
+	}}
+	prx.modelManager.SetClientModelIDs([]string{"public/chat"})
+	prx.modelManager.SetScopedPublicModelAliases(map[string]config.ClientModelAliasConfig{
+		"cloud/legacy-chat": {Target: "public/chat", Scopes: []string{"cloud-ru"}},
+	})
+
+	request := func(key, host, path, body string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "http://"+host+path, strings.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+key)
+		req.Header.Set("Content-Type", "application/json")
+		writer := httptest.NewRecorder()
+		prx.ProxyRequest(writer, req)
+		return writer
+	}
+
+	allowed := request("cloud-key", "api.cloud.example", "/v1/chat/completions", `{"model":"cloud/legacy-chat","messages":[{"role":"user","content":"hello"}]}`)
+	require.Equal(t, http.StatusOK, allowed.Code)
+	assert.Equal(t, int32(1), upstreamCalls.Load())
+
+	hiddenAlias := request("other-key", "router.example", "/v1/chat/completions", `{"model":"cloud/legacy-chat","messages":[{"role":"user","content":"hello"}]}`)
+	assert.Equal(t, http.StatusNotFound, hiddenAlias.Code)
+	assert.Equal(t, int32(1), upstreamCalls.Load())
+
+	foreignHost := request("other-key", "api.cloud.example", "/v1/chat/completions", `{"model":"public/chat","messages":[{"role":"user","content":"hello"}]}`)
+	assert.Equal(t, http.StatusForbidden, foreignHost.Code)
+	assert.Equal(t, int32(1), upstreamCalls.Load())
+
+	spoofedReq := httptest.NewRequest(http.MethodPost, "http://api.cloud.example/v1/chat/completions", strings.NewReader(
+		`{"model":"public/chat","messages":[{"role":"user","content":"hello"}]}`,
+	))
+	spoofedReq.Header.Set("Authorization", "Bearer other-key")
+	spoofedReq.Header.Set("Content-Type", "application/json")
+	spoofedReq.Header.Set("x-vsellm-request-auth-org-id", "org-cloud")
+	spoofedWriter := httptest.NewRecorder()
+	prx.ProxyRequest(spoofedWriter, spoofedReq)
+	assert.Equal(t, http.StatusForbidden, spoofedWriter.Code)
+	assert.Equal(t, int32(1), upstreamCalls.Load())
+
+	deniedRoute := request("cloud-key", "router.example", "/v1/embeddings", `{"model":"cloud/legacy-chat","input":"hello"}`)
+	assert.Equal(t, http.StatusForbidden, deniedRoute.Code)
+	assert.Equal(t, int32(1), upstreamCalls.Load())
 }
 
 func (m *clientAuthTestDB) seenTokens() []string {

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -68,7 +68,10 @@ func isHopByHopHeader(key string) bool {
 }
 
 func isInternalAIRRequestHeader(key string) bool {
-	return strings.EqualFold(key, HeaderAIRProxyClient) ||
+	lowerKey := strings.ToLower(key)
+	return strings.HasPrefix(lowerKey, "x-vsellm-") ||
+		strings.HasPrefix(lowerKey, "x-auth-request-") ||
+		strings.EqualFold(key, HeaderAIRProxyClient) ||
 		strings.EqualFold(key, HeaderLegacyAIRProxyClient) ||
 		strings.EqualFold(key, HeaderAIRUsageAudioTokens)
 }
@@ -111,7 +114,9 @@ func copyRequestHeaders(dst *http.Request, src *http.Request, apiKey string) {
 		if key == "Accept-Encoding" {
 			continue
 		}
-		// Strip internal AIR markers — they must not be forwarded to the actual provider.
+		// Strip router-internal metadata, including Cloud.ru identity, routing,
+		// pricing, and provider credentials. AIR may consume these headers before
+		// this boundary, but they must never reach the selected provider.
 		if isInternalAIRRequestHeader(key) {
 			continue
 		}
@@ -141,7 +146,9 @@ func copyHeadersSkipAuth(dst *http.Request, src *http.Request) {
 		if key == "Accept-Encoding" {
 			continue
 		}
-		// Strip internal AIR markers — they must not be forwarded to the actual provider.
+		// Strip router-internal metadata, including Cloud.ru identity, routing,
+		// pricing, and provider credentials. AIR may consume these headers before
+		// this boundary, but they must never reach the selected provider.
 		if isInternalAIRRequestHeader(key) {
 			continue
 		}

--- a/internal/proxy/headers_test.go
+++ b/internal/proxy/headers_test.go
@@ -155,10 +155,66 @@ func TestCopyRequestHeadersStripsInternalUsageContractHeader(t *testing.T) {
 	assert.Equal(t, "ok", dst.Header.Get("X-Regular"))
 }
 
+func TestRequestHeaderCopyStripsCloudInternalNamespaces(t *testing.T) {
+	internalHeaders := http.Header{
+		"X-Vsellm-Provider-000-Api-Keys":    {"provider-key-id=provider-secret"},
+		"x-VsElLm-Model-Pricing-Json":       {`{"currency":"RUB"}`},
+		"X-Vsellm-Request-Auth-Org-Id":      {"organization-id"},
+		"x-vsellm-provider-000-route-id":    {"model:provider:key:"},
+		"X-AuTh-ReQuEsT-UsEr":               {"internal-user"},
+		"X-Auth-Request-Preferred-Username": {"internal-username"},
+		"X-Regular":                         {"preserved"},
+	}
+
+	tests := []struct {
+		name string
+		copy func(dst, src *http.Request)
+	}{
+		{
+			name: "provider request",
+			copy: func(dst, src *http.Request) {
+				copyRequestHeaders(dst, src, "configured-provider-key")
+			},
+		},
+		{
+			name: "passthrough request",
+			copy: func(dst, src *http.Request) {
+				copyHeadersSkipAuth(dst, src)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := httptestRequestWithHTTPHeaders(internalHeaders)
+			dst, err := http.NewRequest(http.MethodPost, "http://upstream.example/v1/chat/completions", nil)
+			assert.NoError(t, err)
+
+			tt.copy(dst, src)
+
+			for key := range internalHeaders {
+				if key == "X-Regular" {
+					continue
+				}
+				assert.Empty(t, dst.Header.Values(key), "internal header %s must not reach provider", key)
+			}
+			assert.Equal(t, "preserved", dst.Header.Get("X-Regular"))
+		})
+	}
+}
+
 func httptestRequestWithHeaders(headers map[string]string) *http.Request {
 	req, _ := http.NewRequest(http.MethodPost, "http://router.example/v1/chat/completions", nil)
 	for key, value := range headers {
 		req.Header.Set(key, value)
+	}
+	return req
+}
+
+func httptestRequestWithHTTPHeaders(headers http.Header) *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, "http://router.example/v1/chat/completions", nil)
+	for key, values := range headers {
+		req.Header[key] = append([]string(nil), values...)
 	}
 	return req
 }

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -432,6 +432,23 @@ func (p *Proxy) AuthenticateClientRequest(w http.ResponseWriter, r *http.Request
 	return tokenInfo, ok
 }
 
+// AuthorizeAndTrustClientRequest performs the public authentication/admission
+// phase once and returns an in-process trusted request for the same operation.
+// Router middleware uses it before optional body capture so a denied protected
+// tenant cannot force an unbounded pre-auth body read.
+func (p *Proxy) AuthorizeAndTrustClientRequest(w http.ResponseWriter, r *http.Request) (*http.Request, bool) {
+	tokenInfo, _, ok := p.AuthenticateClientRequestScoped(w, r)
+	if !ok {
+		return r, false
+	}
+	rawToken, state := extractClientToken(r)
+	if state != clientCredentialPresent || rawToken == "" {
+		WriteErrorUnauthorized(w, "Invalid Authorization header format")
+		return r, false
+	}
+	return withTrustedClientAuth(r, rawToken, tokenInfo), true
+}
+
 // AuthenticateClientRequestScoped authenticates once and returns the exact
 // scope derived from that same credential. This keeps /v1/models visibility
 // identical for Authorization and x-api-key transports and avoids a second DB
@@ -449,7 +466,19 @@ func (p *Proxy) AuthenticateClientRequestScoped(w http.ResponseWriter, r *http.R
 }
 
 func (p *Proxy) IsModelAllowedForToken(tokenInfo *models.TokenInfo, model string) bool {
-	if tokenInfo == nil || !p.strictAllTeamModelsACL {
+	return p.isModelAllowed(tokenInfo, model, p.strictAllTeamModelsACL)
+}
+
+func (p *Proxy) IsModelAllowedForRequest(r *http.Request, tokenInfo *models.TokenInfo, model string) bool {
+	strict := p.strictAllTeamModelsACL
+	if tokenInfo != nil && p.protectedTenantForOrganization(tokenInfo.OrganizationID) != nil {
+		strict = true
+	}
+	return p.isModelAllowed(tokenInfo, model, strict)
+}
+
+func (p *Proxy) isModelAllowed(tokenInfo *models.TokenInfo, model string, strict bool) bool {
+	if tokenInfo == nil || !strict {
 		return true
 	}
 	var matcher models.ModelScopeMatcher
@@ -531,6 +560,9 @@ func (p *Proxy) authenticateRequest(
 		"team_id", tokenInfo.TeamID,
 	)
 	logCtx.Scope = scopeContextFromTokenInfo(tokenInfo)
+	if !p.enforceProtectedTenantAdmission(w, r, logCtx) {
+		return false
+	}
 	return true
 }
 
@@ -620,7 +652,7 @@ func (p *Proxy) readRequestBodyAndSelectModel(
 	// LiteLLM -> AIR hop authenticated with AIR's master key, but ordinary keys
 	// cannot discover or invoke them even when their DB model ACL is empty.
 	trustedInternalModelID := p.isMasterKey(logCtx.Token)
-	modelAllowed := p.IsModelAllowedForToken(logCtx.TokenInfo, modelID)
+	modelAllowed := p.IsModelAllowedForRequest(r, logCtx.TokenInfo, modelID)
 	if !modelAllowed {
 		p.logger.WarnContext(r.Context(), "Model is not allowed for token",
 			"error_code", http.StatusForbidden,
@@ -632,7 +664,7 @@ func (p *Proxy) readRequestBodyAndSelectModel(
 		WriteErrorForbidden(w, "Model not allowed")
 		return nil, "", "", false, false
 	}
-	if p.modelManager != nil && !trustedInternalModelID && !p.modelManager.IsClientModelIDRoutable(modelID) {
+	if p.modelManager != nil && !trustedInternalModelID && !p.modelManager.IsClientModelIDRoutableScoped(modelID, logCtx.Scope) {
 		p.logger.WarnContext(r.Context(), "Client model identifier is not exposed",
 			"error_code", http.StatusNotFound,
 			"model", modelID,
@@ -657,7 +689,7 @@ func (p *Proxy) readRequestBodyAndSelectModel(
 	trustedExactModelID := trustedInternalModelID && len(p.modelManager.GetCredentialsForModel(modelID)) > 0
 	if trustedExactModelID {
 		p.logger.DebugContext(r.Context(), "Preserved trusted internal model identifier", "model", modelID)
-	} else if canonical, isPublicAlias, aliasErr := p.modelManager.ResolvePublicModelAlias(modelID); aliasErr != nil {
+	} else if canonical, isPublicAlias, aliasErr := p.modelManager.ResolvePublicModelAliasScoped(modelID, logCtx.Scope); aliasErr != nil {
 		p.logger.WarnContext(r.Context(), "Public model alias is not uniquely routable",
 			"error_code", http.StatusNotFound,
 			"model", modelID,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -361,6 +361,7 @@ type Config struct {
 	StrictAllTeamModelsACL     bool
 	ResponseHeaderMode         config.ResponseHeaderMode
 	CredentialNameAsTeamID     bool
+	ProtectedTenants           []config.ProtectedTenantConfig
 
 	BudgetReserver                   *budget.Reserver      // Atomic Redis budget reservation (nil if Redis disabled — feature is a no-op)
 	KeyRateLimiter                   *ratelimit.RPMLimiter // Key/user/team/org RPM/TPM enforcement (nil if Redis disabled)
@@ -396,6 +397,7 @@ type Proxy struct {
 	strictAllTeamModelsACL           bool
 	responseHeaderMode               config.ResponseHeaderMode
 	credentialNameAsTeamID           bool
+	protectedTenants                 []config.ProtectedTenantConfig
 	bedrockDailyQuota                *bedrockDailyQuotaTracker
 	budgetReserver                   *budget.Reserver
 	keyRateLimiter                   *ratelimit.RPMLimiter
@@ -475,6 +477,7 @@ func New(cfg *Config) *Proxy {
 		strictAllTeamModelsACL:           cfg.StrictAllTeamModelsACL,
 		responseHeaderMode:               cfg.ResponseHeaderMode,
 		credentialNameAsTeamID:           cfg.CredentialNameAsTeamID,
+		protectedTenants:                 append([]config.ProtectedTenantConfig(nil), cfg.ProtectedTenants...),
 		bedrockDailyQuota:                newBedrockDailyQuotaTracker(),
 		budgetReserver:                   cfg.BudgetReserver,
 		keyRateLimiter:                   cfg.KeyRateLimiter,
@@ -486,6 +489,15 @@ func New(cfg *Config) *Proxy {
 		version:                          cfg.Version,
 		commit:                           cfg.Commit,
 	}
+}
+
+// MaxRequestBodyBytes exposes the same request budget used by ProxyRequest so
+// router middleware cannot allocate an unbounded diagnostic copy first.
+func (p *Proxy) MaxRequestBodyBytes() int64 {
+	if p == nil || p.maxBodySizeMB <= 0 {
+		return 0
+	}
+	return int64(p.maxBodySizeMB) * 1024 * 1024
 }
 
 // Start launches background workers owned by Proxy.

--- a/internal/proxy/proxy_websocket.go
+++ b/internal/proxy/proxy_websocket.go
@@ -366,8 +366,13 @@ outerLoop:
 			continue
 		}
 		internalReq.URL.Path = "/v1/responses"
+		internalReq.Host = r.Host
 		internalReq.Header = r.Header.Clone()
 		internalReq.Header.Set("Content-Type", "application/json")
+		// The WebSocket handshake already authorized the public GET operation.
+		// Per-turn requests still revalidate the key, parent budgets and model ACL,
+		// but must not reinterpret the internal POST as a second public route.
+		internalReq = withTrustedRouteAuthorization(internalReq)
 
 		wsWriter := newWSSSEWriter(conn)
 

--- a/internal/proxy/proxy_websocket_auth_test.go
+++ b/internal/proxy/proxy_websocket_auth_test.go
@@ -1,9 +1,11 @@
 package proxy
 
 import (
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -11,9 +13,78 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/config"
 	"github.com/mixaill76/auto_ai_router/internal/litellmdb"
 	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	aimodels "github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestProtectedWebSocketTurnReusesHandshakeRouteAndRevalidatesKey(t *testing.T) {
+	var upstreamCalls atomic.Int32
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstreamCalls.Add(1)
+		assert.Equal(t, "/v1/responses", r.URL.Path)
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = w.Write([]byte("data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_cloud\",\"object\":\"response\",\"created_at\":1,\"status\":\"completed\",\"model\":\"public/chat\",\"output\":[],\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n\ndata: [DONE]\n\n"))
+	}))
+	defer upstream.Close()
+
+	db := &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"cloud-key": {
+			Token:          "cloud-key-hash",
+			OrganizationID: "org-cloud",
+			Models:         []string{"public/chat"},
+			AllowedRoutes:  []string{"GET /v1/responses"},
+			Metadata:       map[string]interface{}{"air_scopes": []string{"cloud-ru"}},
+		},
+	}}
+	passthrough := true
+	logger := testhelpers.NewTestLogger()
+	credential := config.CredentialConfig{
+		Name: "provider", Type: config.ProviderTypeOpenAI, BaseURL: upstream.URL, APIKey: "provider-key", RPM: 100, TPM: 10000,
+	}
+	manager := aimodels.New(logger, 100, []config.ModelRPMConfig{{
+		Name: "public/chat", Credential: credential.Name, RPM: 100, TPM: 10000, PassthroughResponses: &passthrough,
+	}})
+	manager.SetClientModelIDs([]string{"public/chat"})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+	builder := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key")
+	builder.config.ModelManager = manager
+	prx := builder.Build()
+	prx.LiteLLMDB = db
+	prx.protectedTenants = []config.ProtectedTenantConfig{{
+		Name: "cloud-ru", OrganizationIDs: []string{"org-cloud"}, RequiredScopes: []string{"cloud-ru"},
+		RequireModelACL: true, RequireRouteACL: true,
+	}}
+
+	server := httptest.NewServer(http.HandlerFunc(prx.HandleWebSocketResponses))
+	defer server.Close()
+	serverHost, _, splitErr := net.SplitHostPort(strings.TrimPrefix(server.URL, "http://"))
+	require.NoError(t, splitErr)
+	prx.protectedTenants[0].Hostnames = []string{serverHost}
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, http.Header{"Authorization": []string{"Bearer cloud-key"}})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	require.NoError(t, conn.WriteJSON(map[string]interface{}{
+		"type": "response.create", "model": "public/chat", "input": "hello",
+	}))
+	require.Eventually(t, func() bool {
+		return upstreamCalls.Load() == 1 && len(db.seenTokens()) >= 2
+	}, 5*time.Second, 10*time.Millisecond, "inner POST must reuse the authorized WS route and revalidate the key")
+
+	db.mu.Lock()
+	db.tokens["cloud-key"].OrganizationID = "org-other"
+	db.tokens["cloud-key"].Metadata = map[string]interface{}{"air_scopes": []string{"other"}}
+	db.mu.Unlock()
+	require.NoError(t, conn.WriteJSON(map[string]interface{}{
+		"type": "response.create", "model": "public/chat", "input": "second",
+	}))
+	require.Eventually(t, func() bool { return len(db.seenTokens()) >= 3 }, 5*time.Second, 10*time.Millisecond)
+	assert.Never(t, func() bool { return upstreamCalls.Load() > 1 }, 250*time.Millisecond, 10*time.Millisecond,
+		"changed organization on the protected Host must block the second turn")
+}
 
 func TestWebSocketResponsesAuthenticatesBeforeUpgrade(t *testing.T) {
 	db := &clientAuthTestDB{
@@ -21,10 +92,21 @@ func TestWebSocketResponsesAuthenticatesBeforeUpgrade(t *testing.T) {
 			"llm-key": {
 				Token: "llm-key-hash",
 			},
+			"cloud-key": {
+				Token:          "cloud-key-hash",
+				OrganizationID: "org-cloud",
+				Models:         []string{"public/chat"},
+				AllowedRoutes:  []string{"GET /v1/responses"},
+				Metadata:       map[string]interface{}{"air_scopes": []string{"cloud-ru"}},
+			},
 		},
 		errors: map[string]error{"invalid-key": litellmdb.ErrTokenNotFound},
 	}
 	prx := newClientAuthTestProxy(t, db, "http://example.invalid", config.ProviderTypeOpenAI, "provider-key")
+	prx.protectedTenants = []config.ProtectedTenantConfig{{
+		Name: "cloud-ru", OrganizationIDs: []string{"org-cloud"}, RequiredScopes: []string{"cloud-ru"},
+		RequireModelACL: true, RequireRouteACL: true,
+	}}
 	server := httptest.NewServer(http.HandlerFunc(prx.HandleWebSocketResponses))
 	t.Cleanup(server.Close)
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/v1/responses"
@@ -38,6 +120,7 @@ func TestWebSocketResponsesAuthenticatesBeforeUpgrade(t *testing.T) {
 		{name: "invalid bearer", headers: http.Header{"Authorization": []string{"Bearer invalid-key"}}, wantStatus: http.StatusUnauthorized},
 		{name: "valid bearer", headers: http.Header{"Authorization": []string{"Bearer llm-key"}}, wantStatus: http.StatusSwitchingProtocols},
 		{name: "valid x api key", headers: http.Header{"x-api-key": []string{"llm-key"}}, wantStatus: http.StatusSwitchingProtocols},
+		{name: "protected websocket route", headers: http.Header{"Authorization": []string{"Bearer cloud-key"}}, wantStatus: http.StatusSwitchingProtocols},
 		{name: "master", headers: http.Header{"Authorization": []string{"Bearer master-key"}}, wantStatus: http.StatusSwitchingProtocols},
 	}
 

--- a/internal/proxy/route_acl.go
+++ b/internal/proxy/route_acl.go
@@ -1,0 +1,197 @@
+package proxy
+
+import (
+	"net/http"
+	"strings"
+)
+
+// routeACLDecision keeps an absent ACL distinct from a configured ACL which
+// did not match. LiteLLM verification-token rows use an empty allowed_routes
+// array for the legacy unrestricted case; the integration point must decide
+// whether that legacy default is acceptable for its tenant policy.
+type routeACLDecision uint8
+
+const (
+	routeACLUnconfigured routeACLDecision = iota
+	routeACLDenied
+	routeACLAllowed
+)
+
+type publicRouteGroup uint8
+
+const (
+	publicRouteOpenAI publicRouteGroup = 1 << iota
+	publicRouteLLM
+	publicRouteInfo
+)
+
+var routeACLLegacyAliases = map[string]string{
+	"/chat/completions":   "/v1/chat/completions",
+	"/completions":        "/v1/completions",
+	"/embeddings":         "/v1/embeddings",
+	"/image/generations":  "/v1/images/generations",
+	"/images/edits":       "/v1/images/edits",
+	"/images/generations": "/v1/images/generations",
+	"/messages":           "/v1/messages",
+	"/models":             "/v1/models",
+	"/responses":          "/v1/responses",
+}
+
+var routeACLStaticPublicRoutes = map[string]map[string]publicRouteGroup{
+	http.MethodGet: {
+		"/v1/models":    publicRouteOpenAI | publicRouteLLM | publicRouteInfo,
+		"/v1/responses": publicRouteOpenAI | publicRouteLLM,
+	},
+	http.MethodPost: {
+		"/v1/chat/completions":   publicRouteOpenAI | publicRouteLLM,
+		"/v1/completions":        publicRouteOpenAI | publicRouteLLM,
+		"/v1/embeddings":         publicRouteOpenAI | publicRouteLLM,
+		"/v1/images/generations": publicRouteOpenAI | publicRouteLLM,
+		"/v1/images/edits":       publicRouteOpenAI | publicRouteLLM,
+		"/v1/messages":           publicRouteLLM,
+		"/v1/responses":          publicRouteOpenAI | publicRouteLLM,
+		"/v1/responses/compact":  publicRouteOpenAI | publicRouteLLM,
+	},
+}
+
+// evaluateRouteACL evaluates LiteLLM VerificationToken.allowed_routes against
+// AIR's public API surface. An empty slice is deliberately not interpreted as
+// allow or deny: routeACLUnconfigured lets the caller preserve legacy
+// unrestricted keys or enforce a tenant-specific fail-closed policy.
+//
+// Plain LiteLLM route entries are path-only permissions. They allow every HTTP
+// method which AIR supports for that public path. AIR additionally understands
+// "METHOD /path" (and "METHOD:/path") entries so method-scoped data already
+// stored by an operator remains enforceable.
+//
+// Exact entries, the LiteLLM presets llm_api_routes/openai_routes/info_routes,
+// the response-id template, LiteLLM segment-boundary prefixes, and terminal /*
+// wildcards are supported. No other glob matching is performed.
+func evaluateRouteACL(allowedRoutes []string, method, path string) routeACLDecision {
+	if len(allowedRoutes) == 0 {
+		return routeACLUnconfigured
+	}
+
+	method = strings.ToUpper(strings.TrimSpace(method))
+	path = canonicalRouteACLPath(path)
+	groups, public := classifyRouteACLPublicRoute(method, path)
+	if !public {
+		return routeACLDenied
+	}
+
+	for _, rawEntry := range allowedRoutes {
+		entryMethod, entryPath, ok := parseRouteACLEntry(rawEntry)
+		if !ok || (entryMethod != "" && entryMethod != method) {
+			continue
+		}
+
+		switch entryPath {
+		case "llm_api_routes":
+			if groups&publicRouteLLM != 0 {
+				return routeACLAllowed
+			}
+		case "openai_routes":
+			if groups&publicRouteOpenAI != 0 {
+				return routeACLAllowed
+			}
+		case "info_routes":
+			if groups&publicRouteInfo != 0 {
+				return routeACLAllowed
+			}
+		default:
+			entryPath = canonicalRouteACLPath(entryPath)
+			if routeACLPathMatches(entryPath, path) {
+				return routeACLAllowed
+			}
+		}
+	}
+
+	return routeACLDenied
+}
+
+func canonicalRouteACLPath(path string) string {
+	trimmedTrailingSlash := strings.TrimSuffix(path, "/")
+	if canonical, ok := routeACLLegacyAliases[trimmedTrailingSlash]; ok {
+		return canonical
+	}
+	if strings.HasPrefix(path, "/responses/") {
+		return "/v1" + path
+	}
+	return path
+}
+
+func classifyRouteACLPublicRoute(method, path string) (publicRouteGroup, bool) {
+	if methodRoutes, ok := routeACLStaticPublicRoutes[method]; ok {
+		if groups, ok := methodRoutes[path]; ok {
+			return groups, true
+		}
+	}
+
+	if method == http.MethodGet && isRouteACLResponseIDPath(path) {
+		return publicRouteOpenAI | publicRouteLLM, true
+	}
+	return 0, false
+}
+
+func isRouteACLResponseIDPath(path string) bool {
+	const prefix = "/v1/responses/"
+	if !strings.HasPrefix(path, prefix) {
+		return false
+	}
+	remainder := strings.TrimPrefix(path, prefix)
+	return remainder != "" && remainder != "compact" && !strings.Contains(remainder, "/")
+}
+
+func parseRouteACLEntry(raw string) (method, path string, ok bool) {
+	entry := strings.TrimSpace(raw)
+	if entry == "" {
+		return "", "", false
+	}
+
+	if fields := strings.Fields(entry); len(fields) == 2 && isRouteACLHTTPMethod(fields[0]) {
+		return strings.ToUpper(fields[0]), fields[1], true
+	} else if len(fields) != 1 {
+		return "", "", false
+	}
+
+	if separator := strings.IndexByte(entry, ':'); separator > 0 {
+		candidateMethod := entry[:separator]
+		if isRouteACLHTTPMethod(candidateMethod) {
+			candidatePath := strings.TrimSpace(entry[separator+1:])
+			if candidatePath == "" {
+				return "", "", false
+			}
+			return strings.ToUpper(candidateMethod), candidatePath, true
+		}
+	}
+
+	return "", entry, true
+}
+
+func isRouteACLHTTPMethod(method string) bool {
+	switch strings.ToUpper(method) {
+	case http.MethodGet, http.MethodHead, http.MethodPost, http.MethodPut,
+		http.MethodPatch, http.MethodDelete, http.MethodConnect, http.MethodOptions,
+		http.MethodTrace:
+		return true
+	default:
+		return false
+	}
+}
+
+func routeACLPathMatches(allowedPath, requestPath string) bool {
+	if allowedPath == requestPath {
+		return true
+	}
+	if allowedPath == "/v1/responses/{response_id}" || allowedPath == "/v1/responses/{id}" {
+		return isRouteACLResponseIDPath(requestPath)
+	}
+	if !strings.HasSuffix(allowedPath, "/*") || strings.Count(allowedPath, "*") != 1 {
+		// LiteLLM treats a configured route as a segment-boundary prefix. Keep
+		// that compatibility while classifyRouteACLPublicRoute limits the result
+		// to AIR's actual public surface.
+		return strings.HasPrefix(requestPath, allowedPath+"/")
+	}
+	prefix := strings.TrimSuffix(allowedPath, "*")
+	return strings.HasPrefix(requestPath, prefix)
+}

--- a/internal/proxy/route_acl_test.go
+++ b/internal/proxy/route_acl_test.go
@@ -1,0 +1,133 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEvaluateRouteACLEmptyIsExposedAsUnconfigured(t *testing.T) {
+	assert.Equal(t, routeACLUnconfigured, evaluateRouteACL(nil, http.MethodPost, "/v1/chat/completions"))
+	assert.Equal(t, routeACLUnconfigured, evaluateRouteACL([]string{}, http.MethodPost, "/v1/chat/completions"))
+
+	// A non-empty but unusable ACL is configured and therefore fails closed.
+	assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{""}, http.MethodPost, "/v1/chat/completions"))
+}
+
+func TestEvaluateRouteACLExactCanonicalPaths(t *testing.T) {
+	tests := []struct {
+		name    string
+		allowed []string
+		method  string
+		path    string
+		want    routeACLDecision
+	}{
+		{name: "chat", allowed: []string{"/v1/chat/completions"}, method: http.MethodPost, path: "/v1/chat/completions", want: routeACLAllowed},
+		{name: "models", allowed: []string{"/v1/models"}, method: http.MethodGet, path: "/v1/models", want: routeACLAllowed},
+		{name: "response create", allowed: []string{"/v1/responses"}, method: http.MethodPost, path: "/v1/responses", want: routeACLAllowed},
+		{name: "response websocket path", allowed: []string{"/v1/responses"}, method: http.MethodGet, path: "/v1/responses", want: routeACLAllowed},
+		{name: "compact", allowed: []string{"/v1/responses/compact"}, method: http.MethodPost, path: "/v1/responses/compact", want: routeACLAllowed},
+		{name: "unknown route", allowed: []string{"/*"}, method: http.MethodGet, path: "/health", want: routeACLDenied},
+		{name: "wrong method", allowed: []string{"/v1/models"}, method: http.MethodPost, path: "/v1/models", want: routeACLDenied},
+		{name: "canonical trailing slash is not a route", allowed: []string{"/v1/chat/completions/*"}, method: http.MethodPost, path: "/v1/chat/completions/", want: routeACLDenied},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evaluateRouteACL(tt.allowed, tt.method, tt.path))
+		})
+	}
+}
+
+func TestEvaluateRouteACLNormalizesLegacyAliases(t *testing.T) {
+	tests := []struct {
+		name        string
+		allowed     string
+		requestPath string
+		method      string
+	}{
+		{name: "legacy ACL canonical request", allowed: "/chat/completions", requestPath: "/v1/chat/completions", method: http.MethodPost},
+		{name: "canonical ACL legacy request", allowed: "/v1/embeddings", requestPath: "/embeddings", method: http.MethodPost},
+		{name: "singular image alias", allowed: "/image/generations", requestPath: "/v1/images/generations", method: http.MethodPost},
+		{name: "legacy models trailing slash", allowed: "/v1/models", requestPath: "/models/", method: http.MethodGet},
+		{name: "legacy response id", allowed: "/responses/{response_id}", requestPath: "/v1/responses/resp_123", method: http.MethodGet},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, routeACLAllowed, evaluateRouteACL([]string{tt.allowed}, tt.method, tt.requestPath))
+		})
+	}
+}
+
+func TestEvaluateRouteACLLiteLLMPresetsOnlyCoverAIRPublicRoutes(t *testing.T) {
+	tests := []struct {
+		name   string
+		preset string
+		method string
+		path   string
+		want   routeACLDecision
+	}{
+		{name: "llm covers openai", preset: "llm_api_routes", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLAllowed},
+		{name: "llm covers anthropic messages", preset: "llm_api_routes", method: http.MethodPost, path: "/v1/messages", want: routeACLAllowed},
+		{name: "llm covers response retrieval", preset: "llm_api_routes", method: http.MethodGet, path: "/v1/responses/resp_123", want: routeACLAllowed},
+		{name: "openai covers discovery", preset: "openai_routes", method: http.MethodGet, path: "/v1/models", want: routeACLAllowed},
+		{name: "openai excludes anthropic", preset: "openai_routes", method: http.MethodPost, path: "/v1/messages", want: routeACLDenied},
+		{name: "info covers discovery", preset: "info_routes", method: http.MethodGet, path: "/models", want: routeACLAllowed},
+		{name: "info excludes inference", preset: "info_routes", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLDenied},
+		{name: "preset cannot expose unsupported litellm route", preset: "llm_api_routes", method: http.MethodPost, path: "/v1/audio/speech", want: routeACLDenied},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evaluateRouteACL([]string{tt.preset}, tt.method, tt.path))
+		})
+	}
+}
+
+func TestEvaluateRouteACLResponseIDIsOneSafeDynamicSegment(t *testing.T) {
+	for _, allowed := range []string{"/v1/responses/{response_id}", "/v1/responses/{id}"} {
+		assert.Equal(t, routeACLAllowed, evaluateRouteACL([]string{allowed}, http.MethodGet, "/v1/responses/resp_123"))
+		assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{allowed}, http.MethodGet, "/v1/responses/compact"))
+		assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{allowed}, http.MethodGet, "/v1/responses/resp_123/input_items"))
+		assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{allowed}, http.MethodPost, "/v1/responses/resp_123"))
+	}
+
+	assert.Equal(t, routeACLAllowed, evaluateRouteACL([]string{"/v1/responses/resp_123"}, http.MethodGet, "/v1/responses/resp_123"))
+}
+
+func TestEvaluateRouteACLTerminalWildcardOnly(t *testing.T) {
+	tests := []struct {
+		name    string
+		allowed string
+		method  string
+		path    string
+		want    routeACLDecision
+	}{
+		{name: "response descendants", allowed: "/v1/responses/*", method: http.MethodGet, path: "/v1/responses/resp_123", want: routeACLAllowed},
+		{name: "wildcard does not imply base", allowed: "/v1/responses/*", method: http.MethodPost, path: "/v1/responses", want: routeACLDenied},
+		{name: "global public wildcard", allowed: "/*", method: http.MethodPost, path: "/v1/images/edits", want: routeACLAllowed},
+		{name: "nonterminal wildcard", allowed: "/v1/*/completions", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLDenied},
+		{name: "bare star", allowed: "*", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLDenied},
+		{name: "litellm segment prefix", allowed: "/v1", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLAllowed},
+		{name: "root is not global prefix", allowed: "/", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLDenied},
+		{name: "trailing slash does not widen", allowed: "/v1/", method: http.MethodPost, path: "/v1/chat/completions", want: routeACLDenied},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, evaluateRouteACL([]string{tt.allowed}, tt.method, tt.path))
+		})
+	}
+}
+
+func TestEvaluateRouteACLMethodQualifiedEntries(t *testing.T) {
+	assert.Equal(t, routeACLAllowed, evaluateRouteACL([]string{"GET /v1/responses"}, http.MethodGet, "/v1/responses"))
+	assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{"GET /v1/responses"}, http.MethodPost, "/v1/responses"))
+	assert.Equal(t, routeACLAllowed, evaluateRouteACL([]string{"post:/responses"}, http.MethodPost, "/v1/responses"))
+	assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{"post:/responses"}, http.MethodGet, "/v1/responses"))
+	assert.Equal(t, routeACLAllowed, evaluateRouteACL([]string{"GET info_routes"}, http.MethodGet, "/v1/models"))
+	assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{"POST info_routes"}, http.MethodGet, "/v1/models"))
+	assert.Equal(t, routeACLDenied, evaluateRouteACL([]string{"GET /v1/models extra"}, http.MethodGet, "/v1/models"))
+}

--- a/internal/proxy/tenant_policy.go
+++ b/internal/proxy/tenant_policy.go
@@ -1,0 +1,137 @@
+package proxy
+
+import (
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/scope"
+)
+
+func normalizeRequestHostname(hostport string) string {
+	hostport = strings.TrimSpace(hostport)
+	if host, _, err := net.SplitHostPort(hostport); err == nil {
+		hostport = host
+	}
+	hostport = strings.TrimPrefix(strings.TrimSuffix(hostport, "]"), "[")
+	return strings.ToLower(strings.TrimSuffix(hostport, "."))
+}
+
+func containsString(values []string, wanted string) bool {
+	for _, value := range values {
+		if value == wanted {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *Proxy) hasExplicitProtectedModelACL(modelIDs []string, visibility scope.Context) bool {
+	if len(modelIDs) == 0 {
+		return false
+	}
+	if p == nil || p.modelManager == nil {
+		return false
+	}
+	for _, modelID := range modelIDs {
+		modelID = strings.TrimSpace(modelID)
+		if modelID == "" || modelID == "*" || modelID == "all-proxy-models" ||
+			modelID == "all-team-models" || strings.ContainsRune(modelID, '*') {
+			return false
+		}
+		// Exact configured public IDs and tenant-scoped aliases are allowed.
+		// Regex-looking entries are rejected implicitly because they are not a
+		// routable product identifier in the model manager.
+		if !p.modelManager.IsClientModelIDRoutableScoped(modelID, visibility) {
+			return false
+		}
+	}
+	return true
+}
+
+func (p *Proxy) protectedTenantForOrganization(organizationID string) *config.ProtectedTenantConfig {
+	if p == nil || organizationID == "" {
+		return nil
+	}
+	for index := range p.protectedTenants {
+		if containsString(p.protectedTenants[index].OrganizationIDs, organizationID) {
+			return &p.protectedTenants[index]
+		}
+	}
+	return nil
+}
+
+func (p *Proxy) protectedTenantForHostname(hostname string) *config.ProtectedTenantConfig {
+	if p == nil || hostname == "" {
+		return nil
+	}
+	for index := range p.protectedTenants {
+		if containsString(p.protectedTenants[index].Hostnames, hostname) {
+			return &p.protectedTenants[index]
+		}
+	}
+	return nil
+}
+
+func (p *Proxy) rejectProtectedTenant(w http.ResponseWriter, logCtx *RequestLogContext, message string) bool {
+	if logCtx != nil {
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusForbidden
+		logCtx.ErrorMsg = message
+		// Admission failures are not billable and happen before a provider exists.
+		logCtx.Logged = true
+	}
+	WriteErrorForbidden(w, message)
+	return false
+}
+
+func (p *Proxy) enforceProtectedTenantAdmission(w http.ResponseWriter, r *http.Request, logCtx *RequestLogContext) bool {
+	if p == nil || logCtx == nil || logCtx.TokenInfo == nil || logCtx.TokenInfo.IsMasterKey {
+		return true
+	}
+
+	hostname := normalizeRequestHostname(r.Host)
+	organizationPolicy := p.protectedTenantForOrganization(logCtx.TokenInfo.OrganizationID)
+	hostPolicy := p.protectedTenantForHostname(hostname)
+	if hostPolicy != nil && organizationPolicy != hostPolicy {
+		return p.rejectProtectedTenant(w, logCtx, "Organization is not allowed for this hostname")
+	}
+	// Protected scopes are reserved to the organizations which own their policy.
+	// A copied/misconfigured air_scopes value must not unlock aliases or routes
+	// for another organization on an ordinary hostname.
+	for index := range p.protectedTenants {
+		policy := &p.protectedTenants[index]
+		if len(policy.RequiredScopes) == 0 || organizationPolicy == policy {
+			continue
+		}
+		if logCtx.Scope.AllowsExpression(scope.FromScopes(policy.RequiredScopes, nil)) {
+			return p.rejectProtectedTenant(w, logCtx, "Protected tenant scope does not belong to this organization")
+		}
+	}
+	if organizationPolicy == nil {
+		return true
+	}
+
+	if len(organizationPolicy.RequiredScopes) > 0 &&
+		!logCtx.Scope.AllowsExpression(scope.FromScopes(organizationPolicy.RequiredScopes, nil)) {
+		return p.rejectProtectedTenant(w, logCtx, "Required tenant scope is missing")
+	}
+	if organizationPolicy.RequireModelACL && !p.hasExplicitProtectedModelACL(logCtx.TokenInfo.Models, logCtx.Scope) {
+		return p.rejectProtectedTenant(w, logCtx, "Explicit model access is required")
+	}
+	if organizationPolicy.RequireRouteACL {
+		if hasTrustedRouteAuthorization(r) {
+			return true
+		}
+		switch evaluateRouteACL(logCtx.TokenInfo.AllowedRoutes, r.Method, r.URL.Path) {
+		case routeACLAllowed:
+			return true
+		case routeACLUnconfigured:
+			return p.rejectProtectedTenant(w, logCtx, "Explicit route access is required")
+		default:
+			return p.rejectProtectedTenant(w, logCtx, "Route is not allowed")
+		}
+	}
+	return true
+}

--- a/internal/proxy/tenant_policy_test.go
+++ b/internal/proxy/tenant_policy_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	aimodels "github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/mixaill76/auto_ai_router/internal/scope"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func protectedTenantTestProxy() *Proxy {
+	credential := config.CredentialConfig{Name: "provider", Type: config.ProviderTypeOpenAI}
+	manager := aimodels.New(testhelpers.NewTestLogger(), 100, []config.ModelRPMConfig{{
+		Name: "public/model", Credential: credential.Name,
+	}})
+	manager.SetClientModelIDs([]string{"public/model"})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+	return &Proxy{modelManager: manager, protectedTenants: []config.ProtectedTenantConfig{{
+		Name:            "cloud-ru",
+		OrganizationIDs: []string{"org-cloud"},
+		Hostnames:       []string{"api.cloud.example"},
+		RequiredScopes:  []string{"cloud-ru"},
+		RequireModelACL: true,
+		RequireRouteACL: true,
+	}}}
+}
+
+func protectedTenantToken(organizationID string, modelIDs, allowedRoutes []string) *models.TokenInfo {
+	return &models.TokenInfo{
+		OrganizationID: organizationID,
+		Models:         modelIDs,
+		AllowedRoutes:  allowedRoutes,
+	}
+}
+
+func TestProtectedTenantAdmission(t *testing.T) {
+	tests := []struct {
+		name       string
+		org        string
+		host       string
+		scopes     []string
+		models     []string
+		routes     []string
+		path       string
+		wantStatus int
+	}{
+		{name: "allowed", org: "org-cloud", host: "api.cloud.example:443", scopes: []string{"cloud-ru"}, models: []string{"public/model"}, routes: []string{"POST /v1/chat/completions"}, path: "/v1/chat/completions"},
+		{name: "foreign org on protected host", org: "org-other", host: "api.cloud.example", path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "foreign org with protected scope", org: "org-other", host: "router.example", scopes: []string{"cloud-ru"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "missing scope", org: "org-cloud", host: "router.example", models: []string{"public/model"}, routes: []string{"/v1/chat/completions"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "missing models", org: "org-cloud", host: "router.example", scopes: []string{"cloud-ru"}, routes: []string{"/v1/chat/completions"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "all team models is unbounded", org: "org-cloud", host: "router.example", scopes: []string{"cloud-ru"}, models: []string{"all-team-models"}, routes: []string{"/v1/chat/completions"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "wildcard models are unbounded", org: "org-cloud", host: "router.example", scopes: []string{"cloud-ru"}, models: []string{"public/*"}, routes: []string{"/v1/chat/completions"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "regex models are unbounded", org: "org-cloud", host: "router.example", scopes: []string{"cloud-ru"}, models: []string{".+"}, routes: []string{"/v1/chat/completions"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "missing routes", org: "org-cloud", host: "router.example", scopes: []string{"cloud-ru"}, models: []string{"public/model"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "denied route", org: "org-cloud", host: "router.example", scopes: []string{"cloud-ru"}, models: []string{"public/model"}, routes: []string{"/v1/embeddings"}, path: "/v1/chat/completions", wantStatus: http.StatusForbidden},
+		{name: "unprotected org on ordinary host", org: "org-other", host: "router.example", path: "/v1/chat/completions"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			prx := protectedTenantTestProxy()
+			req := httptest.NewRequest(http.MethodPost, "http://"+test.host+test.path, nil)
+			info := protectedTenantToken(test.org, test.models, test.routes)
+			logCtx := &RequestLogContext{Request: req, TokenInfo: info, Scope: scope.NewContext(test.scopes, nil)}
+			response := httptest.NewRecorder()
+
+			allowed := prx.enforceProtectedTenantAdmission(response, req, logCtx)
+			if test.wantStatus == 0 {
+				require.True(t, allowed)
+				assert.Equal(t, http.StatusOK, response.Code)
+				return
+			}
+			assert.False(t, allowed)
+			assert.Equal(t, test.wantStatus, response.Code)
+		})
+	}
+}
+
+func TestProtectedTenantModelACLIsRequestScoped(t *testing.T) {
+	prx := protectedTenantTestProxy()
+	token := protectedTenantToken("org-cloud", []string{"public/model"}, []string{"llm_api_routes"})
+	assert.True(t, prx.IsModelAllowedForRequest(nil, token, "public/model"))
+	assert.False(t, prx.IsModelAllowedForRequest(nil, token, "other/model"))
+
+	unprotected := protectedTenantToken("org-other", nil, nil)
+	assert.True(t, prx.IsModelAllowedForRequest(nil, unprotected, "other/model"))
+}
+
+func TestProtectedTenantMasterKeyIsAdministrativeException(t *testing.T) {
+	prx := protectedTenantTestProxy()
+	req := httptest.NewRequest(http.MethodPost, "http://api.cloud.example/v1/chat/completions", nil)
+	logCtx := &RequestLogContext{Request: req, TokenInfo: &models.TokenInfo{IsMasterKey: true}}
+	assert.True(t, prx.enforceProtectedTenantAdmission(httptest.NewRecorder(), req, logCtx))
+}
+
+func TestProtectedTenantTrustedInternalRouteKeepsIdentityChecks(t *testing.T) {
+	prx := protectedTenantTestProxy()
+	req := httptest.NewRequest(http.MethodPost, "http://api.cloud.example/v1/responses", nil)
+	req = withTrustedRouteAuthorization(req)
+	logCtx := &RequestLogContext{
+		Request: req,
+		TokenInfo: protectedTenantToken(
+			"org-cloud",
+			[]string{"public/model"},
+			[]string{"GET /v1/responses"},
+		),
+		Scope: scope.NewContext([]string{"cloud-ru"}, nil),
+	}
+	response := httptest.NewRecorder()
+	assert.True(t, prx.enforceProtectedTenantAdmission(response, req, logCtx))
+
+	logCtx.Scope = scope.NewContext([]string{"other"}, nil)
+	response = httptest.NewRecorder()
+	assert.False(t, prx.enforceProtectedTenantAdmission(response, req, logCtx))
+	assert.Equal(t, http.StatusForbidden, response.Code)
+}

--- a/internal/proxy/trusted_client_auth.go
+++ b/internal/proxy/trusted_client_auth.go
@@ -16,6 +16,7 @@ type trustedClientAuth struct {
 }
 
 type trustedClientAuthContextKey struct{}
+type trustedRouteAuthorizationContextKey struct{}
 
 func withTrustedClientAuth(req *http.Request, rawToken string, tokenInfo *dbmodels.TokenInfo) *http.Request {
 	if req == nil || tokenInfo == nil {
@@ -23,6 +24,21 @@ func withTrustedClientAuth(req *http.Request, rawToken string, tokenInfo *dbmode
 	}
 	value := trustedClientAuth{rawToken: rawToken, tokenInfo: tokenInfo.Clone()}
 	return req.WithContext(context.WithValue(req.Context(), trustedClientAuthContextKey{}, value))
+}
+
+func withTrustedRouteAuthorization(req *http.Request) *http.Request {
+	if req == nil {
+		return nil
+	}
+	return req.WithContext(context.WithValue(req.Context(), trustedRouteAuthorizationContextKey{}, true))
+}
+
+func hasTrustedRouteAuthorization(req *http.Request) bool {
+	if req == nil {
+		return false
+	}
+	trusted, _ := req.Context().Value(trustedRouteAuthorizationContextKey{}).(bool)
+	return trusted
 }
 
 func trustedClientAuthFromRequest(req *http.Request) (trustedClientAuth, bool) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -218,8 +218,29 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	if r.monitoringConfig.LogErrors {
+		// Admission must run before captureRequestBody, whose diagnostic copy is
+		// intentionally not the request-size enforcement boundary. ProxyRequest
+		// receives a private trusted handoff and does not query auth twice.
+		maxCaptureBytes := int64(0)
+		if r.proxy != nil {
+			maxCaptureBytes = r.proxy.MaxRequestBodyBytes()
+			var authorized bool
+			authorizationWriter := w
+			var messagesWriter *messagesErrorWriter
+			if req.URL.Path == "/v1/messages" {
+				messagesWriter = &messagesErrorWriter{ResponseWriter: w}
+				authorizationWriter = messagesWriter
+			}
+			req, authorized = r.proxy.AuthorizeAndTrustClientRequest(authorizationWriter, req)
+			if !authorized {
+				if messagesWriter != nil {
+					messagesWriter.finalize()
+				}
+				return
+			}
+		}
 		// Capture request body for logging (detects streaming requests)
-		reqBody, isStreaming, err := captureRequestBody(req)
+		reqBody, isStreaming, err := captureRequestBodyLimited(req, maxCaptureBytes)
 		if err != nil {
 			r.proxyPublicRequest(w, req)
 			return
@@ -266,7 +287,7 @@ func (r *Router) handleModels(w http.ResponseWriter, req *http.Request) {
 	if tokenInfo != nil {
 		filtered := make([]models.Model, 0, len(modelsResp.Data))
 		for _, model := range modelsResp.Data {
-			if r.proxy.IsModelAllowedForToken(tokenInfo, model.ID) {
+			if r.proxy.IsModelAllowedForRequest(req, tokenInfo, model.ID) {
 				filtered = append(filtered, model)
 			}
 		}

--- a/internal/router/router_logger.go
+++ b/internal/router/router_logger.go
@@ -3,6 +3,7 @@ package router
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"os"
@@ -193,20 +194,31 @@ func isErrorStatus(statusCode int) bool {
 // Returns (body, isStreaming, error) where isStreaming indicates if the request
 // has "stream": true in the JSON payload.
 func captureRequestBody(req *http.Request) ([]byte, bool, error) {
+	return captureRequestBodyLimited(req, 0)
+}
+
+func captureRequestBodyLimited(req *http.Request, maxBytes int64) ([]byte, bool, error) {
 	if req.Body == nil {
 		return []byte{}, false, nil
 	}
 
-	body, err := io.ReadAll(req.Body)
+	reader := io.Reader(req.Body)
+	if maxBytes > 0 {
+		reader = io.LimitReader(req.Body, maxBytes+1)
+	}
+	body, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, false, err
+	}
+	// Restore even an oversized prefix. ProxyRequest then applies the canonical
+	// size error contract without diagnostic middleware retaining the full body.
+	req.Body = io.NopCloser(bytes.NewReader(body))
+	if maxBytes > 0 && int64(len(body)) > maxBytes {
+		return body, false, fmt.Errorf("request body exceeds diagnostic capture limit")
 	}
 
 	// Check if this is a streaming request by parsing "stream": true in JSON
 	isStreaming := isStreamingRequestBody(body)
-
-	// Restore body for further processing (necessary for proxy to read it)
-	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	return body, isStreaming, nil
 }

--- a/internal/router/router_logger_test.go
+++ b/internal/router/router_logger_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResponseCapture_WriteHeader(t *testing.T) {
@@ -130,6 +131,17 @@ func TestCaptureRequestBody_LargeBody(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, data, body)
 	assert.False(t, isStreaming)
+}
+
+func TestCaptureRequestBodyLimitedStopsAtCanonicalBudget(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader("123456789"))
+	body, streaming, err := captureRequestBodyLimited(req, 4)
+	require.Error(t, err)
+	assert.False(t, streaming)
+	assert.Equal(t, "12345", string(body), "capture reads only max+1 bytes")
+	restored, readErr := io.ReadAll(req.Body)
+	require.NoError(t, readErr)
+	assert.Equal(t, body, restored)
 }
 
 func TestLogErrorResponse_EmptyPath(t *testing.T) {

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -50,15 +50,11 @@ func (m *routerAuthTestDB) ValidateToken(_ context.Context, rawToken string) (*d
 	if info == nil {
 		return nil, litellmdb.ErrTokenNotFound
 	}
-	clone := *info
-	clone.Models = append([]string(nil), info.Models...)
-	clone.UserModels = append([]string(nil), info.UserModels...)
-	clone.TeamModels = append([]string(nil), info.TeamModels...)
-	clone.TeamMemberModels = append([]string(nil), info.TeamMemberModels...)
+	clone := info.Clone()
 	if err := clone.Validate(""); err != nil {
 		return nil, err
 	}
-	return &clone, nil
+	return clone, nil
 }
 
 func newIPv4Server(t *testing.T, handler http.Handler) *httptest.Server {
@@ -81,6 +77,10 @@ func createTestProxy() *proxy.Proxy {
 }
 
 func createTestProxyWithStrictACL(strictAllTeamModelsACL bool) *proxy.Proxy {
+	return createTestProxyWithPolicies(strictAllTeamModelsACL, nil)
+}
+
+func createTestProxyWithPolicies(strictAllTeamModelsACL bool, protected []config.ProtectedTenantConfig) *proxy.Proxy {
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
 	f2b := fail2ban.New(3, 0, []int{401, 403, 500})
 	rl := ratelimit.New()
@@ -114,6 +114,7 @@ func createTestProxyWithStrictACL(strictAllTeamModelsACL bool) *proxy.Proxy {
 		Version:                "test-version",
 		Commit:                 "test-commit",
 		StrictAllTeamModelsACL: strictAllTeamModelsACL,
+		ProtectedTenants:       protected,
 	})
 }
 
@@ -887,6 +888,48 @@ func TestServeHTTPPublicPreflightDoesNotEnableWildcardCORS(t *testing.T) {
 	assert.Empty(t, w.Header().Get("Access-Control-Allow-Origin"))
 	assert.Empty(t, w.Header().Get("Access-Control-Allow-Headers"))
 	assert.Empty(t, w.Header().Get("Access-Control-Allow-Methods"))
+}
+
+type bodyReadCounter struct {
+	reads int
+}
+
+func (b *bodyReadCounter) Read([]byte) (int, error) {
+	b.reads++
+	return 0, io.EOF
+}
+
+func (b *bodyReadCounter) Close() error { return nil }
+
+func TestProtectedTenantAdmissionRunsBeforeDiagnosticBodyCapture(t *testing.T) {
+	prx := createTestProxyWithPolicies(false, []config.ProtectedTenantConfig{{
+		Name:            "cloud-ru",
+		OrganizationIDs: []string{"org-cloud"},
+		Hostnames:       []string{"api.cloud.example"},
+		RequiredScopes:  []string{"cloud-ru"},
+		RequireModelACL: true,
+		RequireRouteACL: true,
+	}})
+	prx.LiteLLMDB = &routerAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"foreign-key": {Token: "foreign-hash", OrganizationID: "org-foreign"},
+	}}
+	router := New(
+		prx,
+		createTestModelManager(),
+		testhelpers.NewTestMonitoringConfig("/health", true, ""),
+		testhelpers.NewTestLogger(),
+		nil,
+	)
+	body := &bodyReadCounter{}
+	req := httptest.NewRequest(http.MethodPost, "http://api.cloud.example/v1/chat/completions", nil)
+	req.Body = body
+	req.Header.Set("Authorization", "Bearer foreign-key")
+	writer := httptest.NewRecorder()
+
+	router.ServeHTTP(writer, req)
+
+	assert.Equal(t, http.StatusForbidden, writer.Code)
+	assert.Zero(t, body.reads, "protected admission must reject before diagnostic body capture")
 }
 
 func TestServeHTTPWebSocketUpgradeIsCaseInsensitive(t *testing.T) {


### PR DESCRIPTION
## Context

Prepare shared AIR ru01 for direct Cloud.ru virtual keys without changing permissive semantics for existing unrestricted keys.

## Changes

- load and enforce LiteLLM allowed_routes for protected tenants
- resolve effective organization from token or team hierarchy
- add protected organization and hostname policy
- add scope-aware public and accepted model aliases
- require exact routable model ACLs for protected tenants
- preserve LiteLLM route prefix semantics
- strip x-vsellm-* and x-auth-request-* at provider boundaries
- keep diagnostic body capture behind admission and within the proxy size budget
- preserve Responses compact and WebSocket internal route semantics

## Safety

All protected behavior is default-off. Existing deployments without protected_tenants keep legacy model and route semantics. The master key remains an explicit administrative exception.

## Verification

- go test ./...
- go vet ./...
- go test -race ./internal/config ./internal/litellmdb/auth ./internal/litellmdb/models ./internal/models ./internal/proxy ./internal/router
- independent security and compatibility review
- git diff --check
