### PR TITLE
Strip internal request headers before upstream forwarding

### DIFF
--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -68,7 +68,10 @@ func isHopByHopHeader(key string) bool {
 }
 
 func isInternalAIRRequestHeader(key string) bool {
-	return strings.EqualFold(key, HeaderAIRProxyClient) ||
+	lowerKey := strings.ToLower(key)
+	return strings.HasPrefix(lowerKey, "x-vsellm-") ||
+		strings.HasPrefix(lowerKey, "x-auth-request-") ||
+		strings.EqualFold(key, HeaderAIRProxyClient) ||
 		strings.EqualFold(key, HeaderLegacyAIRProxyClient) ||
 		strings.EqualFold(key, HeaderAIRUsageAudioTokens)
 }
@@ -111,7 +114,8 @@ func copyRequestHeaders(dst *http.Request, src *http.Request, apiKey string) {
 		if key == "Accept-Encoding" {
 			continue
 		}
-		// Strip internal AIR markers — they must not be forwarded to the actual provider.
+		// Strip internal identity, routing, pricing, and provider credential
+		// headers at the upstream boundary.
 		if isInternalAIRRequestHeader(key) {
 			continue
 		}
@@ -141,7 +145,8 @@ func copyHeadersSkipAuth(dst *http.Request, src *http.Request) {
 		if key == "Accept-Encoding" {
 			continue
 		}
-		// Strip internal AIR markers — they must not be forwarded to the actual provider.
+		// Strip internal identity, routing, pricing, and provider credential
+		// headers at the upstream boundary.
 		if isInternalAIRRequestHeader(key) {
 			continue
 		}

--- a/internal/proxy/headers_test.go
+++ b/internal/proxy/headers_test.go
@@ -155,10 +155,66 @@ func TestCopyRequestHeadersStripsInternalUsageContractHeader(t *testing.T) {
 	assert.Equal(t, "ok", dst.Header.Get("X-Regular"))
 }
 
+func TestRequestHeaderCopyStripsInternalNamespaces(t *testing.T) {
+	internalHeaders := http.Header{
+		"X-Vsellm-Provider-000-Api-Keys":    {"provider-key-id=provider-secret"},
+		"x-VsElLm-Model-Pricing-Json":       {`{"currency":"RUB"}`},
+		"X-Vsellm-Request-Auth-Org-Id":      {"organization-id"},
+		"x-vsellm-provider-000-route-id":    {"model:provider:key:"},
+		"X-AuTh-ReQuEsT-UsEr":               {"internal-user"},
+		"X-Auth-Request-Preferred-Username": {"internal-username"},
+		"X-Regular":                         {"preserved"},
+	}
+
+	tests := []struct {
+		name string
+		copy func(dst, src *http.Request)
+	}{
+		{
+			name: "provider request",
+			copy: func(dst, src *http.Request) {
+				copyRequestHeaders(dst, src, "configured-provider-key")
+			},
+		},
+		{
+			name: "passthrough request",
+			copy: func(dst, src *http.Request) {
+				copyHeadersSkipAuth(dst, src)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			src := httptestRequestWithHTTPHeaders(internalHeaders)
+			dst, err := http.NewRequest(http.MethodPost, "http://upstream.example/v1/chat/completions", nil)
+			assert.NoError(t, err)
+
+			tt.copy(dst, src)
+
+			for key := range internalHeaders {
+				if key == "X-Regular" {
+					continue
+				}
+				assert.Empty(t, dst.Header.Values(key), "internal header %s must not reach provider", key)
+			}
+			assert.Equal(t, "preserved", dst.Header.Get("X-Regular"))
+		})
+	}
+}
+
 func httptestRequestWithHeaders(headers map[string]string) *http.Request {
 	req, _ := http.NewRequest(http.MethodPost, "http://router.example/v1/chat/completions", nil)
 	for key, value := range headers {
 		req.Header.Set(key, value)
+	}
+	return req
+}
+
+func httptestRequestWithHTTPHeaders(headers http.Header) *http.Request {
+	req, _ := http.NewRequest(http.MethodPost, "http://router.example/v1/chat/completions", nil)
+	for key, values := range headers {
+		req.Header[key] = append([]string(nil), values...)
 	}
 	return req
 }


### PR DESCRIPTION
## Changes

- Strip all `X-Vsellm-*` request headers
- Strip all `X-Auth-Request-*` request headers
- Preserve AIR chain markers
- Preserve regular request headers
- Add coverage for both request forwarding paths
- Add case-insensitive header matching coverage
