### PR TITLE
Handle upstream error statuses

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -738,8 +738,14 @@ func (p *Proxy) executeProxyRequest(
 	}
 
 	if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, respBody); ok {
+		// resp.StatusCode != http.StatusOK already recorded this attempt as
+		// failed above; only record here when the original status was 200,
+		// to keep this at exactly one RecordCredentialAttemptError per
+		// failed attempt.
+		if resp.StatusCode == http.StatusOK {
+			p.metrics.RecordCredentialAttemptError(cred.Name)
+		}
 		resp.StatusCode = mappedStatus
-		p.metrics.RecordCredentialAttemptError(cred.Name)
 	}
 
 	// Return complete response information
@@ -1085,11 +1091,14 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Client-facing outcome decided (this response — success or the last
-		// retryable error with no more attempts left — is what gets written to
-		// the client below) — record exactly once here with genuine end-to-end
-		// duration, not once per retry attempt.
-		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, proxyResp.StatusCode, time.Since(start))
+		// Client-facing outcome metric (RecordRequest) is recorded further down,
+		// after the response has actually been written — see the "Log proxy
+		// response" block below. For streaming, the body/SSE-detected error
+		// remap (statusCodeFromProviderBodyError, above) only happens for
+		// non-streaming; a streaming request's real client-visible status isn't
+		// known until the stream write below has resolved it, so recording here
+		// with proxyResp.StatusCode would record the pre-remap status instead of
+		// what the client actually received.
 
 		// Write response (streaming or non-streaming)
 		tokenUsageOptions := tokenUsageExtractionOptionsForResponse(cred, proxyResp.Headers)
@@ -1306,21 +1315,42 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		// Log proxy response
-		logCtx.Status = "success"
-		if proxyResp.StatusCode >= 400 {
-			logCtx.Status = "failure"
-			// Final error returned to the client — single unified ERROR record.
-			// For streaming responses the body was forwarded to the client and is
-			// not available here (response_body is omitted).
-			p.logUpstreamError(r.Context(), "Proxy request completed with error status", proxyResp.StatusCode, cred, modelID, proxyResp.Body,
-				"url", cred.BaseURL,
-				"streaming", proxyResp.IsStreaming,
-				"actual_credential", logCtx.ActualCredentialName,
-				"request_id", logCtx.RequestID)
+		// Log proxy response.
+		// For streaming, the write path above may already have classified this
+		// request as a terminal stream error or client abort (body-detected
+		// provider error remapped mid-stream, or the client disconnecting) and
+		// set logCtx.Status/HTTPStatus/ErrorMsg accordingly — via
+		// markProxyProviderStreamError / markStreamFailure / finalizeStreamingLog,
+		// all reached from the streaming handlers called above. proxyResp.StatusCode
+		// itself is never mutated for streaming (only the non-streaming branch
+		// remaps it), so blindly overwriting here would silently revert an
+		// already-correct 429/500/499 back to the original upstream 200.
+		streamTerminalErrorAlreadyLogged := proxyResp.IsStreaming &&
+			(logCtx.StreamOutcome == "stream_error" || logCtx.StreamOutcome == "client_aborted")
+		if !streamTerminalErrorAlreadyLogged {
+			logCtx.Status = "success"
+			if proxyResp.StatusCode >= 400 {
+				logCtx.Status = "failure"
+				// Final error returned to the client — single unified ERROR record.
+				// For streaming responses the body was forwarded to the client and is
+				// not available here (response_body is omitted).
+				p.logUpstreamError(r.Context(), "Proxy request completed with error status", proxyResp.StatusCode, cred, modelID, proxyResp.Body,
+					"url", cred.BaseURL,
+					"streaming", proxyResp.IsStreaming,
+					"actual_credential", logCtx.ActualCredentialName,
+					"request_id", logCtx.RequestID)
+			}
+			logCtx.HTTPStatus = proxyResp.StatusCode
 		}
-		logCtx.HTTPStatus = proxyResp.StatusCode
 		logCtx.TargetURL = cred.BaseURL
+
+		// Client-facing outcome decided (this response — success or the last
+		// retryable error with no more attempts left — is what gets written to
+		// the client; for streaming, logCtx.HTTPStatus reflects any body/SSE
+		// remap applied during the write above) — record exactly once here
+		// with genuine end-to-end duration, not once per retry attempt.
+		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, logCtx.HTTPStatus, time.Since(start))
+
 		if !proxyResp.IsStreaming {
 			// Reuses the decode already done above (extractOpenAITokensAndUsage)
 			// instead of a second independent converter.ExtractTokenUsageWithOptions
@@ -1874,11 +1904,28 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 		defer closeBody()
 	}
 
-	// Client-facing outcome decided (this response — success or the last
-	// retryable error with no more attempts left — is what gets written to
-	// the client below) — record exactly once here with genuine end-to-end
-	// duration, not once per retry attempt.
-	p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
+	if isStreamingResp {
+		// Streaming: unlike the non-streaming branch below, resp.StatusCode here
+		// is never remapped from a body/SSE-detected provider error (that only
+		// resolves once the stream write below finishes, via finalizeStreamingLog).
+		// Record the metric at function return instead, using whatever
+		// logCtx.HTTPStatus is authoritative by then; fall back to resp.StatusCode
+		// if a streaming sub-path returns early without ever setting it.
+		fallbackStatus := resp.StatusCode
+		defer func() {
+			finalStatus := logCtx.HTTPStatus
+			if finalStatus == 0 {
+				finalStatus = fallbackStatus
+			}
+			p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, finalStatus, time.Since(start))
+		}()
+	} else {
+		// Client-facing outcome decided (this response — success or the last
+		// retryable error with no more attempts left — is what gets written to
+		// the client below) — record exactly once here with genuine end-to-end
+		// duration, not once per retry attempt.
+		p.metrics.RecordRequest(cred.Name, r.URL.Path, modelID, resp.StatusCode, time.Since(start))
+	}
 
 	// === Process final response ===
 	var finalResponseBody []byte

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -737,6 +737,11 @@ func (p *Proxy) executeProxyRequest(
 		return nil, err
 	}
 
+	if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, respBody); ok {
+		resp.StatusCode = mappedStatus
+		p.metrics.RecordCredentialAttemptError(cred.Name)
+	}
+
 	// Return complete response information
 	return &ProxyResponse{
 		StatusCode:           resp.StatusCode,
@@ -1072,6 +1077,12 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 		if respCred != nil && respCred != cred {
 			cred = respCred
 			logCtx.Credential = cred
+		}
+
+		if !proxyResp.IsStreaming {
+			if mappedStatus, ok := statusCodeFromProviderBodyError(proxyResp.StatusCode, proxyResp.Body); ok {
+				proxyResp.StatusCode = mappedStatus
+			}
 		}
 
 		// Client-facing outcome decided (this response — success or the last
@@ -1777,6 +1788,10 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, responseBody); ok {
+			resp.StatusCode = mappedStatus
+		}
+
 		p.recordProviderResponse(r.Context(), cred, modelID, realModelID, resp.StatusCode, resp.Header, responseBody)
 
 		// Check if we should retry with another same-type credential
@@ -2021,6 +2036,9 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
+		if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, finalResponseBody); ok {
+			resp.StatusCode = mappedStatus
+		}
 		rawErrorBody := finalResponseBody
 		clientBody, clientBodyChanged, clientBodyMasked := clientResponseBodyForCredential(resp.StatusCode, finalResponseBody, cred, modelID)
 		if clientBodyChanged {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1104,7 +1104,6 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 				if logCtx.IsProxyRequest && logCtx.ActualCredentialName != "" {
 					w.Header().Set("X-Credential-Name", logCtx.ActualCredentialName)
 				}
-				w.WriteHeader(proxyResp.StatusCode)
 				p.setPromptTokensEstimate(logCtx, body, realModelID)
 				fakeResp := &http.Response{
 					StatusCode: proxyResp.StatusCode,
@@ -1130,7 +1129,6 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 				if proxyResp.StatusCode >= 200 && proxyResp.StatusCode < 300 {
 					p.markAudioUsageExcludesCachedForClient(w, logCtx)
 				}
-				w.WriteHeader(proxyResp.StatusCode)
 				p.setPromptTokensEstimate(logCtx, body, realModelID)
 				fakeResp := &http.Response{
 					StatusCode: proxyResp.StatusCode,
@@ -1156,7 +1154,6 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 				if proxyResp.StatusCode >= 200 && proxyResp.StatusCode < 300 {
 					p.markAudioUsageContractForClient(w, logCtx, tokenUsageOptions.AudioInputIncludesCachedAudio)
 				}
-				w.WriteHeader(proxyResp.StatusCode)
 				p.setPromptTokensEstimate(logCtx, body, realModelID)
 				fakeResp := &http.Response{
 					StatusCode: proxyResp.StatusCode,
@@ -2150,7 +2147,6 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		setSuccessfulSSEHeaders(w.Header(), resp.StatusCode)
-		w.WriteHeader(resp.StatusCode)
 
 		// Arms the lazy fallback estimate; the actual json-decode + tiktoken pass only
 		// runs later, inside finalizeStreamingLog, and only if the provider never sent

--- a/internal/proxy/proxy_stream_metrics_test.go
+++ b/internal/proxy/proxy_stream_metrics_test.go
@@ -1,0 +1,111 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/monitoring"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestProxyRequest_StreamingBodyErrorMetricUsesRemappedStatus is a regression
+// test for two related bugs found while reviewing PR #149:
+//
+//  1. RecordRequest for a streaming proxy-credential response fired with
+//     proxyResp.StatusCode (the original, pre-remap upstream status — usually
+//     200), before the body/SSE terminal-error remap (applied deep inside
+//     writeProxyStreamingResponseWithTokens/streamToClient) had happened. So a
+//     request the client correctly received as 429 would still count as 200 in
+//     RequestsTotal/RequestDuration.
+//  2. Separately, even once the remap had already set logCtx.Status/HTTPStatus
+//     correctly (via markProxyProviderStreamError), the unconditional
+//     `logCtx.Status = "success"` / `logCtx.HTTPStatus = proxyResp.StatusCode`
+//     in ProxyRequest's shared "Log proxy response" section ran afterward and
+//     clobbered it back to "success"/200 — corrupting the persisted spend log,
+//     not just the metric.
+//
+// This exercises the full ProxyRequest path (same trigger as
+// TestProxyRequest_StreamingImmediateRateLimitEventReturns429) with metrics
+// enabled, and asserts RequestsTotal was incremented under the client-visible
+// 429 label, not 200.
+func TestProxyRequest_StreamingBodyErrorMetricUsesRemappedStatus(t *testing.T) {
+	monitoring.RequestsTotal.Reset()
+
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"code":"rate_limit_exceeded","message":"Request failed"}}}`+"\n\n")
+	}))
+	defer mockServer.Close()
+
+	builder := NewTestProxyBuilder().
+		WithSingleCredential("metrics-test-cred", config.ProviderTypeProxy, mockServer.URL, "upstream-key-1")
+	builder.config.Metrics = monitoring.New(true)
+	prx := builder.Build()
+
+	reqBody := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	rateLimited := testutil.ToFloat64(monitoring.RequestsTotal.WithLabelValues(
+		"metrics-test-cred", "gpt-4", "/v1/chat/completions", "429",
+	))
+	assert.Equal(t, float64(1), rateLimited, "RequestsTotal should record the client-visible 429, not the pre-remap upstream 200")
+
+	falseSuccess := testutil.ToFloat64(monitoring.RequestsTotal.WithLabelValues(
+		"metrics-test-cred", "gpt-4", "/v1/chat/completions", "200",
+	))
+	assert.Equal(t, float64(0), falseSuccess, "RequestsTotal must not also record the pre-remap 200 for this request")
+
+	// Give the async spend-log defer safety-net a moment to run so we're not
+	// racing it (it doesn't touch these metrics, but keeps the test from
+	// exiting mid-goroutine on a slow CI box).
+	time.Sleep(10 * time.Millisecond)
+}
+
+// TestExecuteProxyRequest_NonOKBodyErrorStatusRecordsAttemptErrorOnce is a
+// regression test: the pre-existing "resp.StatusCode != http.StatusOK" guard
+// and the new statusCodeFromProviderBodyError remap both call
+// RecordCredentialAttemptError independently. For a status already != 200
+// (e.g. a hypothetical 201 with an error-shaped body, in [200,300) so the
+// body-error check also fires) that double-counts a single failed attempt.
+func TestExecuteProxyRequest_NonOKBodyErrorStatusRecordsAttemptErrorOnce(t *testing.T) {
+	monitoring.CredentialErrorsTotal.Reset()
+
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated) // 201: != 200, but still in [200,300)
+		_, _ = io.WriteString(w, `{"error":{"message":"provider exploded","type":"server_error"}}`)
+	}))
+	defer mockServer.Close()
+
+	cred := &config.CredentialConfig{
+		Name:    "double-count-cred",
+		Type:    config.ProviderTypeProxy,
+		BaseURL: mockServer.URL,
+		APIKey:  "upstream-key-1",
+	}
+	builder := NewTestProxyBuilder().WithCredentials(*cred)
+	builder.config.Metrics = monitoring.New(true)
+	prx := builder.Build()
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+
+	_, err := prx.executeProxyRequest(req, cred, "gpt-4", []byte(`{}`), time.Now())
+	assert.NoError(t, err)
+
+	count := testutil.ToFloat64(monitoring.CredentialErrorsTotal.WithLabelValues("double-count-cred"))
+	assert.Equal(t, float64(1), count, "a single failed attempt must record exactly one CredentialErrorsTotal, not two")
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -139,6 +139,56 @@ func TestProxyRequest_StreamingImmediateRateLimitEventReturns429(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "response.failed")
 }
 
+func TestProxyRequest_NonStreamingRateLimitBodyReturns429(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"error":{"code":"rate_limit_exceeded","message":"Request failed"}}`)
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeProxy, mockServer.URL, "upstream-key-1").
+		Build()
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Contains(t, w.Body.String(), "rate_limit_error")
+	assert.NotContains(t, w.Body.String(), "rate_limit_exceeded")
+}
+
+func TestProxyRequest_NonStreamingFailedResponseBodyReturns500(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{"id":"resp_1","object":"response","status":"failed","error":{"code":"server_error","message":"Request failed"}}`)
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("openai", config.ProviderTypeOpenAI, mockServer.URL, "upstream-key-1").
+		Build()
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	assert.Contains(t, w.Body.String(), "server_error")
+	assert.NotContains(t, w.Body.String(), "resp_1")
+}
+
 func TestProxyRequest_WithModel(t *testing.T) {
 	// Create mock upstream server
 	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"mime/multipart"
 	"net/http"
@@ -110,6 +111,32 @@ func TestProxyRequest_ValidRequest(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), "success")
+}
+
+func TestProxyRequest_StreamingImmediateRateLimitEventReturns429(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `data: {"type":"response.failed","response":{"id":"resp_1","status":"failed","error":{"code":"rate_limit_exceeded","message":"Request failed"}}}`+"\n\n")
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeProxy, mockServer.URL, "upstream-key-1").
+		Build()
+
+	reqBody := `{"model":"gpt-4","stream":true,"messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+	assert.Contains(t, w.Body.String(), "rate_limit_error")
+	assert.NotContains(t, w.Body.String(), "response.failed")
 }
 
 func TestProxyRequest_WithModel(t *testing.T) {

--- a/internal/proxy/response_compat_test.go
+++ b/internal/proxy/response_compat_test.go
@@ -112,9 +112,7 @@ func TestResponseCompatibilityWriterDoesNotCompleteFailedStream(t *testing.T) {
 		"credential",
 		"model",
 		"/v1/chat/completions",
-		nil,
-		nil,
-		nil,
+		http.StatusOK, nil, nil, nil,
 	)
 	require.ErrorIs(t, err, streamErr)
 	require.ErrorIs(t, writer.Close(), streamErr)

--- a/internal/proxy/response_id_test.go
+++ b/internal/proxy/response_id_test.go
@@ -58,7 +58,7 @@ func TestStreamToClientCapturesResponseID(t *testing.T) {
 
 	err := NewTestProxyBuilder().Build().streamToClient(
 		context.Background(), recorder, strings.NewReader(payload), "cred", "model",
-		"/v1/chat/completions", nil, nil, logCtx,
+		"/v1/chat/completions", http.StatusOK, nil, nil, logCtx,
 	)
 
 	require.NoError(t, err)

--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -265,10 +265,13 @@ func writeProviderStreamErrorBeforeCommit(w http.ResponseWriter, statusCode int)
 }
 
 // resolveCapturedProviderStreamError finalizes one or more bounded stream
-// observers after every upstream byte has already been forwarded. Raw provider
-// and transformed-output observers may both be supplied; the first decoded
-// terminal payload is retained as the authoritative error detail. A pre-existing
-// transport/client error keeps precedence for StreamOutcome classification.
+// observers once the stream ends — whether upstream bytes were already
+// forwarded to the client, or the terminal error was caught before any byte
+// was committed (see the beforeCommit case on proxyProviderStreamError). Raw
+// provider and transformed-output observers may both be supplied; the first
+// decoded terminal payload is retained as the authoritative error detail. A
+// pre-existing transport/client error keeps precedence for StreamOutcome
+// classification.
 func resolveCapturedProviderStreamError(
 	logCtx *RequestLogContext,
 	statusCode int,
@@ -553,6 +556,9 @@ func (p *Proxy) writeProxyStreamingResponseWithTokens(
 	}
 
 	// Non-flushing fallback: copy as-is (token usage cannot be parsed reliably here).
+	// Unlike the streamToClient path above, there's no preflight gate here to
+	// delay the header, so the real upstream status is committed immediately.
+	w.WriteHeader(resp.StatusCode)
 	var responseIDScanner clientResponseIDScanner
 	observedReader := io.TeeReader(clientReader, clientResponseIDObserver{scanner: &responseIDScanner, logCtx: logCtx})
 	if _, err := io.Copy(w, observedReader); err != nil {

--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -26,6 +26,37 @@ func clientResponseBodyForCredential(statusCode int, body []byte, _ *config.Cred
 	return body, false, false
 }
 
+func statusCodeFromProviderBodyError(statusCode int, body []byte) (int, bool) {
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices || len(body) == 0 {
+		return 0, false
+	}
+
+	var evt struct {
+		Type     string          `json:"type"`
+		Status   string          `json:"status"`
+		Error    json.RawMessage `json:"error"`
+		Response struct {
+			Status string          `json:"status"`
+			Error  json.RawMessage `json:"error"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal(body, &evt); err != nil {
+		return 0, false
+	}
+
+	signals := []string{evt.Type, evt.Status, evt.Response.Status}
+	topErrorSignals, hasTopError := providerErrorSignals(evt.Error)
+	responseErrorSignals, hasResponseError := providerErrorSignals(evt.Response.Error)
+	signals = append(signals, topErrorSignals...)
+	signals = append(signals, responseErrorSignals...)
+
+	hasFailedStatus := strings.EqualFold(evt.Status, "failed") || strings.EqualFold(evt.Response.Status, "failed")
+	if !hasTopError && !hasResponseError && !hasFailedStatus {
+		return 0, false
+	}
+	return statusCodeFromErrorSignals(signals), true
+}
+
 const maxProxyStreamErrorCaptureBytes = 256 * 1024
 
 // proxyProviderStreamError reports an error event carried by an otherwise
@@ -166,6 +197,44 @@ func statusCodeFromProviderStreamError(payload string) int {
 		evt.Response.Error.Message,
 		evt.Type,
 	}
+	return statusCodeFromErrorSignals(signals)
+}
+
+func providerErrorSignals(raw json.RawMessage) ([]string, bool) {
+	trimmed := bytes.TrimSpace(raw)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+		return nil, false
+	}
+
+	var text string
+	if err := json.Unmarshal(trimmed, &text); err == nil {
+		text = strings.TrimSpace(text)
+		if text == "" {
+			return nil, false
+		}
+		return []string{text}, true
+	}
+
+	var fields struct {
+		Type    string `json:"type"`
+		Code    string `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	}
+	if err := json.Unmarshal(trimmed, &fields); err == nil {
+		signals := []string{fields.Code, fields.Type, fields.Message, fields.Status}
+		for _, signal := range signals {
+			if strings.TrimSpace(signal) != "" {
+				return signals, true
+			}
+		}
+		return nil, false
+	}
+
+	return nil, false
+}
+
+func statusCodeFromErrorSignals(signals []string) int {
 	for _, signal := range signals {
 		signal = strings.ToLower(strings.TrimSpace(signal))
 		switch {
@@ -259,6 +328,9 @@ func (p *Proxy) writeProxyResponse(w http.ResponseWriter, resp *ProxyResponse, c
 		credName = cred.Name
 	}
 
+	if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, resp.Body); ok {
+		resp.StatusCode = mappedStatus
+	}
 	responseBody, responseBodyChanged, responseBodyMasked := clientResponseBodyForCredential(resp.StatusCode, resp.Body, cred, modelID)
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		endpoint := endpointFromRequest(clientReq)

--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"strings"
@@ -28,11 +29,15 @@ func clientResponseBodyForCredential(statusCode int, body []byte, _ *config.Cred
 const maxProxyStreamErrorCaptureBytes = 256 * 1024
 
 // proxyProviderStreamError reports an error event carried by an otherwise
-// successful HTTP/SSE response. The response has already been forwarded to the
-// client, so callers must not try to replace it with another HTTP response; the
-// error exists to drive terminal logging and session semantics.
+// successful HTTP/SSE response. Most instances are detected after the response
+// has already been forwarded to the client, so callers must not try to replace
+// that response. beforeCommit is set only when streamToClient catches the
+// terminal event before writing any downstream byte and has already replaced it
+// with a normal HTTP error response.
 type proxyProviderStreamError struct {
-	payload string
+	payload      string
+	statusCode   int
+	beforeCommit bool
 }
 
 func (e proxyProviderStreamError) Error() string {
@@ -131,6 +136,65 @@ func markProxyProviderStreamError(logCtx *RequestLogContext, statusCode int, pay
 	logCtx.ErrorMsg = payload
 }
 
+func statusCodeFromProviderStreamError(payload string) int {
+	var evt struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+		Response struct {
+			Status string `json:"status"`
+			Error  struct {
+				Type    string `json:"type"`
+				Code    string `json:"code"`
+				Message string `json:"message"`
+			} `json:"error"`
+		} `json:"response"`
+	}
+	if err := json.Unmarshal([]byte(payload), &evt); err != nil {
+		return http.StatusBadGateway
+	}
+
+	signals := []string{
+		evt.Error.Code,
+		evt.Error.Type,
+		evt.Error.Message,
+		evt.Response.Error.Code,
+		evt.Response.Error.Type,
+		evt.Response.Error.Message,
+		evt.Type,
+	}
+	for _, signal := range signals {
+		signal = strings.ToLower(strings.TrimSpace(signal))
+		switch {
+		case signal == "":
+			continue
+		case strings.Contains(signal, "rate_limit") || strings.Contains(signal, "too_many_requests"):
+			return http.StatusTooManyRequests
+		case strings.Contains(signal, "timeout"):
+			return http.StatusRequestTimeout
+		case strings.Contains(signal, "overloaded") || strings.Contains(signal, "service_unavailable"):
+			return http.StatusServiceUnavailable
+		case strings.Contains(signal, "server_error") || strings.Contains(signal, "internal"):
+			return http.StatusInternalServerError
+		}
+	}
+	return http.StatusBadGateway
+}
+
+func writeProviderStreamErrorBeforeCommit(w http.ResponseWriter, statusCode int) {
+	body := maskedUpstreamErrorBody(statusCode)
+	header := w.Header()
+	header.Set("Content-Type", "application/json")
+	header.Set("Content-Length", itoa(len(body)))
+	header.Del(accelBufferingHeader)
+	dropRepresentationIntegrityHeaders(header)
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(body)
+}
+
 // resolveCapturedProviderStreamError finalizes one or more bounded stream
 // observers after every upstream byte has already been forwarded. Raw provider
 // and transformed-output observers may both be supplied; the first decoded
@@ -146,6 +210,11 @@ func resolveCapturedProviderStreamError(
 		return streamErr
 	}
 
+	var earlyErr proxyProviderStreamError
+	if err, ok := streamErr.(proxyProviderStreamError); ok && err.beforeCommit {
+		earlyErr = err
+	}
+
 	payload := ""
 	for _, capture := range captures {
 		if capture == nil {
@@ -155,13 +224,19 @@ func resolveCapturedProviderStreamError(
 			payload = captured
 		}
 	}
+	if payload == "" && earlyErr.payload != "" {
+		payload = earlyErr.payload
+	}
 	if payload == "" {
 		return streamErr
 	}
 
+	if earlyErr.statusCode >= http.StatusBadRequest {
+		statusCode = earlyErr.statusCode
+	}
 	markProxyProviderStreamError(logCtx, statusCode, payload)
 	if streamErr == nil {
-		return proxyProviderStreamError{payload: payload}
+		return proxyProviderStreamError{payload: payload, statusCode: statusCode}
 	}
 	return streamErr
 }
@@ -326,8 +401,6 @@ func (p *Proxy) writeProxyStreamingResponseWithTokens(
 	}
 	setSuccessfulSSEHeaders(w.Header(), resp.StatusCode)
 
-	w.WriteHeader(resp.StatusCode)
-
 	var lastUsage *converter.TokenUsage
 	completion := p.newCompletionTokenAccumulator(tokenizerModelID)
 	var payloadBuf [][]byte
@@ -387,6 +460,7 @@ func (p *Proxy) writeProxyStreamingResponseWithTokens(
 			credName,
 			modelID,
 			endpointFromRequest(clientReq),
+			resp.StatusCode,
 			onChunk,
 			nil,
 			logCtx,

--- a/internal/proxy/response_writer_terminal_error_test.go
+++ b/internal/proxy/response_writer_terminal_error_test.go
@@ -19,6 +19,7 @@ func TestWriteProxyStreamingResponseWithTokensDetectsFragmentedProviderTerminalE
 		name       string
 		chunks     []string
 		wantMarker string
+		wantStatus int
 		masked     bool
 	}{
 		{
@@ -31,6 +32,7 @@ func TestWriteProxyStreamingResponseWithTokensDetectsFragmentedProviderTerminalE
 				"data: [DONE]\n\n",
 			},
 			wantMarker: "provider exploded",
+			wantStatus: http.StatusOK,
 			masked:     true,
 		},
 		{
@@ -42,16 +44,19 @@ func TestWriteProxyStreamingResponseWithTokensDetectsFragmentedProviderTerminalE
 				`pe":"error","error":{"type":"overloaded_error","message":"anthropic overloaded"}}` + "\r\n\r\n",
 			},
 			wantMarker: "anthropic overloaded",
+			wantStatus: http.StatusServiceUnavailable,
 			masked:     true,
 		},
 		{
 			name: "responses failed event",
 			chunks: []string{
 				`data: {"type":"response.`,
-				`failed","response":{"id":"resp_1","status":"failed"}}` + "\n",
+				`failed","response":{"id":"resp_1","status":"failed","error":{"code":"rate_limit_exceeded","message":"Request failed"}}}` + "\n",
 				"\n",
 			},
-			wantMarker: "response.failed",
+			wantMarker: "rate_limit_exceeded",
+			wantStatus: http.StatusTooManyRequests,
+			masked:     true,
 		},
 	}
 
@@ -97,20 +102,69 @@ func TestWriteProxyStreamingResponseWithTokensDetectsFragmentedProviderTerminalE
 
 			var terminalErr proxyProviderStreamError
 			require.ErrorAs(t, err, &terminalErr)
-			assert.Equal(t, http.StatusOK, w.Code, "the already-started client response keeps its HTTP status")
+			assert.Equal(t, tt.wantStatus, w.Code)
 			if tt.masked {
-				assert.Contains(t, w.Body.String(), "Request failed")
+				if tt.wantStatus == http.StatusTooManyRequests {
+					assert.Contains(t, w.Body.String(), "Rate limit exceeded")
+					assert.Contains(t, w.Body.String(), "rate_limit_error")
+				} else {
+					assert.Contains(t, w.Body.String(), "Request failed")
+				}
 				assert.NotContains(t, w.Body.String(), tt.wantMarker)
 			} else {
 				assert.Equal(t, streamBody, w.Body.String())
 			}
 			assert.Equal(t, "failure", logCtx.Status)
-			assert.Equal(t, http.StatusOK, logCtx.HTTPStatus)
+			assert.Equal(t, tt.wantStatus, logCtx.HTTPStatus)
 			assert.Equal(t, "stream_error", logCtx.StreamOutcome)
 			assert.Contains(t, logCtx.ErrorMsg, tt.wantMarker)
 
 		})
 	}
+}
+
+func TestWriteProxyStreamingResponseWithTokensKeepsStatusAfterStreamCommitted(t *testing.T) {
+	chunks := []string{
+		`data: {"id":"chatcmpl-1","choices":[{"delta":{"content":"partial"}}]}` + "\n\n",
+		`data: {"error":{"message":"provider exploded","type":"server_error"}}` + "\n\n",
+	}
+	prx := NewTestProxyBuilder().Build()
+	proxyResp := &ProxyResponse{
+		StatusCode: http.StatusOK,
+		Headers: http.Header{
+			"Content-Type": {"text/event-stream"},
+		},
+		StreamBody:  &fragmentedStreamReadCloser{chunks: stringChunks(chunks)},
+		IsStreaming: true,
+	}
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	logCtx := &RequestLogContext{
+		RequestID:   "event-terminal-error-after-content",
+		StartTime:   time.Now().UTC(),
+		Request:     request,
+		Status:      "unknown",
+		Credential:  &config.CredentialConfig{Name: "proxy-upstream"},
+		ModelID:     "gpt-4o-mini",
+		RealModelID: "gpt-4o-mini",
+	}
+	w := httptest.NewRecorder()
+
+	_, err := prx.writeProxyStreamingResponseWithTokens(
+		w,
+		proxyResp,
+		request,
+		logCtx.Credential,
+		logCtx.ModelID,
+		logCtx.RealModelID,
+		logCtx,
+	)
+
+	var terminalErr proxyProviderStreamError
+	require.ErrorAs(t, err, &terminalErr)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "partial")
+	assert.Contains(t, w.Body.String(), "Request failed")
+	assert.Equal(t, http.StatusOK, logCtx.HTTPStatus)
 }
 
 func TestWriteProxyStreamingResponseWithTokensKeepsNormalFragmentedStreamSuccessful(t *testing.T) {

--- a/internal/proxy/response_writer_terminal_error_test.go
+++ b/internal/proxy/response_writer_terminal_error_test.go
@@ -211,6 +211,61 @@ func TestProxyStreamErrorCaptureFinalizesFragmentedBareJSON(t *testing.T) {
 	assert.Contains(t, capture.Finalize(), "bare failure")
 }
 
+func TestStatusCodeFromProviderBodyError(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		body       string
+		wantStatus int
+		wantOK     bool
+	}{
+		{
+			name:       "top level rate limit error",
+			statusCode: http.StatusOK,
+			body:       `{"error":{"code":"rate_limit_exceeded","message":"Request failed"}}`,
+			wantStatus: http.StatusTooManyRequests,
+			wantOK:     true,
+		},
+		{
+			name:       "failed responses object",
+			statusCode: http.StatusOK,
+			body:       `{"id":"resp_1","status":"failed","error":{"code":"server_error","message":"Request failed"}}`,
+			wantStatus: http.StatusInternalServerError,
+			wantOK:     true,
+		},
+		{
+			name:       "nested failed response event body",
+			statusCode: http.StatusOK,
+			body:       `{"type":"response.failed","response":{"status":"failed","error":{"code":"rate_limit_exceeded"}}}`,
+			wantStatus: http.StatusTooManyRequests,
+			wantOK:     true,
+		},
+		{
+			name:       "normal success",
+			statusCode: http.StatusOK,
+			body:       `{"id":"chatcmpl-1","choices":[{"message":{"content":"ok"}}]}`,
+			wantOK:     false,
+		},
+		{
+			name:       "real error status not remapped",
+			statusCode: http.StatusBadGateway,
+			body:       `{"error":{"code":"rate_limit_exceeded"}}`,
+			wantOK:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotStatus, gotOK := statusCodeFromProviderBodyError(tt.statusCode, []byte(tt.body))
+
+			assert.Equal(t, tt.wantOK, gotOK)
+			if tt.wantOK {
+				assert.Equal(t, tt.wantStatus, gotStatus)
+			}
+		})
+	}
+}
+
 type fragmentedStreamReadCloser struct {
 	chunks [][]byte
 	index  int

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -1118,7 +1118,7 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 		logCtx.UsageSource = "estimated"
 	}
 
-	if !(logCtx.StreamOutcome == "stream_error" && logCtx.HTTPStatus >= http.StatusBadRequest) {
+	if logCtx.StreamOutcome != "stream_error" || logCtx.HTTPStatus < http.StatusBadRequest {
 		logCtx.HTTPStatus = statusCode
 	}
 	if logCtx.StreamOutcome == "client_aborted" || logCtx.StreamOutcome == "stream_error" {
@@ -1487,7 +1487,6 @@ func (p *Proxy) streamToClient(
 				if payload := initialCommit.FinalizeTerminalError(); payload != "" {
 					return writeEarlyStreamError(payload)
 				}
-				committed = true
 				if writeErr := writeStreamChunk(initialCommit.Release()); writeErr != nil {
 					return writeErr
 				}

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -38,6 +38,13 @@ const streamDrainTimeout = 60 * time.Second
 // stays zero, matching existing "never reached" semantics.
 const streamTTFTDetectionLimit = 64 * 1024
 
+// streamInitialCommitBufferLimit bounds how much of a successful upstream SSE
+// response we hold before committing downstream headers. This small preflight
+// window lets an immediate terminal SSE error (for example response.failed with
+// rate_limit_exceeded) become a real HTTP error status instead of an HTTP 200
+// stream whose first body event is failure.
+const streamInitialCommitBufferLimit = 64 * 1024
+
 // ttftScanState incrementally scans SSE lines for the first detectable content
 // delta, byte-for-byte equivalent to calling extractCompletionDeltaText on the
 // whole buffer accumulated so far after every Read — but each byte is scanned
@@ -809,7 +816,7 @@ func (p *Proxy) handleTransformedStreaming(
 		}
 	}()
 
-	if err := p.streamToClient(respCtx(resp), w, clientReader, credName, metricModelID(modelID, logCtx), endpointFromLogContext(logCtx), nil, func() { _ = pr.Close() }, logCtx); err != nil {
+	if err := p.streamToClient(respCtx(resp), w, clientReader, credName, metricModelID(modelID, logCtx), endpointFromLogContext(logCtx), resp.StatusCode, nil, func() { _ = pr.Close() }, logCtx); err != nil {
 		p.logStreamHandlerError(respCtx(resp), "streamToClient error in handleTransformedStreaming", err,
 			"credential", credName, "provider", providerName, "model", modelID)
 		wg.Wait()
@@ -922,7 +929,7 @@ func (p *Proxy) handleStreamingWithTokens(w http.ResponseWriter, resp *http.Resp
 		logCtx,
 		modelID,
 	)
-	if err := p.streamToClient(respCtx(resp), w, clientReader, credName, metricModelID(modelID, logCtx), endpointFromLogContext(logCtx), onChunk, nil, logCtx); err != nil {
+	if err := p.streamToClient(respCtx(resp), w, clientReader, credName, metricModelID(modelID, logCtx), endpointFromLogContext(logCtx), resp.StatusCode, onChunk, nil, logCtx); err != nil {
 		p.logStreamHandlerError(respCtx(resp), "streamToClient error in handleStreamingWithTokens", err,
 			"credential", credName, "model", modelID, "chunks_received", chunkCount)
 		if p.drainUpstreamOnAbort {
@@ -1111,7 +1118,9 @@ func (p *Proxy) finalizeStreamingLog(logCtx *RequestLogContext, totalTokens int,
 		logCtx.UsageSource = "estimated"
 	}
 
-	logCtx.HTTPStatus = statusCode
+	if !(logCtx.StreamOutcome == "stream_error" && logCtx.HTTPStatus >= http.StatusBadRequest) {
+		logCtx.HTTPStatus = statusCode
+	}
 	if logCtx.StreamOutcome == "client_aborted" || logCtx.StreamOutcome == "stream_error" {
 		logCtx.Status = "failure"
 		if logCtx.StreamOutcome == "client_aborted" {
@@ -1266,6 +1275,55 @@ func (p *Proxy) drainUpstream(ctx context.Context, body io.Reader, onChunk func(
 	}
 }
 
+type streamInitialCommitGate struct {
+	pending []byte
+	capture proxyStreamErrorCapture
+}
+
+func (g *streamInitialCommitGate) Observe(chunk []byte) (payload string, ready bool) {
+	if len(chunk) == 0 {
+		return "", false
+	}
+	g.pending = append(g.pending, chunk...)
+	if payload := g.capture.Observe(chunk); payload != "" {
+		return payload, false
+	}
+	if len(g.pending) > streamInitialCommitBufferLimit {
+		return "", true
+	}
+
+	trimmed := bytes.TrimSpace(g.pending)
+	if len(trimmed) == 0 {
+		return "", false
+	}
+	if looksLikeEventStream(trimmed) {
+		return "", nextSSEFrameEnd(g.pending) >= 0
+	}
+	if frameMayCarryStreamError(trimmed) {
+		if payload := extractStreamErrorEvent(trimmed); payload != "" {
+			return payload, false
+		}
+	}
+	return "", true
+}
+
+func (g *streamInitialCommitGate) FinalizeTerminalError() string {
+	if payload := g.capture.Finalize(); payload != "" {
+		return payload
+	}
+	trimmed := bytes.TrimSpace(g.pending)
+	if frameMayCarryStreamError(trimmed) {
+		return extractStreamErrorEvent(trimmed)
+	}
+	return ""
+}
+
+func (g *streamInitialCommitGate) Release() []byte {
+	pending := g.pending
+	g.pending = nil
+	return pending
+}
+
 func (p *Proxy) streamToClient(
 	ctx context.Context,
 	w http.ResponseWriter,
@@ -1273,6 +1331,7 @@ func (p *Proxy) streamToClient(
 	credName string,
 	modelID string,
 	endpoint string,
+	statusCode int,
 	onChunk func([]byte),
 	onWriteErr func(),
 	logCtx *RequestLogContext,
@@ -1313,13 +1372,83 @@ func (p *Proxy) streamToClient(
 	// here; see TestStreamToClient_FlushesTailOnMidStreamPause.
 	flushPending := false
 	var responseIDScanner clientResponseIDScanner
+	if statusCode == 0 {
+		statusCode = http.StatusOK
+	}
+	preflightEnabled := statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices
+	committed := !preflightEnabled
+	if !preflightEnabled {
+		w.WriteHeader(statusCode)
+	}
+	var initialCommit streamInitialCommitGate
+
+	writeStreamChunk := func(chunk []byte) error {
+		if len(chunk) == 0 {
+			return nil
+		}
+		// Set write deadline before each write — keeps active streams alive,
+		// terminates if client stops reading for streamChunkWriteTimeout.
+		_ = controller.SetWriteDeadline(time.Now().Add(streamChunkWriteTimeout))
+		if _, writeErr := w.Write(chunk); writeErr != nil {
+			if isClientDisconnectError(writeErr) {
+				p.logger.DebugContext(ctx, "Client disconnected during streaming", "error", writeErr, "credential", credName)
+				p.recordAbortedRequest(credName, endpoint, modelID)
+			} else {
+				p.logger.ErrorContext(ctx, "Failed to write streaming chunk", "error", writeErr, "credential", credName)
+			}
+			if onWriteErr != nil {
+				onWriteErr()
+			}
+			return writeErr
+		}
+		// Coalesce flushes within streamFlushCoalesceWindow: always flush the
+		// first chunk (TTFT); in between, skip a flush if the previous one was
+		// very recent — bursty reads (e.g. an upstream that batches several SSE
+		// frames per write) then cost one syscall, not N. Whatever gets skipped
+		// here is guaranteed to be flushed before this function returns (see
+		// the unconditional flushPending check below) — do NOT rely on "err !=
+		// nil" to force a flush from inside this block: a terminal Read()
+		// commonly returns (0, io.EOF), which never enters "if n > 0" at all.
+		now := time.Now()
+		if lastFlush.IsZero() || now.Sub(lastFlush) >= streamFlushCoalesceWindow {
+			if flushErr := p.flushStreaming(ctx, controller, credName); flushErr != nil {
+				if isClientDisconnectError(flushErr) {
+					p.logger.DebugContext(ctx, "Client disconnected during streaming flush", "error", flushErr, "credential", credName)
+					p.recordAbortedRequest(credName, endpoint, modelID)
+				}
+				if onWriteErr != nil {
+					onWriteErr()
+				}
+				return flushErr
+			}
+			lastFlush = now
+			flushPending = false
+		} else {
+			flushPending = true
+		}
+		return nil
+	}
+
+	writeEarlyStreamError := func(payload string) error {
+		statusCode := statusCodeFromProviderStreamError(payload)
+		markProxyProviderStreamError(logCtx, statusCode, payload)
+		if logCtx != nil {
+			logCtx.StreamOutcome = "stream_error"
+		}
+		writeProviderStreamErrorBeforeCommit(w, statusCode)
+		if onWriteErr != nil {
+			onWriteErr()
+		}
+		return proxyProviderStreamError{payload: payload, statusCode: statusCode, beforeCommit: true}
+	}
 
 	for {
 		n, err := reader.Read(*buf)
 		if n > 0 {
-			responseIDScanner.observe(logCtx, (*buf)[:n])
+			chunk := (*buf)[:n]
+			responseIDScanner.observe(logCtx, chunk)
 			if ttftPending {
-				if ttftScan.observe((*buf)[:n]) {
+				if ttftScan.observe(chunk) {
 					logCtx.CompletionStartTime = time.Now()
 					ttftPending = false
 				} else if ttftScan.total > streamTTFTDetectionLimit {
@@ -1330,50 +1459,39 @@ func (p *Proxy) streamToClient(
 				}
 			}
 			if onChunk != nil {
-				onChunk((*buf)[:n])
+				onChunk(chunk)
 			}
-			// Set write deadline before each write — keeps active streams alive,
-			// terminates if client stops reading for streamChunkWriteTimeout.
-			_ = controller.SetWriteDeadline(time.Now().Add(streamChunkWriteTimeout))
-			if _, writeErr := w.Write((*buf)[:n]); writeErr != nil {
-				if isClientDisconnectError(writeErr) {
-					p.logger.DebugContext(ctx, "Client disconnected during streaming", "error", writeErr, "credential", credName)
-					p.recordAbortedRequest(credName, endpoint, modelID)
+
+			if !committed {
+				payload, ready := initialCommit.Observe(chunk)
+				if payload != "" {
+					return writeEarlyStreamError(payload)
+				}
+				if !ready {
+					if err == nil {
+						continue
+					}
 				} else {
-					p.logger.ErrorContext(ctx, "Failed to write streaming chunk", "error", writeErr, "credential", credName)
+					chunk = initialCommit.Release()
+					committed = true
 				}
-				if onWriteErr != nil {
-					onWriteErr()
-				}
-				return writeErr
 			}
-			// Coalesce flushes within streamFlushCoalesceWindow: always flush the
-			// first chunk (TTFT); in between, skip a flush if the previous one was
-			// very recent — bursty reads (e.g. an upstream that batches several SSE
-			// frames per write) then cost one syscall, not N. Whatever gets skipped
-			// here is guaranteed to be flushed before this function returns (see
-			// the unconditional flushPending check below) — do NOT rely on "err !=
-			// nil" to force a flush from inside this block: a terminal Read()
-			// commonly returns (0, io.EOF), which never enters "if n > 0" at all.
-			now := time.Now()
-			if lastFlush.IsZero() || now.Sub(lastFlush) >= streamFlushCoalesceWindow {
-				if flushErr := p.flushStreaming(ctx, controller, credName); flushErr != nil {
-					if isClientDisconnectError(flushErr) {
-						p.logger.DebugContext(ctx, "Client disconnected during streaming flush", "error", flushErr, "credential", credName)
-						p.recordAbortedRequest(credName, endpoint, modelID)
-					}
-					if onWriteErr != nil {
-						onWriteErr()
-					}
-					return flushErr
+			if committed {
+				if writeErr := writeStreamChunk(chunk); writeErr != nil {
+					return writeErr
 				}
-				lastFlush = now
-				flushPending = false
-			} else {
-				flushPending = true
 			}
 		}
 		if err != nil {
+			if !committed {
+				if payload := initialCommit.FinalizeTerminalError(); payload != "" {
+					return writeEarlyStreamError(payload)
+				}
+				committed = true
+				if writeErr := writeStreamChunk(initialCommit.Release()); writeErr != nil {
+					return writeErr
+				}
+			}
 			if flushPending {
 				// No need to clear flushPending here — every path below
 				// returns immediately, so nothing would ever read it again.
@@ -1712,7 +1830,7 @@ func (p *Proxy) handlePassthroughResponsesStreaming(
 		logCtx,
 		modelID,
 	)
-	if err := p.streamToClient(respCtx(resp), w, clientReader, credName, metricModelID(modelID, logCtx), endpointFromLogContext(logCtx), onChunk, nil, logCtx); err != nil {
+	if err := p.streamToClient(respCtx(resp), w, clientReader, credName, metricModelID(modelID, logCtx), endpointFromLogContext(logCtx), resp.StatusCode, onChunk, nil, logCtx); err != nil {
 		p.logStreamHandlerError(respCtx(resp), "streamToClient error in handlePassthroughResponsesStreaming", err,
 			"credential", credName, "model", modelID, "chunks_received", chunkCount)
 		if p.drainUpstreamOnAbort {

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -1473,6 +1473,7 @@ func (p *Proxy) streamToClient(
 					}
 				} else {
 					chunk = initialCommit.Release()
+					w.WriteHeader(statusCode)
 					committed = true
 				}
 			}
@@ -1487,6 +1488,8 @@ func (p *Proxy) streamToClient(
 				if payload := initialCommit.FinalizeTerminalError(); payload != "" {
 					return writeEarlyStreamError(payload)
 				}
+				w.WriteHeader(statusCode)
+				committed = true
 				if writeErr := writeStreamChunk(initialCommit.Release()); writeErr != nil {
 					return writeErr
 				}

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -1489,7 +1489,6 @@ func (p *Proxy) streamToClient(
 					return writeEarlyStreamError(payload)
 				}
 				w.WriteHeader(statusCode)
-				committed = true
 				if writeErr := writeStreamChunk(initialCommit.Release()); writeErr != nil {
 					return writeErr
 				}

--- a/internal/proxy/stream_abort_test.go
+++ b/internal/proxy/stream_abort_test.go
@@ -54,7 +54,7 @@ func TestStreamToClient_RecordAbortedMetric(t *testing.T) {
 	prx.metrics = monitoring.New(true)
 
 	w := newFailAfterNBytesWriter(0)
-	err := prx.streamToClient(context.Background(), w, strings.NewReader("data: hello\n\n"), "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, nil)
+	err := prx.streamToClient(context.Background(), w, strings.NewReader("data: hello\n\n"), "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, nil)
 	require.Error(t, err)
 
 	assert.Equal(t, 1.0, testutil.ToFloat64(monitoring.AbortedRequestsTotal.WithLabelValues("cred1", "gpt-4o", "/v1/chat/completions")))
@@ -83,9 +83,7 @@ func TestStreamToClientPropagatesUnexpectedReadError(t *testing.T) {
 		"cred1",
 		"gpt-4o",
 		"/v1/chat/completions",
-		nil,
-		nil,
-		nil,
+		http.StatusOK, nil, nil, nil,
 	)
 
 	require.ErrorIs(t, err, io.ErrUnexpectedEOF)

--- a/internal/proxy/stream_flush_test.go
+++ b/internal/proxy/stream_flush_test.go
@@ -78,7 +78,7 @@ func TestStreamToClient_FlushesTailOnEOF(t *testing.T) {
 		delay: time.Millisecond,
 	}
 
-	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, nil)
+	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, nil)
 	require.NoError(t, err)
 
 	written, flushed := w.snapshot()
@@ -124,7 +124,7 @@ func TestStreamToClient_FlushesTailOnMidStreamPause(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, nil)
+		done <- prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, nil)
 	}()
 
 	// Sample mid-pause, well after "first" was written (~1ms in) but well

--- a/internal/proxy/stream_status_commit_test.go
+++ b/internal/proxy/stream_status_commit_test.go
@@ -1,0 +1,120 @@
+package proxy
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// statusTrackingWriter records every WriteHeader call (unlike
+// httptest.ResponseRecorder, whose Code field defaults to 200 whether
+// WriteHeader was ever called or not — indistinguishable from an implicit
+// 200, which is exactly the bug these tests guard against).
+type statusTrackingWriter struct {
+	header      http.Header
+	body        strings.Builder
+	statusCalls []int
+}
+
+func (w *statusTrackingWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *statusTrackingWriter) Write(p []byte) (int, error) {
+	return w.body.Write(p)
+}
+
+func (w *statusTrackingWriter) WriteHeader(statusCode int) {
+	w.statusCalls = append(w.statusCalls, statusCode)
+}
+
+func (w *statusTrackingWriter) Flush() {}
+
+// TestStreamToClient_NonStandard2xxStatusIsCommitted is a regression test:
+// streamToClient used to rely entirely on Go's implicit WriteHeader(200) on
+// first Write() to commit the response, so a genuine non-200 2xx upstream
+// status (e.g. 201/202/204) was silently downgraded to 200 for the client.
+func TestStreamToClient_NonStandard2xxStatusIsCommitted(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	w := &statusTrackingWriter{}
+	reader := strings.NewReader(`data: {"choices":[{"delta":{"content":"hi"}}]}` + "\n\n")
+
+	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusAccepted, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Len(t, w.statusCalls, 1, "streamToClient must explicitly commit the real upstream status exactly once")
+	assert.Equal(t, http.StatusAccepted, w.statusCalls[0])
+}
+
+// TestStreamToClient_NonStandard2xxStatusIsCommittedOnImmediateEOF covers the
+// other commit path: an upstream that returns a non-200 2xx and then an empty
+// body (immediate EOF, nothing ever buffered past the initial commit gate).
+func TestStreamToClient_NonStandard2xxStatusIsCommittedOnImmediateEOF(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	w := &statusTrackingWriter{}
+	reader := strings.NewReader("")
+
+	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusNoContent, nil, nil, nil)
+	require.NoError(t, err)
+
+	require.Len(t, w.statusCalls, 1)
+	assert.Equal(t, http.StatusNoContent, w.statusCalls[0])
+}
+
+// nonFlushingWriter deliberately does NOT implement http.Flusher, exercising
+// writeProxyStreamingResponseWithTokens's non-flushing io.Copy fallback path.
+type nonFlushingWriter struct {
+	header      http.Header
+	body        strings.Builder
+	statusCalls []int
+}
+
+func (w *nonFlushingWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = make(http.Header)
+	}
+	return w.header
+}
+
+func (w *nonFlushingWriter) Write(p []byte) (int, error) {
+	return w.body.Write(p)
+}
+
+func (w *nonFlushingWriter) WriteHeader(statusCode int) {
+	w.statusCalls = append(w.statusCalls, statusCode)
+}
+
+// TestWriteProxyStreamingResponseWithTokens_NonFlushingFallbackCommitsStatus
+// is a regression test: the non-flushing io.Copy fallback branch used to
+// never call WriteHeader at all, so Go implicitly sent 200 on the first
+// Write() regardless of the real upstream/error status.
+func TestWriteProxyStreamingResponseWithTokens_NonFlushingFallbackCommitsStatus(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	w := &nonFlushingWriter{}
+
+	proxyResp := &ProxyResponse{
+		StatusCode:  http.StatusTooManyRequests,
+		Headers:     http.Header{"Content-Type": {"application/json"}},
+		StreamBody:  io.NopCloser(strings.NewReader(`{"error":{"message":"rate limited"}}`)),
+		IsStreaming: true,
+	}
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	credential := &config.CredentialConfig{Name: "cred1", Type: config.ProviderTypeOpenAI, BaseURL: "https://api.invalid"}
+	logCtx := &RequestLogContext{Request: request, Credential: credential}
+
+	_, err := prx.writeProxyStreamingResponseWithTokens(w, proxyResp, request, credential, "gpt-4o", "gpt-4o", logCtx)
+	require.NoError(t, err)
+
+	require.Len(t, w.statusCalls, 1, "non-flushing fallback must explicitly commit the real upstream status")
+	assert.Equal(t, http.StatusTooManyRequests, w.statusCalls[0])
+}

--- a/internal/proxy/stream_terminal_error_test.go
+++ b/internal/proxy/stream_terminal_error_test.go
@@ -23,7 +23,7 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 		"data: [DONE]\n\n"
 	outputErrorChunks := []string{
 		`data: {"type":"response.`,
-		`failed","response":{"id":"resp-output-failed","status":"failed"}}` + "\n\n",
+		`failed","response":{"id":"resp-output-failed","status":"failed","error":{"code":"rate_limit_exceeded","message":"Request failed"}}}` + "\n\n",
 	}
 
 	tests := []struct {
@@ -32,6 +32,7 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 		input      []string
 		wantBody   string
 		wantMarker string
+		wantStatus int
 		masked     bool
 	}{
 		{
@@ -42,6 +43,7 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 			input:      terminalChunks,
 			wantBody:   strings.Join(terminalChunks, ""),
 			wantMarker: "fragmented terminal failure",
+			wantStatus: http.StatusServiceUnavailable,
 			masked:     true,
 		},
 		{
@@ -59,6 +61,7 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 			input:      terminalChunks,
 			wantBody:   normalOutput,
 			wantMarker: "fragmented terminal failure",
+			wantStatus: http.StatusOK,
 		},
 		{
 			name: "transformed stream observes fragmented emitted failure",
@@ -78,7 +81,9 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 			},
 			input:      []string{"data: [DONE]\n\n"},
 			wantBody:   strings.Join(outputErrorChunks, ""),
-			wantMarker: "response.failed",
+			wantMarker: "rate_limit_exceeded",
+			wantStatus: http.StatusTooManyRequests,
+			masked:     true,
 		},
 	}
 
@@ -109,13 +114,18 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 			var terminalErr proxyProviderStreamError
 			require.ErrorAs(t, err, &terminalErr)
 			if tt.masked {
-				assert.Contains(t, w.Body.String(), "Request failed")
+				if tt.wantStatus == http.StatusTooManyRequests {
+					assert.Contains(t, w.Body.String(), "Rate limit exceeded")
+					assert.Contains(t, w.Body.String(), "rate_limit_error")
+				} else {
+					assert.Contains(t, w.Body.String(), "Request failed")
+				}
 				assert.NotContains(t, w.Body.String(), tt.wantMarker)
 			} else {
 				assert.Equal(t, tt.wantBody, w.Body.String())
 			}
 			assert.Equal(t, "failure", logCtx.Status)
-			assert.Equal(t, http.StatusOK, logCtx.HTTPStatus)
+			assert.Equal(t, tt.wantStatus, logCtx.HTTPStatus)
 			assert.Equal(t, "stream_error", logCtx.StreamOutcome)
 			assert.Contains(t, logCtx.ErrorMsg, tt.wantMarker)
 		})

--- a/internal/proxy/stream_ttft_test.go
+++ b/internal/proxy/stream_ttft_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -49,7 +50,7 @@ func TestStreamToClient_CapturesTTFT(t *testing.T) {
 			`data: {"choices":[{"delta":{"content":" world"}}]}` + "\n\n",
 	)
 
-	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, logCtx)
+	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, logCtx)
 	require.NoError(t, err)
 
 	assert.False(t, logCtx.CompletionStartTime.IsZero(), "CompletionStartTime should be set after a real content delta")
@@ -76,7 +77,7 @@ func TestStreamToClient_TTFTIgnoresContentFreeDeltas(t *testing.T) {
 		},
 	}
 
-	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, logCtx)
+	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, logCtx)
 	require.NoError(t, err)
 
 	require.False(t, logCtx.CompletionStartTime.IsZero(), "CompletionStartTime should be set once real content arrives")
@@ -95,7 +96,7 @@ func TestStreamToClient_TTFTNotOverwrittenOnSubsequentChunks(t *testing.T) {
 	logCtx := &RequestLogContext{StartTime: preset.Add(-time.Minute), CompletionStartTime: preset}
 	reader := strings.NewReader(`data: {"choices":[{"delta":{"content":"hello"}}]}` + "\n\n")
 
-	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, logCtx)
+	err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, logCtx)
 	require.NoError(t, err)
 
 	assert.Equal(t, preset, logCtx.CompletionStartTime, "an already-set CompletionStartTime must not be overwritten")
@@ -110,7 +111,7 @@ func TestStreamToClient_NilLogCtx(t *testing.T) {
 	reader := strings.NewReader("data: hello\n\n")
 
 	assert.NotPanics(t, func() {
-		err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", nil, nil, nil)
+		err := prx.streamToClient(context.Background(), w, reader, "cred1", "gpt-4o", "/v1/chat/completions", http.StatusOK, nil, nil, nil)
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
Summary
- Return HTTP error status for immediate terminal SSE failures before committing stream headers
- Map HTTP 200 JSON error bodies to HTTP error status before retry, metrics, masking, and logging
- Preserve HTTP 200 for terminal stream failures after content has already been sent

Tests
- go test ./...