### PR TITLE
Refresh sticky session TTL

### DIFF
--- a/docs/advanced/session_sticky.md
+++ b/docs/advanced/session_sticky.md
@@ -178,7 +178,7 @@ When disabled, no `SessionStore` is created and all routing uses plain round-rob
 
 ### TTL
 
-The binding expires after the configured TTL of inactivity. After expiry, the next request starts a new binding via round-robin.
+The binding expires after the configured TTL of inactivity. Every successful lookup for the same session and model refreshes the TTL immediately, so an active conversation keeps its credential affinity even while a response is still in progress. After expiry, the next request starts a new binding via round-robin.
 
 ```yaml
 server:

--- a/internal/proxy/sessions.go
+++ b/internal/proxy/sessions.go
@@ -17,39 +17,39 @@ type SessionEntry struct {
 }
 
 type SessionStore struct {
-	mu      sync.RWMutex
+	mu      sync.Mutex
 	entries map[sessionKey]*SessionEntry
 	ttl     time.Duration
+	now     func() time.Time
 }
 
 func NewSessionStore(ttl time.Duration) *SessionStore {
 	return &SessionStore{
 		entries: make(map[sessionKey]*SessionEntry),
 		ttl:     ttl,
+		now:     time.Now,
 	}
 }
 
 func (s *SessionStore) Get(sessionID, modelID string) (string, bool) {
 	key := sessionKey{sessionID: sessionID, modelID: modelID}
 
-	s.mu.RLock()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	entry, ok := s.entries[key]
-	s.mu.RUnlock()
 	if !ok {
 		return "", false
 	}
 
-	if time.Since(entry.LastAccess) <= s.ttl {
-		return entry.CredentialName, true
+	now := s.now()
+	if now.Sub(entry.LastAccess) > s.ttl {
+		delete(s.entries, key)
+		return "", false
 	}
 
-	s.mu.Lock()
-	entry, ok = s.entries[key]
-	if ok && time.Since(entry.LastAccess) > s.ttl {
-		delete(s.entries, key)
-	}
-	s.mu.Unlock()
-	return "", false
+	entry.LastAccess = now
+	return entry.CredentialName, true
 }
 
 func (s *SessionStore) Set(sessionID, modelID, credentialName string) {
@@ -58,7 +58,7 @@ func (s *SessionStore) Set(sessionID, modelID, credentialName string) {
 
 	s.entries[sessionKey{sessionID: sessionID, modelID: modelID}] = &SessionEntry{
 		CredentialName: credentialName,
-		LastAccess:     time.Now(),
+		LastAccess:     s.now(),
 	}
 }
 
@@ -71,7 +71,7 @@ func (s *SessionStore) Delete(sessionID, modelID string) {
 func (s *SessionStore) Len() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.cleanupExpiredLocked(time.Now())
+	s.cleanupExpiredLocked(s.now())
 	return len(s.entries)
 }
 
@@ -83,9 +83,9 @@ func (s *SessionStore) StartCleanup(ctx context.Context, interval time.Duration)
 		select {
 		case <-ctx.Done():
 			return
-		case now := <-ticker.C:
+		case <-ticker.C:
 			s.mu.Lock()
-			s.cleanupExpiredLocked(now)
+			s.cleanupExpiredLocked(s.now())
 			s.mu.Unlock()
 		}
 	}

--- a/internal/proxy/sessions_test.go
+++ b/internal/proxy/sessions_test.go
@@ -34,6 +34,27 @@ func TestSessionStoreExpiresEntries(t *testing.T) {
 	assert.Equal(t, 0, store.Len())
 }
 
+func TestSessionStoreGetRefreshesExpiry(t *testing.T) {
+	now := time.Date(2026, time.August, 24, 12, 0, 0, 0, time.UTC)
+	store := NewSessionStore(10 * time.Minute)
+	store.now = func() time.Time { return now }
+	store.Set("session-1", "anthropic/claude-sonnet-4.6", "anthropic-cred-1")
+
+	now = now.Add(9 * time.Minute)
+	cred, ok := store.Get("session-1", "anthropic/claude-sonnet-4.6")
+	require.True(t, ok)
+	assert.Equal(t, "anthropic-cred-1", cred)
+
+	now = now.Add(9 * time.Minute)
+	cred, ok = store.Get("session-1", "anthropic/claude-sonnet-4.6")
+	require.True(t, ok)
+	assert.Equal(t, "anthropic-cred-1", cred)
+
+	now = now.Add(11 * time.Minute)
+	_, ok = store.Get("session-1", "anthropic/claude-sonnet-4.6")
+	assert.False(t, ok)
+}
+
 func TestSessionStoreKeysAreIndependentPerModel(t *testing.T) {
 	store := NewSessionStore(time.Minute)
 	store.Set("session-1", "model-a", "cred-1")


### PR DESCRIPTION
Refresh session bindings on lookup.

Tests: `go test ./...`, `make lint`