### PR TITLE
Add organization policy support

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -176,6 +176,18 @@ func main() {
 	if litellmDBManager.IsEnabled() {
 		applyInitialDBModelTable(context.Background(), litellmDBManager, staticCreds, bal, modelManager, rateLimiter, priceRegistry, cfg, log)
 	}
+	organizationPolicies, err := models.LoadOrganizationPolicies(cfg.OrganizationPolicies, modelManager, models.OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      cfg.LiteLLMDB.Enabled,
+		LiteLLMDBRequired:     cfg.LiteLLMDB.IsRequired,
+		DisableSpendLogsWrite: cfg.LiteLLMDB.DisableSpendLogsWrite,
+	})
+	if err != nil {
+		log.Error("Failed to load organization policies", "error", err)
+		os.Exit(1)
+	}
+	if !organizationPolicies.Empty() {
+		log.Info("Organization policies loaded", "count", len(cfg.OrganizationPolicies))
+	}
 	tokenManager := auth.NewVertexTokenManager(log)
 	defer tokenManager.Stop()
 
@@ -238,6 +250,7 @@ func main() {
 		KafkaLog:                   kafkaLogManager,
 		HealthChecker:              healthChecker,
 		PriceRegistry:              priceRegistry,
+		OrganizationPolicies:       organizationPolicies,
 		MaxProviderRetries:         cfg.Server.MaxProviderRetries,
 		MaxFallbackAttempts:        cfg.Server.MaxFallbackAttempts,
 		ResponseStore:              respStore,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -176,15 +176,7 @@ func main() {
 	if litellmDBManager.IsEnabled() {
 		applyInitialDBModelTable(context.Background(), litellmDBManager, staticCreds, bal, modelManager, rateLimiter, priceRegistry, cfg, log)
 	}
-	organizationPolicies, err := models.LoadOrganizationPolicies(cfg.OrganizationPolicies, modelManager, models.OrganizationPolicyLoadOptions{
-		LiteLLMDBEnabled:      cfg.LiteLLMDB.Enabled,
-		LiteLLMDBRequired:     cfg.LiteLLMDB.IsRequired,
-		DisableSpendLogsWrite: cfg.LiteLLMDB.DisableSpendLogsWrite,
-	})
-	if err != nil {
-		log.Error("Failed to load organization policies", "error", err)
-		os.Exit(1)
-	}
+	organizationPolicies := loadOrganizationPoliciesOrExit(log, cfg, modelManager)
 	if !organizationPolicies.Empty() {
 		log.Info("Organization policies loaded", "count", len(cfg.OrganizationPolicies))
 	}
@@ -535,6 +527,24 @@ const (
 // defer hasn't bought anything to skip yet (no background work has produced
 // anything worth draining before the listener is even bound), so moving the
 // exit into its own defer-free function is the correct fix, not a workaround.
+// loadOrganizationPoliciesOrExit is its own defer-free function for the same
+// reason as bindOrExit: by this point main holds `defer hybridBackend.Close()`,
+// and gocritic's exitAfterDefer flags any os.Exit that would skip it. A failed
+// policy load is a fatal startup misconfiguration, before any background work
+// worth draining exists.
+func loadOrganizationPoliciesOrExit(log *slog.Logger, cfg *config.Config, modelManager *models.Manager) *models.OrganizationPolicyRegistry {
+	policies, err := models.LoadOrganizationPolicies(cfg.OrganizationPolicies, modelManager, models.OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      cfg.LiteLLMDB.Enabled,
+		LiteLLMDBRequired:     cfg.LiteLLMDB.IsRequired,
+		DisableSpendLogsWrite: cfg.LiteLLMDB.DisableSpendLogsWrite,
+	})
+	if err != nil {
+		log.Error("Failed to load organization policies", "error", err)
+		os.Exit(1)
+	}
+	return policies
+}
+
 func bindOrExit(log *slog.Logger, what string, port int) net.Listener {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -247,6 +247,20 @@ models:
 # accepted_model_alias:
 #   "legacy-gpt-4o-mini": "openai/gpt-4o-mini"
 
+# Optional: organization policy overlay for verified LiteLLM organizations.
+# Requires litellm_db.enabled=true, litellm_db.is_required=true, and
+# litellm_db.disable_spend_logs_write=false. Omit the section to keep legacy
+# global model and pricing behavior.
+# organization_policies:
+#   - organization_id: os.environ/CLOUD_RU_ORGANIZATION_ID
+#     price_profile_id: cloud-ru-2026-09
+#     model_prices_link: /app/organization-prices/cloud-ru-2026-09.json
+#     model_allowlist:
+#       - openai/gpt-5.5-pro
+#       - anthropic/claude-sonnet-4
+#     model_mappings:
+#       openai/gpt-5.5-pro: gpt-5.5-pro
+
 # Optional: Redis/Valkey backend for distributed rate limiting and response storage.
 # When enabled, all replicas share a single counter namespace — RPM/TPM limits are
 # enforced globally across the whole cluster instead of per-pod.

--- a/docs/advanced/model_alias.md
+++ b/docs/advanced/model_alias.md
@@ -226,3 +226,36 @@ A client sending `"model": "haiku"`:
 
 1. `model_alias` resolves `haiku` → `aws/claude-haiku-4.5` (credential lookup uses `aws/claude-haiku-4.5`)
 2. `models[].model` replaces body model field with `global.anthropic.claude-haiku-4-5-20251001-v1:0`
+
+______________________________________________________________________
+
+## Organization Model Policies
+
+`organization_policies` adds a scoped public model surface for verified LiteLLM organizations. It is an overlay on top of the global surface.
+
+```yaml
+organization_policies:
+  - organization_id: os.environ/CLOUD_RU_ORGANIZATION_ID
+    price_profile_id: cloud-ru-2026-09
+    model_prices_link: /app/organization-prices/cloud-ru-2026-09.json
+    model_allowlist:
+      - openai/gpt-5.5-pro
+    model_mappings:
+      openai/gpt-5.5-pro: gpt-5.5-pro
+```
+
+For a mapped organization request AIR keeps separate identifiers:
+
+| Field              | Value                                                     |
+| ------------------ | --------------------------------------------------------- |
+| `PublicModelID`    | Exact model string from the client request                |
+| `CanonicalModelID` | Organization mapping target or global canonical public ID |
+| `ModelID`          | Final routable AIR ID after global `model_alias`          |
+| `RealModelID`      | Provider-facing model ID                                  |
+| `PriceModelID`     | Exact public model ID from the client request             |
+
+An organization mapping shadows every global meaning of the same request ID only for that organization. The mapping target must be a direct active route or one active global `model_alias` key. It cannot target another organization entry, `public_model_alias`, or `accepted_model_alias`.
+
+`model_allowlist` controls the effective organization surface. When omitted, AIR exposes the global callable surface plus organization mappings. When present and empty, the organization has no callable models. When present and non-empty, entries are exact public request IDs.
+
+Database model ACLs still run after organization surface admission. For an organization-mapped request, AIR tests the ordered candidate set `PublicModelID`, `CanonicalModelID`, and `ModelID` against the applicable key, team, user, and membership allowlists. A direct request for a canonical or routed target does not inherit permission from an organization public ID.

--- a/docs/advanced/model_alias.md
+++ b/docs/advanced/model_alias.md
@@ -259,3 +259,5 @@ An organization mapping shadows every global meaning of the same request ID only
 `model_allowlist` controls the effective organization surface. When omitted, AIR exposes the global callable surface plus organization mappings. When present and empty, the organization has no callable models. When present and non-empty, entries are exact public request IDs.
 
 Database model ACLs still run after organization surface admission. For an organization-mapped request, AIR tests the ordered candidate set `PublicModelID`, `CanonicalModelID`, and `ModelID` against the applicable key, team, user, and membership allowlists. A direct request for a canonical or routed target does not inherit permission from an organization public ID.
+
+`GET /v1/models?include_model_access_groups=true` returns the same curated organization surface as the plain listing. The provider access-group projection is an administrative view over internal routes and is intentionally suppressed for organization-scoped keys so backend IDs are not re-introduced through a query parameter.

--- a/docs/litellm-integration/litellm_auth.md
+++ b/docs/litellm-integration/litellm_auth.md
@@ -57,6 +57,22 @@ sequenceDiagram
 - Cache invalidation is TTL-only (`auth_cache_ttl`, default 5s). There is no push invalidation from LiteLLM admin actions (`InvalidateToken`/`InvalidateAll` exist but nothing calls them yet) — a blocked/rebudgeted key can stay valid in a hot cache for up to `auth_cache_ttl`.
 - The cache is per-instance, not shared across replicas.
 
+### Verified organization policy identity
+
+When `organization_policies` is configured, AIR selects policy identity only from verified LiteLLM database relationships. Request headers and request body metadata cannot select an organization.
+
+Selection order:
+
+1. Direct `LiteLLM_VerificationToken.organization_id`.
+2. Team organization from an existing `LiteLLM_TeamTable` row when the direct organization is absent.
+3. No organization policy.
+
+A configured direct organization never falls back to the team organization. If the selected configured organization is dangling, AIR returns `403 Forbidden` before credential selection and spend logging. An unmatched dangling organization keeps legacy behavior.
+
+For mapped team fallback requests, AIR writes the effective organization into budget and rate-limit entities, SpendLog organization fields, Kafka `organization_id`, and organization aggregate projections. Unmapped requests keep the legacy direct-only accounting identity.
+
+AIR does not propagate organization policy identity through AIR scope headers. A downstream AIR hop authenticated with the master key remains audit-only and does not select an organization policy.
+
 ## 2. Model resolution + allow-list + budget/rate-limit enforcement (`orchestrateRequest`)
 
 Once auth succeeds, the body is parsed and the model alias resolved to its real provider-facing name, then three checks run in order.

--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -28,6 +28,29 @@ Accepted values for `model_prices_link`:
 
 The file must be valid JSON and must not exceed 100 MB.
 
+## Organization Price Profiles
+
+`organization_policies` can bind a verified LiteLLM organization to an immutable USD tariff profile. These profiles use the same source schemes, size limit, and timeout behavior as `server.model_prices_link`, but they are loaded synchronously during startup and are not refreshed until process restart.
+
+```yaml
+organization_policies:
+  - organization_id: os.environ/CLOUD_RU_ORGANIZATION_ID
+    price_profile_id: cloud-ru-2026-09
+    model_prices_link: /app/organization-prices/cloud-ru-2026-09.json
+    model_allowlist:
+      - openai/gpt-5.5-pro
+    model_mappings:
+      openai/gpt-5.5-pro: gpt-5.5-pro
+```
+
+The section is disabled when omitted. When present, it requires `litellm_db.enabled: true`, `litellm_db.is_required: true`, and `litellm_db.disable_spend_logs_write: false`.
+
+Organization profile lookup is exact and case-sensitive. AIR prices mapped requests by the raw public model ID from the client request. It does not fall back to the default registry, database prices, canonical IDs, routed IDs, real provider IDs, or normalized names.
+
+The organization tariff JSON is strict. Duplicate exact keys, unknown row fields, `null` rows, and empty price objects fail startup. An explicit free model must still include at least one recognized price field with a zero value.
+
+When `model_allowlist` is omitted, the organization sees the global callable surface plus organization mapping keys, subject to exact profile prices in `/v1/models`. A callable request without an exact profile row returns `503` before provider selection. When `model_allowlist` is present and empty, the organization surface is empty. When present and non-empty, every listed ID must be routable and have an exact profile row at startup.
+
 ### Refresh interval
 
 Prices are read once at startup and then re-read in the background every `model_prices_sync_interval`. Set it to any Go duration string:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -184,19 +184,20 @@ func (m *ModelRPMConfig) UnmarshalYAML(value *yaml.Node) error {
 }
 
 type Config struct {
-	Server             ServerConfig       `yaml:"server"`
-	Fail2Ban           Fail2BanConfig     `yaml:"fail2ban,omitempty"`
-	Credentials        []CredentialConfig `yaml:"credentials"`
-	Monitoring         MonitoringConfig   `yaml:"monitoring"`
-	Models             []ModelRPMConfig   `yaml:"models,omitempty"`
-	ModelAlias         map[string]string  `yaml:"model_alias,omitempty"`
-	ClientModelIDs     []string           `yaml:"client_model_ids,omitempty"`
-	PublicModelAlias   map[string]string  `yaml:"public_model_alias,omitempty"`
-	AcceptedModelAlias map[string]string  `yaml:"accepted_model_alias,omitempty"`
-	LiteLLMDB          LiteLLMDBConfig    `yaml:"litellm_db,omitempty"`
-	Redis              RedisConfig        `yaml:"redis,omitempty"`
-	OTEL               OTELConfig         `yaml:"otel,omitempty"`
-	Kafka              KafkaConfig        `yaml:"kafka,omitempty"`
+	Server               ServerConfig               `yaml:"server"`
+	Fail2Ban             Fail2BanConfig             `yaml:"fail2ban,omitempty"`
+	Credentials          []CredentialConfig         `yaml:"credentials"`
+	Monitoring           MonitoringConfig           `yaml:"monitoring"`
+	Models               []ModelRPMConfig           `yaml:"models,omitempty"`
+	ModelAlias           map[string]string          `yaml:"model_alias,omitempty"`
+	ClientModelIDs       []string                   `yaml:"client_model_ids,omitempty"`
+	PublicModelAlias     map[string]string          `yaml:"public_model_alias,omitempty"`
+	AcceptedModelAlias   map[string]string          `yaml:"accepted_model_alias,omitempty"`
+	OrganizationPolicies []OrganizationPolicyConfig `yaml:"organization_policies,omitempty"`
+	LiteLLMDB            LiteLLMDBConfig            `yaml:"litellm_db,omitempty"`
+	Redis                RedisConfig                `yaml:"redis,omitempty"`
+	OTEL                 OTELConfig                 `yaml:"otel,omitempty"`
+	Kafka                KafkaConfig                `yaml:"kafka,omitempty"`
 	// ModelTemplates stores x-model-templates entries as raw interface{} so that
 	// both single-model mappings and lists of models can be defined as YAML anchors
 	// without type errors. The actual model data is extracted via anchor expansion.
@@ -214,20 +215,21 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 
 	// Then unmarshal the resolved data into Config
 	type RawConfig struct {
-		Server             ServerConfig           `yaml:"server"`
-		Fail2Ban           Fail2BanConfig         `yaml:"fail2ban,omitempty"`
-		Credentials        []CredentialConfig     `yaml:"credentials"`
-		Monitoring         MonitoringConfig       `yaml:"monitoring"`
-		Models             []ModelRPMConfig       `yaml:"models,omitempty"`
-		ModelAlias         map[string]string      `yaml:"model_alias,omitempty"`
-		ClientModelIDs     []string               `yaml:"client_model_ids,omitempty"`
-		PublicModelAlias   map[string]string      `yaml:"public_model_alias,omitempty"`
-		AcceptedModelAlias map[string]string      `yaml:"accepted_model_alias,omitempty"`
-		LiteLLMDB          LiteLLMDBConfig        `yaml:"litellm_db,omitempty"`
-		Redis              RedisConfig            `yaml:"redis,omitempty"`
-		OTEL               OTELConfig             `yaml:"otel,omitempty"`
-		Kafka              KafkaConfig            `yaml:"kafka,omitempty"`
-		ModelTemplates     map[string]interface{} `yaml:"x-model-templates,omitempty"`
+		Server               ServerConfig               `yaml:"server"`
+		Fail2Ban             Fail2BanConfig             `yaml:"fail2ban,omitempty"`
+		Credentials          []CredentialConfig         `yaml:"credentials"`
+		Monitoring           MonitoringConfig           `yaml:"monitoring"`
+		Models               []ModelRPMConfig           `yaml:"models,omitempty"`
+		ModelAlias           map[string]string          `yaml:"model_alias,omitempty"`
+		ClientModelIDs       []string                   `yaml:"client_model_ids,omitempty"`
+		PublicModelAlias     map[string]string          `yaml:"public_model_alias,omitempty"`
+		AcceptedModelAlias   map[string]string          `yaml:"accepted_model_alias,omitempty"`
+		OrganizationPolicies []OrganizationPolicyConfig `yaml:"organization_policies,omitempty"`
+		LiteLLMDB            LiteLLMDBConfig            `yaml:"litellm_db,omitempty"`
+		Redis                RedisConfig                `yaml:"redis,omitempty"`
+		OTEL                 OTELConfig                 `yaml:"otel,omitempty"`
+		Kafka                KafkaConfig                `yaml:"kafka,omitempty"`
+		ModelTemplates       map[string]interface{}     `yaml:"x-model-templates,omitempty"`
 	}
 
 	var raw RawConfig
@@ -245,6 +247,7 @@ func (c *Config) UnmarshalYAML(value *yaml.Node) error {
 	c.ClientModelIDs = raw.ClientModelIDs
 	c.PublicModelAlias = raw.PublicModelAlias
 	c.AcceptedModelAlias = raw.AcceptedModelAlias
+	c.OrganizationPolicies = raw.OrganizationPolicies
 	c.LiteLLMDB = raw.LiteLLMDB
 	c.Redis = raw.Redis
 	c.OTEL = raw.OTEL
@@ -1738,6 +1741,10 @@ func (c *Config) Validate() error {
 
 	if len(c.Credentials) == 0 && !c.LiteLLMDB.Enabled {
 		return fmt.Errorf("no credentials configured")
+	}
+
+	if err := ValidateOrganizationPolicies(c.OrganizationPolicies); err != nil {
+		return err
 	}
 
 	// Validate Fail2Ban error code rules for duplicates

--- a/internal/config/organization_policy.go
+++ b/internal/config/organization_policy.go
@@ -1,0 +1,120 @@
+package config
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type OrganizationPolicyConfig struct {
+	OrganizationID  string            `yaml:"organization_id"`
+	PriceProfileID  string            `yaml:"price_profile_id"`
+	ModelPricesLink string            `yaml:"model_prices_link"`
+	ModelAllowlist  []string          `yaml:"model_allowlist,omitempty"`
+	AllowlistSet    bool              `yaml:"-"`
+	ModelMappings   map[string]string `yaml:"model_mappings,omitempty"`
+}
+
+func (p *OrganizationPolicyConfig) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Kind != yaml.MappingNode {
+		return fmt.Errorf("organization policy must be a mapping")
+	}
+
+	allowedFields := map[string]struct{}{
+		"organization_id":   {},
+		"price_profile_id":  {},
+		"model_prices_link": {},
+		"model_allowlist":   {},
+		"model_mappings":    {},
+	}
+
+	var raw struct {
+		OrganizationID  string   `yaml:"organization_id"`
+		PriceProfileID  string   `yaml:"price_profile_id"`
+		ModelPricesLink string   `yaml:"model_prices_link"`
+		ModelAllowlist  []string `yaml:"model_allowlist,omitempty"`
+	}
+	mappings := make(map[string]string)
+
+	for i := 0; i+1 < len(value.Content); i += 2 {
+		key := value.Content[i]
+		field := key.Value
+		if _, ok := allowedFields[field]; !ok {
+			return fmt.Errorf("organization policy: unknown field %q", field)
+		}
+		if field == "model_allowlist" {
+			p.AllowlistSet = true
+		}
+		if field != "model_mappings" {
+			continue
+		}
+		mapNode := value.Content[i+1]
+		if mapNode.Kind != yaml.MappingNode {
+			return fmt.Errorf("organization policy: model_mappings must be a mapping")
+		}
+		for j := 0; j+1 < len(mapNode.Content); j += 2 {
+			rawKey := strings.TrimSpace(resolveEnvString(mapNode.Content[j].Value))
+			if _, exists := mappings[rawKey]; exists {
+				return fmt.Errorf("organization policy: duplicate model mapping key %q", rawKey)
+			}
+			var target string
+			if err := mapNode.Content[j+1].Decode(&target); err != nil {
+				return err
+			}
+			mappings[rawKey] = strings.TrimSpace(resolveEnvString(target))
+		}
+	}
+
+	if err := value.Decode(&raw); err != nil {
+		return err
+	}
+	p.OrganizationID = strings.TrimSpace(resolveEnvString(raw.OrganizationID))
+	p.PriceProfileID = strings.TrimSpace(resolveEnvString(raw.PriceProfileID))
+	p.ModelPricesLink = strings.TrimSpace(resolveEnvString(raw.ModelPricesLink))
+	p.ModelAllowlist = make([]string, 0, len(raw.ModelAllowlist))
+	for _, modelID := range raw.ModelAllowlist {
+		p.ModelAllowlist = append(p.ModelAllowlist, strings.TrimSpace(resolveEnvString(modelID)))
+	}
+	p.ModelMappings = mappings
+	return nil
+}
+
+func ValidateOrganizationPolicies(policies []OrganizationPolicyConfig) error {
+	seen := make(map[string]struct{}, len(policies))
+	for _, policy := range policies {
+		if policy.OrganizationID == "" {
+			return fmt.Errorf("organization policy: organization_id is required")
+		}
+		if _, exists := seen[policy.OrganizationID]; exists {
+			return fmt.Errorf("organization policy: duplicate organization_id %q", policy.OrganizationID)
+		}
+		seen[policy.OrganizationID] = struct{}{}
+		if policy.PriceProfileID == "" {
+			return fmt.Errorf("organization policy %q: price_profile_id is required", policy.OrganizationID)
+		}
+		if policy.ModelPricesLink == "" {
+			return fmt.Errorf("organization policy %q: model_prices_link is required", policy.OrganizationID)
+		}
+		for _, modelID := range policy.ModelAllowlist {
+			if modelID == "" {
+				return fmt.Errorf("organization policy %q: model_allowlist contains an empty model ID", policy.OrganizationID)
+			}
+		}
+		allowlisted := make(map[string]struct{}, len(policy.ModelAllowlist))
+		for _, modelID := range policy.ModelAllowlist {
+			allowlisted[modelID] = struct{}{}
+		}
+		for source, target := range policy.ModelMappings {
+			if source == "" || target == "" {
+				return fmt.Errorf("organization policy %q: model_mappings contains an empty key or target", policy.OrganizationID)
+			}
+			if policy.AllowlistSet {
+				if _, ok := allowlisted[source]; !ok {
+					return fmt.Errorf("organization policy %q: mapped model %q is outside model_allowlist", policy.OrganizationID, source)
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/internal/config/organization_policy_test.go
+++ b/internal/config/organization_policy_test.go
@@ -1,0 +1,88 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestOrganizationPolicyConfig_UnmarshalStrictFieldsAndPresence(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+organization_policies:
+  - organization_id: " org-1 "
+    price_profile_id: profile-1
+    model_prices_link: /tmp/prices.json
+    model_allowlist: []
+    model_mappings:
+      public/model: route-model
+`), &cfg)
+
+	require.NoError(t, err)
+	require.Len(t, cfg.OrganizationPolicies, 1)
+	policy := cfg.OrganizationPolicies[0]
+	assert.Equal(t, "org-1", policy.OrganizationID)
+	assert.True(t, policy.AllowlistSet)
+	assert.Empty(t, policy.ModelAllowlist)
+	assert.Equal(t, map[string]string{"public/model": "route-model"}, policy.ModelMappings)
+}
+
+func TestOrganizationPolicyConfig_RejectsUnknownField(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+organization_policies:
+  - organization_id: org-1
+    price_profile_id: profile-1
+    model_prices_link: /tmp/prices.json
+    unsupported: true
+`), &cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown field")
+}
+
+func TestOrganizationPolicyConfig_RejectsDuplicateMappingKey(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+organization_policies:
+  - organization_id: org-1
+    price_profile_id: profile-1
+    model_prices_link: /tmp/prices.json
+    model_mappings:
+      public/model: target-a
+      public/model: target-b
+`), &cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate model mapping key")
+}
+
+func TestValidateOrganizationPolicies(t *testing.T) {
+	err := ValidateOrganizationPolicies([]OrganizationPolicyConfig{
+		{
+			OrganizationID:  "org-1",
+			PriceProfileID:  "profile-1",
+			ModelPricesLink: "/tmp/prices.json",
+		},
+		{
+			OrganizationID:  "org-1",
+			PriceProfileID:  "profile-2",
+			ModelPricesLink: "/tmp/prices-2.json",
+		},
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate organization_id")
+
+	err = ValidateOrganizationPolicies([]OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: "/tmp/prices.json",
+		AllowlistSet:    true,
+		ModelAllowlist:  []string{"public/allowed"},
+		ModelMappings:   map[string]string{"public/other": "target"},
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "outside model_allowlist")
+}

--- a/internal/config/utils.go
+++ b/internal/config/utils.go
@@ -190,6 +190,9 @@ func PrintConfig(logger *slog.Logger, cfg *Config) {
 			logger.Info("  accepted alias", "from", alias, "to", target)
 		}
 	}
+	if len(cfg.OrganizationPolicies) > 0 {
+		logger.Info("organization_policies", "total_count", len(cfg.OrganizationPolicies))
+	}
 
 	// LiteLLM DB config
 	if cfg.LiteLLMDB.Enabled {

--- a/internal/litellmdb/auth/auth.go
+++ b/internal/litellmdb/auth/auth.go
@@ -313,6 +313,10 @@ func (a *Authenticator) fetchTokenFromDB(ctx context.Context, hashedToken string
 	}
 	if orgID != nil {
 		info.OrganizationID = *orgID
+		info.DirectOrganizationID = *orgID
+	}
+	if teamOrganizationID != nil {
+		info.TeamOrganizationID = *teamOrganizationID
 	}
 	if blocked != nil {
 		info.Blocked = *blocked
@@ -351,6 +355,8 @@ func (a *Authenticator) fetchTokenFromDB(ctx context.Context, hashedToken string
 
 	// A missing referenced team denies instead of becoming unrestricted.
 	info.TeamDangling = teamID != nil && teamIDCheck == nil
+	info.DirectOrganizationDangling = orgID != nil && orgIDCheck == nil
+	info.TeamOrganizationDangling = orgID == nil && teamOrganizationID != nil && orgIDCheck == nil
 
 	// Set Organization fields (external budget from BudgetTable)
 	info.OrgSpend = orgSpend

--- a/internal/litellmdb/models/models.go
+++ b/internal/litellmdb/models/models.go
@@ -170,6 +170,11 @@ type TokenInfo struct {
 	OrganizationID string   // Organization ID (optional, resolved from token or team)
 	Tags           []string // Request tags from token metadata
 
+	DirectOrganizationID       string
+	DirectOrganizationDangling bool
+	TeamOrganizationID         string
+	TeamOrganizationDangling   bool
+
 	// Token budget (embedded)
 	Spend     float64  // Current spend
 	MaxBudget *float64 // Max budget (nil = unlimited)

--- a/internal/models/organization_policy.go
+++ b/internal/models/organization_policy.go
@@ -229,6 +229,23 @@ func (m *Manager) ResolveOrganizationModel(policy *OrganizationPolicy, publicID 
 	}, nil
 }
 
+func (m *Manager) ResolveOrganizationModelScoped(
+	policy *OrganizationPolicy,
+	publicID string,
+	visibility scope.Context,
+) (OrganizationModelResolution, error) {
+	resolution, err := m.ResolveOrganizationModel(policy, publicID)
+	if err != nil {
+		return OrganizationModelResolution{}, err
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if !m.modelVisibleInScopeLocked(resolution.ModelID, visibility) {
+		return OrganizationModelResolution{}, ErrOrganizationModelNotFound
+	}
+	return resolution, nil
+}
+
 func (m *Manager) ResolveOrganizationMappingTarget(target string) (string, bool) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()

--- a/internal/models/organization_policy.go
+++ b/internal/models/organization_policy.go
@@ -1,0 +1,521 @@
+package models
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/scope"
+	"github.com/mixaill76/auto_ai_router/internal/utils"
+)
+
+type OrganizationPolicyRegistry struct {
+	byOrganization map[string]*OrganizationPolicy
+}
+
+type OrganizationPolicy struct {
+	OrganizationID  string
+	PriceProfileID  string
+	ModelPricesLink string
+	ProfileSHA256   string
+	AllowlistSet    bool
+
+	allowlist map[string]struct{}
+	mappings  map[string]string
+	prices    map[string]*ModelPrice
+}
+
+type OrganizationModelResolution struct {
+	PublicModelID    string
+	CanonicalModelID string
+	ModelID          string
+	RealModelID      string
+	PriceModelID     string
+	ModelPrice       *ModelPrice
+}
+
+type OrganizationPolicyLoadOptions struct {
+	LiteLLMDBEnabled      bool
+	LiteLLMDBRequired     bool
+	DisableSpendLogsWrite bool
+}
+
+func NewOrganizationPolicyRegistry() *OrganizationPolicyRegistry {
+	return &OrganizationPolicyRegistry{byOrganization: make(map[string]*OrganizationPolicy)}
+}
+
+func LoadOrganizationPolicies(
+	policies []config.OrganizationPolicyConfig,
+	manager *Manager,
+	opts OrganizationPolicyLoadOptions,
+) (*OrganizationPolicyRegistry, error) {
+	registry := NewOrganizationPolicyRegistry()
+	if len(policies) == 0 {
+		return registry, nil
+	}
+	if !opts.LiteLLMDBEnabled || !opts.LiteLLMDBRequired || opts.DisableSpendLogsWrite {
+		return nil, fmt.Errorf("organization policies require litellm_db.enabled=true, litellm_db.is_required=true, and litellm_db.disable_spend_logs_write=false")
+	}
+	if manager == nil {
+		return nil, fmt.Errorf("organization policies require a model manager")
+	}
+
+	profiles := make(map[string]profileIdentity)
+	for _, cfg := range policies {
+		priceRows, identity, err := loadStrictOrganizationPriceProfile(cfg.PriceProfileID, cfg.ModelPricesLink)
+		if err != nil {
+			return nil, fmt.Errorf("organization policy %q: %w", cfg.OrganizationID, err)
+		}
+		if previous, exists := profiles[cfg.PriceProfileID]; exists && previous != identity {
+			return nil, fmt.Errorf("organization policy %q: profile %q has conflicting source or digest", cfg.OrganizationID, cfg.PriceProfileID)
+		}
+		profiles[cfg.PriceProfileID] = identity
+
+		policy := &OrganizationPolicy{
+			OrganizationID:  cfg.OrganizationID,
+			PriceProfileID:  cfg.PriceProfileID,
+			ModelPricesLink: cfg.ModelPricesLink,
+			ProfileSHA256:   identity.sha256,
+			AllowlistSet:    cfg.AllowlistSet,
+			allowlist:       make(map[string]struct{}, len(cfg.ModelAllowlist)),
+			mappings:        make(map[string]string, len(cfg.ModelMappings)),
+			prices:          priceRows,
+		}
+		for _, modelID := range cfg.ModelAllowlist {
+			policy.allowlist[modelID] = struct{}{}
+		}
+		for source, target := range cfg.ModelMappings {
+			policy.mappings[source] = target
+			if _, ok := manager.ResolveOrganizationMappingTarget(target); !ok {
+				return nil, fmt.Errorf("organization policy %q: model mapping %q target %q is not an active direct route or active model_alias", cfg.OrganizationID, source, target)
+			}
+		}
+		if cfg.AllowlistSet {
+			for _, modelID := range cfg.ModelAllowlist {
+				if !policy.inSurface(manager, modelID) {
+					return nil, fmt.Errorf("organization policy %q: allowlisted model %q is not routable", cfg.OrganizationID, modelID)
+				}
+				if _, ok := policy.prices[modelID]; !ok {
+					return nil, fmt.Errorf("organization policy %q: allowlisted model %q has no exact profile price", cfg.OrganizationID, modelID)
+				}
+			}
+		}
+		registry.byOrganization[policy.OrganizationID] = policy
+	}
+	return registry, nil
+}
+
+func (r *OrganizationPolicyRegistry) Empty() bool {
+	return r == nil || len(r.byOrganization) == 0
+}
+
+func (r *OrganizationPolicyRegistry) HasOrganization(organizationID string) bool {
+	if r == nil {
+		return false
+	}
+	_, ok := r.byOrganization[strings.TrimSpace(organizationID)]
+	return ok
+}
+
+func (r *OrganizationPolicyRegistry) Policy(organizationID string) (*OrganizationPolicy, bool) {
+	if r == nil {
+		return nil, false
+	}
+	policy, ok := r.byOrganization[strings.TrimSpace(organizationID)]
+	return policy, ok
+}
+
+func (p *OrganizationPolicy) MappingTarget(modelID string) (string, bool) {
+	if p == nil {
+		return "", false
+	}
+	target, ok := p.mappings[modelID]
+	return target, ok
+}
+
+func (p *OrganizationPolicy) Price(modelID string) (*ModelPrice, bool) {
+	if p == nil {
+		return nil, false
+	}
+	price, ok := p.prices[modelID]
+	return price, ok
+}
+
+func (p *OrganizationPolicy) CacheKey() string {
+	if p == nil {
+		return ""
+	}
+	return p.OrganizationID + "|" + p.PriceProfileID + "|" + p.ProfileSHA256
+}
+
+func (p *OrganizationPolicy) inSurface(manager *Manager, publicID string) bool {
+	if p == nil || manager == nil {
+		return false
+	}
+	if p.AllowlistSet {
+		if _, ok := p.allowlist[publicID]; !ok {
+			return false
+		}
+	}
+	if _, ok := p.mappings[publicID]; ok {
+		return true
+	}
+	return manager.IsClientModelIDRoutable(publicID)
+}
+
+func (m *Manager) ResolveOrganizationModel(policy *OrganizationPolicy, publicID string) (OrganizationModelResolution, error) {
+	if policy == nil {
+		return OrganizationModelResolution{}, fmt.Errorf("organization policy is required")
+	}
+	publicID = strings.TrimSpace(publicID)
+	if !policy.inSurface(m, publicID) {
+		return OrganizationModelResolution{}, ErrOrganizationModelNotFound
+	}
+
+	canonicalID := publicID
+	if target, mapped := policy.MappingTarget(publicID); mapped {
+		resolved, active := m.ResolveOrganizationMappingTarget(target)
+		if !active {
+			return OrganizationModelResolution{}, ErrOrganizationModelNotFound
+		}
+		canonicalID = target
+		publicRouteID := resolved
+		realID := publicRouteID
+		if realName, ok := m.GetRealModelName(publicRouteID); ok {
+			realID = realName
+		}
+		price, _ := policy.Price(publicID)
+		return OrganizationModelResolution{
+			PublicModelID:    publicID,
+			CanonicalModelID: canonicalID,
+			ModelID:          publicRouteID,
+			RealModelID:      realID,
+			PriceModelID:     publicID,
+			ModelPrice:       price,
+		}, nil
+	}
+
+	resolvedCanonical, isAlias, err := m.ResolvePublicModelAlias(publicID)
+	if err != nil {
+		return OrganizationModelResolution{}, ErrOrganizationModelNotFound
+	}
+	if isAlias {
+		canonicalID = resolvedCanonical
+	}
+	modelID := canonicalID
+	if resolved, isModelAlias := m.ResolveAlias(modelID); isModelAlias {
+		modelID = resolved
+	}
+	realID := modelID
+	if realName, ok := m.GetRealModelName(modelID); ok {
+		realID = realName
+	}
+	price, _ := policy.Price(publicID)
+	return OrganizationModelResolution{
+		PublicModelID:    publicID,
+		CanonicalModelID: canonicalID,
+		ModelID:          modelID,
+		RealModelID:      realID,
+		PriceModelID:     publicID,
+		ModelPrice:       price,
+	}, nil
+}
+
+func (m *Manager) ResolveOrganizationMappingTarget(target string) (string, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	if _, ok := m.publicModelAliases[target]; ok {
+		return "", false
+	}
+	if _, ok := m.acceptedModelAliases[target]; ok {
+		return "", false
+	}
+	return m.clientCanonicalRouteTargetLocked(target)
+}
+
+func (m *Manager) IsAnyModelIDAllowedByScope(candidates []string, allowedModelIDs []string) bool {
+	for _, candidate := range candidates {
+		if m.IsModelIDAllowedByScope(candidate, allowedModelIDs) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manager) GetAllModelsScopedForOrganization(visibility scope.Context, policy *OrganizationPolicy) ModelsResponse {
+	if policy == nil {
+		return m.GetAllModelsScoped(visibility)
+	}
+	if response, ok := m.getCachedScopedAllModelsForOrganization(visibility, policy); ok {
+		return response
+	}
+	response := m.GetAllModelsScoped(visibility)
+	projected := m.projectOrganizationCatalog(response, visibility, policy)
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.scopedAllModelsCache.Add(m.scopedAllModelsCacheKeyForOrganizationLocked(visibility, policy), allModelsCache{
+		response:  copyModelsResponse(projected),
+		expiresAt: utils.NowUTC().Add(allModelsCacheTTL),
+	})
+	return projected
+}
+
+func (m *Manager) GetAllModelsWithAccessGroupsScopedForOrganization(visibility scope.Context, policy *OrganizationPolicy) ModelsResponse {
+	return m.GetAllModelsScopedForOrganization(visibility, policy)
+}
+
+func (m *Manager) getCachedScopedAllModelsForOrganization(visibility scope.Context, policy *OrganizationPolicy) (ModelsResponse, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	cacheKey := m.scopedAllModelsCacheKeyForOrganizationLocked(visibility, policy)
+	cached, ok := m.scopedAllModelsCache.Get(cacheKey)
+	if !ok || cached.expiresAt.IsZero() || !utils.NowUTC().Before(cached.expiresAt) {
+		if ok {
+			m.scopedAllModelsCache.Remove(cacheKey)
+		}
+		return ModelsResponse{}, false
+	}
+	return copyModelsResponse(cached.response), true
+}
+
+func (m *Manager) scopedAllModelsCacheKeyForOrganizationLocked(visibility scope.Context, policy *OrganizationPolicy) string {
+	return m.scopedAllModelsCacheKeyLocked(visibility) + "|op:" + policy.CacheKey()
+}
+
+func (m *Manager) projectOrganizationCatalog(response ModelsResponse, visibility scope.Context, policy *OrganizationPolicy) ModelsResponse {
+	if policy == nil {
+		return response
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	publicByID := make(map[string]Model, len(response.Data)+len(policy.mappings))
+	for _, model := range response.Data {
+		if !policy.inSurfaceLocked(model.ID) {
+			continue
+		}
+		if _, priced := policy.prices[model.ID]; !priced {
+			continue
+		}
+		publicByID[model.ID] = model
+	}
+	for source, target := range policy.mappings {
+		if policy.AllowlistSet {
+			if _, ok := policy.allowlist[source]; !ok {
+				continue
+			}
+		}
+		if _, priced := policy.prices[source]; !priced {
+			continue
+		}
+		routeID, active := m.resolveOrganizationMappingTargetLocked(target)
+		if !active || !m.modelVisibleInScopeLocked(routeID, visibility) {
+			continue
+		}
+		model := Model{ID: source, Object: "model", OwnedBy: "system"}
+		if sourceModel, ok := publicByID[routeID]; ok {
+			model = sourceModel
+			model.ID = source
+		}
+		publicByID[source] = model
+	}
+
+	result := make([]Model, 0, len(publicByID))
+	for _, model := range publicByID {
+		result = append(result, model)
+	}
+	slices.SortFunc(result, func(left, right Model) int {
+		return strings.Compare(left.ID, right.ID)
+	})
+	return ModelsResponse{Object: response.Object, Data: result}
+}
+
+func (p *OrganizationPolicy) inSurfaceLocked(publicID string) bool {
+	if p.AllowlistSet {
+		_, ok := p.allowlist[publicID]
+		return ok
+	}
+	return true
+}
+
+func (m *Manager) resolveOrganizationMappingTargetLocked(target string) (string, bool) {
+	if _, ok := m.publicModelAliases[target]; ok {
+		return "", false
+	}
+	if _, ok := m.acceptedModelAliases[target]; ok {
+		return "", false
+	}
+	return m.clientCanonicalRouteTargetLocked(target)
+}
+
+func (m *Manager) modelVisibleInScopeLocked(modelID string, visibility scope.Context) bool {
+	visibleCreds := m.visibleCredentialNamesLocked(visibility)
+	return m.modelVisibleLocked(modelID, visibleCreds, visibility)
+}
+
+var (
+	ErrOrganizationModelNotFound    = errors.New("organization model not found")
+	ErrOrganizationPriceUnavailable = errors.New("organization price unavailable")
+)
+
+type profileIdentity struct {
+	id     string
+	source string
+	sha256 string
+}
+
+func loadStrictOrganizationPriceProfile(profileID, link string) (map[string]*ModelPrice, profileIdentity, error) {
+	data, err := LoadModelPriceBytes(link)
+	if err != nil {
+		return nil, profileIdentity{}, err
+	}
+	if err := rejectDuplicateJSONKeys(data); err != nil {
+		return nil, profileIdentity{}, err
+	}
+
+	var raw map[string]json.RawMessage
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&raw); err != nil {
+		return nil, profileIdentity{}, fmt.Errorf("failed to parse organization tariff JSON: %w", err)
+	}
+	if err := ensureJSONEOF(decoder); err != nil {
+		return nil, profileIdentity{}, err
+	}
+
+	prices := make(map[string]*ModelPrice, len(raw))
+	for modelID, row := range raw {
+		price, err := decodeStrictPriceRow(modelID, row)
+		if err != nil {
+			return nil, profileIdentity{}, err
+		}
+		prices[modelID] = price
+	}
+	sum := sha256.Sum256(data)
+	return prices, profileIdentity{id: profileID, source: link, sha256: hex.EncodeToString(sum[:])}, nil
+}
+
+func ensureJSONEOF(decoder *json.Decoder) error {
+	if decoder == nil {
+		return nil
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return fmt.Errorf("organization tariff JSON contains trailing data")
+	}
+	return nil
+}
+
+func decodeStrictPriceRow(modelID string, row json.RawMessage) (*ModelPrice, error) {
+	if bytes.Equal(bytes.TrimSpace(row), []byte("null")) {
+		return nil, fmt.Errorf("organization tariff %q: null price row", modelID)
+	}
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(row, &fields); err != nil {
+		return nil, fmt.Errorf("organization tariff %q: price row must be an object: %w", modelID, err)
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("organization tariff %q: empty price row", modelID)
+	}
+	known := modelPriceJSONFields()
+	for field := range fields {
+		if _, ok := known[field]; !ok {
+			return nil, fmt.Errorf("organization tariff %q: unknown price field %q", modelID, field)
+		}
+	}
+	var price ModelPrice
+	decoder := json.NewDecoder(bytes.NewReader(row))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&price); err != nil {
+		return nil, fmt.Errorf("organization tariff %q: %w", modelID, err)
+	}
+	hasPriceField := false
+	for field := range fields {
+		if known[field] {
+			hasPriceField = true
+			break
+		}
+	}
+	if !hasPriceField {
+		return nil, fmt.Errorf("organization tariff %q: no recognized price field", modelID)
+	}
+	return &price, nil
+}
+
+func modelPriceJSONFields() map[string]bool {
+	result := make(map[string]bool)
+	t := reflect.TypeOf(ModelPrice{})
+	for i := 0; i < t.NumField(); i++ {
+		tag := t.Field(i).Tag.Get("json")
+		name, _, _ := strings.Cut(tag, ",")
+		if name == "" || name == "-" {
+			continue
+		}
+		isPriceField := name != "litellm_provider" && name != "reasoning_tokens_additive" && name != "web_search_billing_unit"
+		result[name] = isPriceField
+	}
+	return result
+}
+
+func rejectDuplicateJSONKeys(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	type frame struct {
+		object    bool
+		keys      map[string]struct{}
+		expectKey bool
+	}
+	var stack []frame
+	completeValue := func() {
+		if len(stack) > 0 && stack[len(stack)-1].object && !stack[len(stack)-1].expectKey {
+			stack[len(stack)-1].expectKey = true
+		}
+	}
+	for {
+		token, err := decoder.Token()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		switch value := token.(type) {
+		case json.Delim:
+			switch value {
+			case '{':
+				stack = append(stack, frame{object: true, keys: map[string]struct{}{}, expectKey: true})
+			case '}':
+				stack = stack[:len(stack)-1]
+				completeValue()
+			case '[':
+				stack = append(stack, frame{})
+			case ']':
+				stack = stack[:len(stack)-1]
+				completeValue()
+			}
+		case string:
+			if len(stack) == 0 || !stack[len(stack)-1].object {
+				completeValue()
+				continue
+			}
+			top := &stack[len(stack)-1]
+			if top.expectKey {
+				if _, exists := top.keys[value]; exists {
+					return fmt.Errorf("duplicate JSON key %q", value)
+				}
+				top.keys[value] = struct{}{}
+				top.expectKey = false
+			} else {
+				top.expectKey = true
+			}
+		default:
+			completeValue()
+		}
+	}
+}

--- a/internal/models/organization_policy.go
+++ b/internal/models/organization_policy.go
@@ -48,6 +48,15 @@ type OrganizationPolicyLoadOptions struct {
 	DisableSpendLogsWrite bool
 }
 
+// Several organizations routinely share one model_prices_link / price
+// profile. Load, parse, duplicate-key scan and SHA-256 each distinct link
+// only once; the resulting price map is read-only after construction, so it
+// is safe to share across policies.
+type loadedProfile struct {
+	prices   map[string]*ModelPrice
+	identity profileIdentity
+}
+
 func NewOrganizationPolicyRegistry() *OrganizationPolicyRegistry {
 	return &OrganizationPolicyRegistry{byOrganization: make(map[string]*OrganizationPolicy)}
 }
@@ -68,12 +77,22 @@ func LoadOrganizationPolicies(
 		return nil, fmt.Errorf("organization policies require a model manager")
 	}
 
+	profileByLink := make(map[string]loadedProfile, len(policies))
+
 	profiles := make(map[string]profileIdentity)
 	for _, cfg := range policies {
-		priceRows, identity, err := loadStrictOrganizationPriceProfile(cfg.PriceProfileID, cfg.ModelPricesLink)
-		if err != nil {
-			return nil, fmt.Errorf("organization policy %q: %w", cfg.OrganizationID, err)
+		loaded, cached := profileByLink[cfg.ModelPricesLink]
+		if !cached {
+			priceRows, identity, err := loadStrictOrganizationPriceProfile(cfg.PriceProfileID, cfg.ModelPricesLink)
+			if err != nil {
+				return nil, fmt.Errorf("organization policy %q: %w", cfg.OrganizationID, err)
+			}
+			loaded = loadedProfile{prices: priceRows, identity: identity}
+			profileByLink[cfg.ModelPricesLink] = loaded
 		}
+		priceRows := loaded.prices
+		identity := loaded.identity
+		identity.id = cfg.PriceProfileID
 		if previous, exists := profiles[cfg.PriceProfileID]; exists && previous != identity {
 			return nil, fmt.Errorf("organization policy %q: profile %q has conflicting source or digest", cfg.OrganizationID, cfg.PriceProfileID)
 		}
@@ -285,6 +304,13 @@ func (m *Manager) GetAllModelsScopedForOrganization(visibility scope.Context, po
 	return projected
 }
 
+// GetAllModelsWithAccessGroupsScopedForOrganization deliberately ignores
+// include_model_access_groups for organization-scoped keys: the access-group
+// projection is an administrative view over internal routes, and an
+// organization catalog is an explicit curated surface (allowlist + mappings +
+// prices). Returning access-group pseudo-models would re-introduce backend IDs
+// through a query parameter, exactly as GetAllModelsWithAccessGroupsScoped
+// already suppresses them once a client model surface is configured.
 func (m *Manager) GetAllModelsWithAccessGroupsScopedForOrganization(visibility scope.Context, policy *OrganizationPolicy) ModelsResponse {
 	return m.GetAllModelsScopedForOrganization(visibility, policy)
 }
@@ -314,9 +340,25 @@ func (m *Manager) projectOrganizationCatalog(response ModelsResponse, visibility
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
+	// globalByID indexes every model reachable in this scope by its real
+	// internal id so a mapped entry can borrow created/owned_by from the route
+	// it points at. response.Data is keyed by public/client id, which is not
+	// the route id returned by resolveOrganizationMappingTargetLocked.
+	globalByID := make(map[string]Model, len(m.allModels)+len(response.Data))
+	for _, model := range m.allModels {
+		if model.ID != "" {
+			globalByID[model.ID] = model
+		}
+	}
+	for _, model := range response.Data {
+		if model.ID != "" {
+			globalByID[model.ID] = model
+		}
+	}
+
 	publicByID := make(map[string]Model, len(response.Data)+len(policy.mappings))
 	for _, model := range response.Data {
-		if !policy.inSurfaceLocked(model.ID) {
+		if !policy.allowlistAdmitsLocked(model.ID) {
 			continue
 		}
 		if _, priced := policy.prices[model.ID]; !priced {
@@ -338,9 +380,15 @@ func (m *Manager) projectOrganizationCatalog(response ModelsResponse, visibility
 			continue
 		}
 		model := Model{ID: source, Object: "model", OwnedBy: "system"}
-		if sourceModel, ok := publicByID[routeID]; ok {
+		if sourceModel, ok := globalByID[routeID]; ok {
 			model = sourceModel
 			model.ID = source
+		} else if sourceModel, ok := globalByID[target]; ok {
+			model = sourceModel
+			model.ID = source
+		}
+		if model.Object == "" {
+			model.Object = "model"
 		}
 		publicByID[source] = model
 	}
@@ -355,7 +403,12 @@ func (m *Manager) projectOrganizationCatalog(response ModelsResponse, visibility
 	return ModelsResponse{Object: response.Object, Data: result}
 }
 
-func (p *OrganizationPolicy) inSurfaceLocked(publicID string) bool {
+// allowlistAdmitsLocked is only the allowlist gate: it returns true for any id
+// when no allowlist is configured. It is NOT a lock-held twin of inSurface and
+// performs no mapping/routability check, so callers must pass ids that are
+// already known to be routable (projectOrganizationCatalog feeds it entries
+// straight from the routable global catalog).
+func (p *OrganizationPolicy) allowlistAdmitsLocked(publicID string) bool {
 	if p.AllowlistSet {
 		_, ok := p.allowlist[publicID]
 		return ok

--- a/internal/models/organization_policy_test.go
+++ b/internal/models/organization_policy_test.go
@@ -1,0 +1,121 @@
+package models
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/scope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writePolicyPrices(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prices.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	return path
+}
+
+func testPolicyManager() *Manager {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+	credential := config.CredentialConfig{Name: "provider", Type: config.ProviderTypeOpenAI}
+	manager := New(logger, 100, []config.ModelRPMConfig{
+		{Name: "route-a", Credential: credential.Name},
+		{Name: "route-b", Credential: credential.Name},
+	})
+	manager.SetModelAliases(map[string]string{"public/a": "route-a"})
+	manager.SetPublicModelAliases(map[string]string{"alias/a": "public/a"})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+	return manager
+}
+
+func validPolicyOptions() OrganizationPolicyLoadOptions {
+	return OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      true,
+		LiteLLMDBRequired:     true,
+		DisableSpendLogsWrite: false,
+	}
+}
+
+func TestLoadOrganizationPolicies_RequiresPostgresWriter(t *testing.T) {
+	_, err := LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writePolicyPrices(t, `{"public/a":{"input_cost_per_token":0}}`),
+	}}, testPolicyManager(), OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      true,
+		LiteLLMDBRequired:     true,
+		DisableSpendLogsWrite: true,
+	})
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "disable_spend_logs_write=false")
+}
+
+func TestLoadOrganizationPolicies_StrictTariffJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "duplicate key", body: `{"public/a":{"input_cost_per_token":0},"public/a":{"output_cost_per_token":0}}`, want: "duplicate JSON key"},
+		{name: "unknown field", body: `{"public/a":{"unexpected":1}}`, want: "unknown price field"},
+		{name: "null row", body: `{"public/a":null}`, want: "null price row"},
+		{name: "empty row", body: `{"public/a":{}}`, want: "empty price row"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+				OrganizationID:  "org-1",
+				PriceProfileID:  "profile-1",
+				ModelPricesLink: writePolicyPrices(t, tt.body),
+				AllowlistSet:    true,
+				ModelAllowlist:  []string{"public/a"},
+			}}, testPolicyManager(), validPolicyOptions())
+
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.want)
+		})
+	}
+}
+
+func TestLoadOrganizationPolicies_AllowlistRequiresExactPrice(t *testing.T) {
+	_, err := LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writePolicyPrices(t, `{"route-a":{"input_cost_per_token":0.001}}`),
+		AllowlistSet:    true,
+		ModelAllowlist:  []string{"public/a"},
+	}}, testPolicyManager(), validPolicyOptions())
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no exact profile price")
+}
+
+func TestLoadOrganizationPolicies_FreePriceAndScopedCatalog(t *testing.T) {
+	manager := testPolicyManager()
+	registry, err := LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writePolicyPrices(t, `{"public/a":{"input_cost_per_token":0},"org/model":{"input_cost_per_token":0.5}}`),
+		ModelMappings:   map[string]string{"org/model": "route-b"},
+	}}, manager, validPolicyOptions())
+	require.NoError(t, err)
+	policy, ok := registry.Policy("org-1")
+	require.True(t, ok)
+
+	catalog := manager.GetAllModelsScopedForOrganization(scope.PublicContext(), policy)
+
+	assert.Equal(t, []string{"org/model", "public/a"}, responseModelIDs(catalog))
+	resolution, err := manager.ResolveOrganizationModel(policy, "org/model")
+	require.NoError(t, err)
+	assert.Equal(t, "org/model", resolution.PublicModelID)
+	assert.Equal(t, "route-b", resolution.CanonicalModelID)
+	assert.Equal(t, "route-b", resolution.ModelID)
+	assert.Equal(t, "org/model", resolution.PriceModelID)
+}

--- a/internal/models/price_loader.go
+++ b/internal/models/price_loader.go
@@ -25,6 +25,25 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 		return nil, fmt.Errorf("empty link")
 	}
 
+	data, err := LoadModelPriceBytes(link)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse JSON
+	var rawPrices map[string]*ModelPrice
+	if err := json.Unmarshal(data, &rawPrices); err != nil {
+		return nil, fmt.Errorf("failed to parse model prices JSON: %w", err)
+	}
+
+	return normalizeModelPrices(rawPrices), nil
+}
+
+func LoadModelPriceBytes(link string) ([]byte, error) {
+	if link == "" {
+		return nil, fmt.Errorf("empty link")
+	}
+
 	var data []byte
 	var err error
 
@@ -46,13 +65,10 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 	if err != nil {
 		return nil, err
 	}
+	return data, nil
+}
 
-	// Parse JSON
-	var rawPrices map[string]*ModelPrice
-	if err := json.Unmarshal(data, &rawPrices); err != nil {
-		return nil, fmt.Errorf("failed to parse model prices JSON: %w", err)
-	}
-
+func normalizeModelPrices(rawPrices map[string]*ModelPrice) map[string]*ModelPrice {
 	// Normalize model names (convert keys to normalized format)
 	// Also store raw lowercase keys so that provider-prefixed names like
 	// "google/gemini-3-flash-preview-highlimits" survive normalisation and
@@ -108,7 +124,7 @@ func LoadModelPrices(link string) (map[string]*ModelPrice, error) {
 		normalizedPrices[normalized] = price
 	}
 
-	return normalizedPrices, nil
+	return normalizedPrices
 }
 
 // loadFromFile reads model prices from a file

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -643,6 +643,7 @@ func (p *Proxy) readRequestBodyAndSelectModel(
 		r.Header.Del("Content-Encoding")
 	}
 	logCtx.PublicModelID = modelID
+	logCtx.CanonicalModelID = modelID
 	logCtx.ModelID = modelID
 	logCtx.SessionID = sessionID
 
@@ -654,6 +655,15 @@ func (p *Proxy) readRequestBodyAndSelectModel(
 		logCtx.ErrorMsg = "Model not specified in request body"
 		WriteErrorBadRequest(w, "model field is required")
 		return nil, "", "", false, false
+	}
+	if p.modelManager != nil {
+		policyBody, policyModelID, policyRealModelID, ok := p.admitOrganizationModel(w, r, body, modelID, logCtx)
+		if !ok {
+			return nil, "", "", false, false
+		}
+		if logCtx.OrganizationPolicy != nil {
+			return policyBody, policyModelID, policyRealModelID, streaming, true
+		}
 	}
 	// An unrestricted virtual key must still stay inside the configured product
 	// model surface. Provider backend IDs remain available to the trusted

--- a/internal/proxy/organization_policy.go
+++ b/internal/proxy/organization_policy.go
@@ -86,7 +86,7 @@ func (p *Proxy) admitOrganizationModel(
 		return body, "", "", true
 	}
 
-	resolution, err := p.modelManager.ResolveOrganizationModel(policy, publicModelID)
+	resolution, err := p.modelManager.ResolveOrganizationModelScoped(policy, publicModelID, logCtx.Scope)
 	if err != nil {
 		logCtx.Status = "failure"
 		logCtx.HTTPStatus = http.StatusNotFound
@@ -134,6 +134,37 @@ func (p *Proxy) admitOrganizationModel(
 	logCtx.billingPrice = resolution.ModelPrice
 
 	return body, resolution.ModelID, resolution.RealModelID, true
+}
+
+func (p *Proxy) IsOrganizationModelAllowedForToken(
+	tokenInfo *dbmodels.TokenInfo,
+	policy *routermodels.OrganizationPolicy,
+	publicModelID string,
+) bool {
+	if p == nil || p.modelManager == nil || policy == nil {
+		return false
+	}
+	resolution, err := p.modelManager.ResolveOrganizationModel(policy, publicModelID)
+	if err != nil {
+		return false
+	}
+	return p.isAnyModelAllowedForToken(tokenInfo, []string{
+		resolution.PublicModelID,
+		resolution.CanonicalModelID,
+		resolution.ModelID,
+	})
+}
+
+func (p *Proxy) resolveRetryBillingPrice(
+	logCtx *RequestLogContext,
+	publicModelID string,
+	modelID string,
+	realModelID string,
+) (string, *routermodels.ModelPrice) {
+	if logCtx != nil && logCtx.OrganizationPolicy != nil {
+		return logCtx.PriceModelID, logCtx.ModelPrice
+	}
+	return lookupBillingModelPrice(p.priceRegistry, publicModelID, modelID, realModelID)
 }
 
 func replaceModelInBodyPreserveContentType(body []byte, contentType, oldModel, newModel string) []byte {

--- a/internal/proxy/organization_policy.go
+++ b/internal/proxy/organization_policy.go
@@ -13,10 +13,12 @@ func (p *Proxy) effectiveOrganizationPolicy(info *dbmodels.TokenInfo) (*routermo
 		return nil, "", false
 	}
 
+	// Only the token's own organization counts as a direct organization here.
+	// info.OrganizationID is documented as "resolved from token or team", so it
+	// must not be used as a fallback: a team-derived organization would then be
+	// admitted through the direct branch and skip the TeamDangling /
+	// TeamOrganizationDangling checks below.
 	directOrg := info.DirectOrganizationID
-	if directOrg == "" {
-		directOrg = info.OrganizationID
-	}
 	if directOrg != "" {
 		policy, ok := p.organizationPolicies.Policy(directOrg)
 		if !ok {
@@ -113,14 +115,11 @@ func (p *Proxy) admitOrganizationModel(
 		return nil, "", "", false
 	}
 
-	if resolution.CanonicalModelID != publicModelID {
-		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), publicModelID, resolution.CanonicalModelID)
-	}
-	if resolution.ModelID != resolution.CanonicalModelID {
-		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), resolution.CanonicalModelID, resolution.ModelID)
-	}
-	if resolution.RealModelID != resolution.ModelID {
-		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), resolution.ModelID, resolution.RealModelID)
+	// The public → canonical → model → real chain always lands on RealModelID
+	// (each replacement overwrites the model field unconditionally), so rewrite
+	// the body once instead of parsing and re-serializing it up to three times.
+	if resolution.RealModelID != publicModelID {
+		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), publicModelID, resolution.RealModelID)
 	}
 
 	logCtx.PublicModelID = resolution.PublicModelID

--- a/internal/proxy/organization_policy.go
+++ b/internal/proxy/organization_policy.go
@@ -1,0 +1,162 @@
+package proxy
+
+import (
+	"fmt"
+	"net/http"
+
+	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	routermodels "github.com/mixaill76/auto_ai_router/internal/models"
+)
+
+func (p *Proxy) effectiveOrganizationPolicy(info *dbmodels.TokenInfo) (*routermodels.OrganizationPolicy, string, bool) {
+	if p == nil || p.organizationPolicies == nil || p.organizationPolicies.Empty() || info == nil || info.IsMasterKey {
+		return nil, "", false
+	}
+
+	directOrg := info.DirectOrganizationID
+	if directOrg == "" {
+		directOrg = info.OrganizationID
+	}
+	if directOrg != "" {
+		policy, ok := p.organizationPolicies.Policy(directOrg)
+		if !ok {
+			return nil, "", false
+		}
+		if info.DirectOrganizationDangling {
+			return nil, directOrg, true
+		}
+		return policy, directOrg, false
+	}
+
+	teamOrg := info.TeamOrganizationID
+	if teamOrg == "" {
+		return nil, "", false
+	}
+	policy, ok := p.organizationPolicies.Policy(teamOrg)
+	if !ok {
+		return nil, "", false
+	}
+	if info.TeamDangling || info.TeamOrganizationDangling {
+		return nil, teamOrg, true
+	}
+	return policy, teamOrg, false
+}
+
+func (p *Proxy) OrganizationPolicyForTokenInfo(info *dbmodels.TokenInfo) (*routermodels.OrganizationPolicy, bool) {
+	policy, _, dangling := p.effectiveOrganizationPolicy(info)
+	return policy, dangling
+}
+
+func (p *Proxy) selectOrganizationPolicy(w http.ResponseWriter, logCtx *RequestLogContext) (*routermodels.OrganizationPolicy, bool) {
+	policy, organizationID, dangling := p.effectiveOrganizationPolicy(logCtx.TokenInfo)
+	if dangling {
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusForbidden
+		logCtx.ErrorMsg = "Organization not available"
+		logCtx.Logged = true
+		WriteErrorForbidden(w, "Forbidden")
+		return nil, false
+	}
+	if policy == nil {
+		return nil, true
+	}
+	logCtx.OrganizationPolicy = policy
+	logCtx.BillingProfileID = policy.PriceProfileID
+	logCtx.BillingProfileSHA256 = policy.ProfileSHA256
+	logCtx.BillingOrganizationID = organizationID
+	if logCtx.TokenInfo != nil && logCtx.TokenInfo.OrganizationID != organizationID {
+		logCtx.TokenInfo = logCtx.TokenInfo.Clone()
+		logCtx.TokenInfo.OrganizationID = organizationID
+	}
+	return policy, true
+}
+
+func (p *Proxy) admitOrganizationModel(
+	w http.ResponseWriter,
+	r *http.Request,
+	body []byte,
+	publicModelID string,
+	logCtx *RequestLogContext,
+) ([]byte, string, string, bool) {
+	policy, ok := p.selectOrganizationPolicy(w, logCtx)
+	if !ok {
+		return nil, "", "", false
+	}
+	if policy == nil {
+		return body, "", "", true
+	}
+
+	resolution, err := p.modelManager.ResolveOrganizationModel(policy, publicModelID)
+	if err != nil {
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusNotFound
+		logCtx.ErrorMsg = fmt.Sprintf("Model %s not found", publicModelID)
+		logCtx.Logged = true
+		WriteErrorNotFound(w, logCtx.ErrorMsg)
+		return nil, "", "", false
+	}
+
+	candidates := []string{resolution.PublicModelID, resolution.CanonicalModelID, resolution.ModelID}
+	if !p.isAnyModelAllowedForToken(logCtx.TokenInfo, candidates) {
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusForbidden
+		logCtx.ErrorMsg = "Model not allowed"
+		WriteErrorForbidden(w, "Model not allowed")
+		return nil, "", "", false
+	}
+	if resolution.ModelPrice == nil {
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusServiceUnavailable
+		logCtx.ErrorMsg = "model pricing unavailable"
+		logCtx.Logged = true
+		WriteErrorServiceUnavailable(w, "Model pricing unavailable")
+		return nil, "", "", false
+	}
+
+	if resolution.CanonicalModelID != publicModelID {
+		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), publicModelID, resolution.CanonicalModelID)
+	}
+	if resolution.ModelID != resolution.CanonicalModelID {
+		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), resolution.CanonicalModelID, resolution.ModelID)
+	}
+	if resolution.RealModelID != resolution.ModelID {
+		body = replaceModelInBodyPreserveContentType(body, r.Header.Get("Content-Type"), resolution.ModelID, resolution.RealModelID)
+	}
+
+	logCtx.PublicModelID = resolution.PublicModelID
+	logCtx.CanonicalModelID = resolution.CanonicalModelID
+	logCtx.ModelID = resolution.ModelID
+	logCtx.RealModelID = resolution.RealModelID
+	logCtx.PriceModelID = resolution.PriceModelID
+	logCtx.ModelPrice = resolution.ModelPrice
+	logCtx.billingPriceResolved = true
+	logCtx.billingPriceModelID = resolution.PriceModelID
+	logCtx.billingPrice = resolution.ModelPrice
+
+	return body, resolution.ModelID, resolution.RealModelID, true
+}
+
+func replaceModelInBodyPreserveContentType(body []byte, contentType, oldModel, newModel string) []byte {
+	if oldModel == "" || newModel == "" || oldModel == newModel {
+		return body
+	}
+	if replaced, err := replaceRequestModel(body, contentType, newModel); err == nil {
+		return replaced
+	}
+	return body
+}
+
+func (p *Proxy) isAnyModelAllowedForToken(tokenInfo *dbmodels.TokenInfo, candidates []string) bool {
+	if tokenInfo == nil || !p.strictAllTeamModelsACL {
+		return true
+	}
+	var matcher dbmodels.ModelScopeMatcher
+	if p.modelManager != nil {
+		matcher = func(model string, allowedModels []string) bool {
+			return p.modelManager.IsAnyModelIDAllowedByScope(candidates, allowedModels)
+		}
+	}
+	return tokenInfo.IsModelAllowedByPolicy(candidates[0], matcher, dbmodels.ModelAccessPolicy{
+		StrictAllTeamModelsACL: true,
+	})
+}

--- a/internal/proxy/organization_policy_test.go
+++ b/internal/proxy/organization_policy_test.go
@@ -1,0 +1,336 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/litellmdb"
+	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	routermodels "github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type organizationPolicyTestDB struct {
+	litellmdb.NoopManager
+	tokens map[string]*dbmodels.TokenInfo
+	logs   []*dbmodels.SpendLogEntry
+}
+
+func (d *organizationPolicyTestDB) IsEnabled() bool           { return true }
+func (d *organizationPolicyTestDB) IsHealthy() bool           { return true }
+func (d *organizationPolicyTestDB) SpendLoggingEnabled() bool { return true }
+
+func (d *organizationPolicyTestDB) ValidateToken(_ context.Context, rawToken string) (*dbmodels.TokenInfo, error) {
+	info := d.tokens[rawToken]
+	if info == nil {
+		return nil, litellmdb.ErrTokenNotFound
+	}
+	return info.Clone(), nil
+}
+
+func (d *organizationPolicyTestDB) LogSpend(entry *dbmodels.SpendLogEntry) error {
+	d.logs = append(d.logs, entry)
+	return nil
+}
+
+func writeProxyPolicyPrices(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "prices.json")
+	require.NoError(t, os.WriteFile(path, []byte(body), 0600))
+	return path
+}
+
+func newOrganizationPolicyProxy(t *testing.T, upstreamURL string, db *organizationPolicyTestDB, policies []config.OrganizationPolicyConfig) *Proxy {
+	t.Helper()
+	logger := testhelpers.NewTestLogger()
+	credential := config.CredentialConfig{
+		Name: "provider", Type: config.ProviderTypeOpenAI, BaseURL: upstreamURL, APIKey: "provider-key", RPM: 100, TPM: 10000,
+	}
+	manager := routermodels.New(logger, 100, []config.ModelRPMConfig{
+		{Name: "route-a", Credential: credential.Name},
+		{Name: "route-b", Credential: credential.Name},
+	})
+	manager.SetModelAliases(map[string]string{"public/shared": "route-a"})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+	registry, err := routermodels.LoadOrganizationPolicies(policies, manager, routermodels.OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      true,
+		LiteLLMDBRequired:     true,
+		DisableSpendLogsWrite: false,
+	})
+	require.NoError(t, err)
+
+	builder := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key")
+	builder.config.ModelManager = manager
+	builder.config.OrganizationPolicies = registry
+	prx := builder.Build()
+	prx.LiteLLMDB = db
+	return prx
+}
+
+func TestOrganizationPolicy_ShadowMappingUsesExactPriceAndMetadata(t *testing.T) {
+	var calls atomic.Int32
+	var upstreamModel string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		upstreamModel, _ = body["model"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"route-b","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"total_tokens":15}}`))
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {Token: "token-hash", UserID: "user-1", DirectOrganizationID: "org-1", OrganizationID: "org-1"},
+	}}
+	prx := newOrganizationPolicyProxy(t, upstream.URL, db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.001,"output_cost_per_token":0.002}}`),
+		ModelMappings:   map[string]string{"public/shared": "route-b"},
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[{"role":"user","content":"hi"}]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(1), calls.Load())
+	assert.Equal(t, "route-b", upstreamModel)
+	require.Len(t, db.logs, 1)
+	log := db.logs[0]
+	assert.Equal(t, "route-b", log.Model)
+	assert.Equal(t, "route-b", log.ModelGroup)
+	assert.Equal(t, "provider:route-b", log.ModelID)
+	assert.Equal(t, "org-1", log.OrganizationID)
+	var metadata map[string]any
+	require.NoError(t, json.Unmarshal([]byte(log.Metadata), &metadata))
+	spendMetadata := metadata["spend_logs_metadata"].(map[string]any)
+	assert.Equal(t, "public/shared", spendMetadata["public_model_name"])
+	assert.Equal(t, "route-b", spendMetadata["canonical_model_name"])
+	assert.Equal(t, "profile-1", spendMetadata["billing_profile_id"])
+	assert.Equal(t, "public/shared", spendMetadata["billing_price_model_name"])
+	assert.Equal(t, "org-1", spendMetadata["billing_organization_id"])
+	assert.NotEmpty(t, spendMetadata["billing_profile_sha256"])
+}
+
+func TestOrganizationPolicy_MissingExactPriceRejectsBeforeProvider(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {Token: "token-hash", UserID: "user-1", DirectOrganizationID: "org-1", OrganizationID: "org-1"},
+	}}
+	prx := newOrganizationPolicyProxy(t, upstream.URL, db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"route-b":{"input_cost_per_token":0.001}}`),
+		ModelMappings:   map[string]string{"public/shared": "route-b"},
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+	assert.Equal(t, int32(0), calls.Load())
+	assert.Empty(t, db.logs)
+}
+
+func TestOrganizationPolicy_ACLDenialPrecedesMissingPrice(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {Token: "token-hash", UserID: "user-1", DirectOrganizationID: "org-1", OrganizationID: "org-1", Models: []string{"other"}},
+	}}
+	prx := newOrganizationPolicyProxy(t, upstream.URL, db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"route-b":{"input_cost_per_token":0.001}}`),
+		ModelMappings:   map[string]string{"public/shared": "route-b"},
+	}})
+	prx.strictAllTeamModelsACL = true
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, int32(0), calls.Load())
+	assert.Empty(t, db.logs)
+}
+
+func TestOrganizationPolicy_DanglingConfiguredIdentityRejectsBeforeProvider(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {Token: "token-hash", UserID: "user-1", DirectOrganizationID: "org-1", DirectOrganizationDangling: true},
+	}}
+	prx := newOrganizationPolicyProxy(t, upstream.URL, db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.001}}`),
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	assert.Equal(t, int32(0), calls.Load())
+	assert.Empty(t, db.logs)
+}
+
+func TestOrganizationPolicy_TeamFallbackSetsAccountingOrganization(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"route-a","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {Token: "token-hash", UserID: "user-1", TeamID: "team-1", TeamOrganizationID: "org-team"},
+	}}
+	prx := newOrganizationPolicyProxy(t, upstream.URL, db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-team",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.001}}`),
+	}})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, db.logs, 1)
+	assert.Equal(t, "org-team", db.logs[0].OrganizationID)
+}
+
+func TestOrganizationPolicy_DirectOrganizationTakesPrecedenceOverTeam(t *testing.T) {
+	var upstreamModel string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		upstreamModel, _ = body["model"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":"chatcmpl-1","object":"chat.completion","model":"route-b","choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`))
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {
+			Token:                "token-hash",
+			UserID:               "user-1",
+			TeamID:               "team-1",
+			DirectOrganizationID: "org-direct",
+			OrganizationID:       "org-direct",
+			TeamOrganizationID:   "org-team",
+		},
+	}}
+	prx := newOrganizationPolicyProxy(t, upstream.URL, db, []config.OrganizationPolicyConfig{
+		{
+			OrganizationID:  "org-direct",
+			PriceProfileID:  "profile-direct",
+			ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.001}}`),
+			ModelMappings:   map[string]string{"public/shared": "route-b"},
+		},
+		{
+			OrganizationID:  "org-team",
+			PriceProfileID:  "profile-team",
+			ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.002}}`),
+			ModelMappings:   map[string]string{"public/shared": "route-a"},
+		},
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, "route-b", upstreamModel)
+	require.Len(t, db.logs, 1)
+	assert.Equal(t, "org-direct", db.logs[0].OrganizationID)
+}
+
+func TestOrganizationPolicy_AddsCandidateSetACL(t *testing.T) {
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {Token: "token-hash", UserID: "user-1", DirectOrganizationID: "org-1", OrganizationID: "org-1", Models: []string{"public/shared"}},
+	}}
+	prx := newOrganizationPolicyProxy(t, "http://provider.example", db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.001}}`),
+		ModelMappings:   map[string]string{"public/shared": "route-b"},
+	}})
+	prx.strictAllTeamModelsACL = true
+
+	assert.True(t, prx.isAnyModelAllowedForToken(db.tokens["token"], []string{"public/shared", "route-b", "route-b"}))
+	assert.False(t, prx.isAnyModelAllowedForToken(db.tokens["token"], []string{"route-b", "route-b", "route-b"}))
+}
+
+func TestOrganizationPolicy_FrozenPriceSurvivesDefaultRegistryChange(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	policy := &routermodels.OrganizationPolicy{
+		OrganizationID: "org-1", PriceProfileID: "profile-1", ProfileSHA256: "sha",
+	}
+	price := &routermodels.ModelPrice{InputCostPerToken: 0.001}
+	logCtx := &RequestLogContext{
+		OrganizationPolicy:   policy,
+		PublicModelID:        "public/shared",
+		ModelID:              "route-b",
+		RealModelID:          "route-b",
+		PriceModelID:         "public/shared",
+		ModelPrice:           price,
+		billingPriceResolved: true,
+		billingPriceModelID:  "public/shared",
+		billingPrice:         price,
+	}
+	registry := routermodels.NewModelPriceRegistry()
+	registry.Update(map[string]*routermodels.ModelPrice{"route-b": {InputCostPerToken: 9}})
+	prx.priceRegistry = registry
+
+	_, resolved := prx.resolveBillingPrice(logCtx, "public/shared", "route-b", "route-b")
+
+	assert.Same(t, price, resolved)
+}
+
+func stringsReader(value string) *strings.Reader {
+	return strings.NewReader(value)
+}

--- a/internal/proxy/organization_policy_test.go
+++ b/internal/proxy/organization_policy_test.go
@@ -52,10 +52,20 @@ func writeProxyPolicyPrices(t *testing.T, body string) string {
 
 func newOrganizationPolicyProxy(t *testing.T, upstreamURL string, db *organizationPolicyTestDB, policies []config.OrganizationPolicyConfig) *Proxy {
 	t.Helper()
-	logger := testhelpers.NewTestLogger()
 	credential := config.CredentialConfig{
 		Name: "provider", Type: config.ProviderTypeOpenAI, BaseURL: upstreamURL, APIKey: "provider-key", RPM: 100, TPM: 10000,
 	}
+	return newOrganizationPolicyProxyWithCredential(t, db, policies, credential)
+}
+
+func newOrganizationPolicyProxyWithCredential(
+	t *testing.T,
+	db *organizationPolicyTestDB,
+	policies []config.OrganizationPolicyConfig,
+	credential config.CredentialConfig,
+) *Proxy {
+	t.Helper()
+	logger := testhelpers.NewTestLogger()
 	manager := routermodels.New(logger, 100, []config.ModelRPMConfig{
 		{Name: "route-a", Credential: credential.Name},
 		{Name: "route-b", Credential: credential.Name},
@@ -326,9 +336,49 @@ func TestOrganizationPolicy_FrozenPriceSurvivesDefaultRegistryChange(t *testing.
 	registry.Update(map[string]*routermodels.ModelPrice{"route-b": {InputCostPerToken: 9}})
 	prx.priceRegistry = registry
 
-	_, resolved := prx.resolveBillingPrice(logCtx, "public/shared", "route-b", "route-b")
+	resolvedID, resolved := prx.resolveRetryBillingPrice(logCtx, "public/shared", "route-b", "route-b")
 
+	assert.Equal(t, "public/shared", resolvedID)
 	assert.Same(t, price, resolved)
+}
+
+func TestOrganizationPolicy_InvisibleTargetRejectsBeforePriceAndProvider(t *testing.T) {
+	var calls atomic.Int32
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"token": {
+			Token:                "token-hash",
+			UserID:               "user-1",
+			KeyName:              "scope-b",
+			DirectOrganizationID: "org-1",
+			OrganizationID:       "org-1",
+		},
+	}}
+	credential := config.CredentialConfig{
+		Name: "provider", Type: config.ProviderTypeOpenAI, BaseURL: upstream.URL, APIKey: "provider-key",
+		RPM: 100, TPM: 10000, Scopes: []string{"scope-a"},
+	}
+	prx := newOrganizationPolicyProxyWithCredential(t, db, []config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: writeProxyPolicyPrices(t, `{"public/shared":{"input_cost_per_token":0.001}}`),
+		ModelMappings:   map[string]string{"public/shared": "route-b"},
+	}}, credential)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", stringsReader(`{"model":"public/shared","messages":[]}`))
+	req.Header.Set("Authorization", "Bearer token")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, int32(0), calls.Load())
+	assert.Empty(t, db.logs)
 }
 
 func stringsReader(value string) *strings.Reader {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -245,38 +245,43 @@ func (logCtx *RequestLogContext) Context() context.Context {
 // RequestLogContext holds all data needed for logging a request to LiteLLM DB
 // Filled throughout request processing and logged at the end via defer
 type RequestLogContext struct {
-	RequestID            string                   // Internal request UUID; may be adopted from a trusted inbound traceparent (see requestid.Middleware), so two distinct requests can share this value
-	EventID              string                   // Always server-minted, never client-influenced; used as AirEventID so spend-log collision resolution stays meaningful even when RequestID collides
-	ClientResponseID     string                   // ID returned to the client
-	StartTime            time.Time                // Request start time
-	CompletionStartTime  time.Time                // Timestamp of the first real content/tool/reasoning delta (TTFT), not just the first byte/chunk; zero if not streamed or never reached
-	Request              *http.Request            // HTTP request
-	Token                string                   // Auth token (raw, will be hashed)
-	PublicModelID        string                   // Client-facing model before alias resolution
-	ModelID              string                   // Model alias name (what client requested)
-	RealModelID          string                   // Real model name sent to provider (for price lookup; equals ModelID if no alias)
-	Status               string                   // "success" or "failure"
-	HTTPStatus           int                      // HTTP response status code
-	ErrorMsg             string                   // Error message (added to metadata on failure)
-	TokenUsage           *converter.TokenUsage    // Token usage with detailed breakdown
-	ModelPrice           *models.ModelPrice       // Price resolved before the provider request
-	PriceModelID         string                   // Model identifier used for price lookup
-	UsageSource          string                   // provider, estimated, request_parameters, or missing
-	StreamOutcome        string                   // completed, client_aborted, or stream_error
-	Credential           *config.CredentialConfig // Credential used
-	SessionID            string                   // Session ID
-	TargetURL            string                   // Target URL (for APIBase extraction)
-	TokenInfo            *litellmdb.TokenInfo     // User/team/org info
-	IsImageGeneration    bool                     // True if this is an image generation request
-	ImageCount           int                      // Number of images to generate (from 'n' param)
-	WebSearchRequested   bool                     // True when the request enabled the built-in web search tool
-	WebSearchContextSize string                   // low|medium|high from web_search_options/tool config
-	Logged               bool                     // True if already logged (prevents duplicate logging)
-	IsResponsesAPI       bool                     // True if this is a Responses API request (converted to Chat Completions)
-	RequestCompleted     bool                     // True only after the response was fully and successfully delivered
-	ActualCredentialName string                   // Real credential name from upstream when Credential.Type == ProviderTypeProxy
-	IsProxyRequest       bool                     // True when this request came from another auto_ai_router (HeaderAIRProxyClient)
-	Scope                scope.Context
+	RequestID             string                   // Internal request UUID; may be adopted from a trusted inbound traceparent (see requestid.Middleware), so two distinct requests can share this value
+	EventID               string                   // Always server-minted, never client-influenced; used as AirEventID so spend-log collision resolution stays meaningful even when RequestID collides
+	ClientResponseID      string                   // ID returned to the client
+	StartTime             time.Time                // Request start time
+	CompletionStartTime   time.Time                // Timestamp of the first real content/tool/reasoning delta (TTFT), not just the first byte/chunk; zero if not streamed or never reached
+	Request               *http.Request            // HTTP request
+	Token                 string                   // Auth token (raw, will be hashed)
+	PublicModelID         string                   // Client-facing model before alias resolution
+	CanonicalModelID      string                   // Organization canonical public model after scoped admission
+	ModelID               string                   // Model alias name (what client requested)
+	RealModelID           string                   // Real model name sent to provider (for price lookup; equals ModelID if no alias)
+	Status                string                   // "success" or "failure"
+	HTTPStatus            int                      // HTTP response status code
+	ErrorMsg              string                   // Error message (added to metadata on failure)
+	TokenUsage            *converter.TokenUsage    // Token usage with detailed breakdown
+	ModelPrice            *models.ModelPrice       // Price resolved before the provider request
+	PriceModelID          string                   // Model identifier used for price lookup
+	UsageSource           string                   // provider, estimated, request_parameters, or missing
+	StreamOutcome         string                   // completed, client_aborted, or stream_error
+	Credential            *config.CredentialConfig // Credential used
+	SessionID             string                   // Session ID
+	TargetURL             string                   // Target URL (for APIBase extraction)
+	TokenInfo             *litellmdb.TokenInfo     // User/team/org info
+	IsImageGeneration     bool                     // True if this is an image generation request
+	ImageCount            int                      // Number of images to generate (from 'n' param)
+	WebSearchRequested    bool                     // True when the request enabled the built-in web search tool
+	WebSearchContextSize  string                   // low|medium|high from web_search_options/tool config
+	Logged                bool                     // True if already logged (prevents duplicate logging)
+	IsResponsesAPI        bool                     // True if this is a Responses API request (converted to Chat Completions)
+	RequestCompleted      bool                     // True only after the response was fully and successfully delivered
+	ActualCredentialName  string                   // Real credential name from upstream when Credential.Type == ProviderTypeProxy
+	IsProxyRequest        bool                     // True when this request came from another auto_ai_router (HeaderAIRProxyClient)
+	Scope                 scope.Context
+	OrganizationPolicy    *models.OrganizationPolicy
+	BillingProfileID      string
+	BillingProfileSHA256  string
+	BillingOrganizationID string
 
 	reservedEntities       []reservedEntity
 	rateLimitedTPMEntities []string
@@ -351,9 +356,10 @@ type Config struct {
 	KafkaLog                   kafkalog.Manager           // Kafka spend-log publishing (optional, analytics write-path)
 	HealthChecker              HealthChecker              // Optional: cached DB health status (updated by health monitor)
 	PriceRegistry              *models.ModelPriceRegistry // Model pricing information (optional)
-	MaxProviderRetries         int                        // Max same-type credential retries (default: 2)
-	MaxFallbackAttempts        int                        // Max fallback proxy hops per request chain (default: 5)
-	ResponseStore              responsestore.Store        // Optional: Responses API store (bbolt or Redis)
+	OrganizationPolicies       *models.OrganizationPolicyRegistry
+	MaxProviderRetries         int                 // Max same-type credential retries (default: 2)
+	MaxFallbackAttempts        int                 // Max fallback proxy hops per request chain (default: 5)
+	ResponseStore              responsestore.Store // Optional: Responses API store (bbolt or Redis)
 	SessionStickyEnabled       bool
 	SessionStickyAutoCacheCtrl bool // Auto-inject Anthropic cache_control markers when session is active (default: true)
 	SessionStoreTTL            time.Duration
@@ -389,13 +395,14 @@ type Proxy struct {
 	kafkaLog                         kafkalog.Manager           // Kafka spend-log publishing (optional, analytics write-path)
 	healthChecker                    HealthChecker              // Cached DB health status (optional)
 	priceRegistry                    *models.ModelPriceRegistry // Model pricing information (optional)
-	maxProviderRetries               int                        // Max same-type credential retries on provider errors
-	maxFallbackAttempts              int                        // Max fallback proxy hops per request chain
-	responseStore                    responsestore.Store        // Optional: Responses API store (bbolt or Redis)
-	sessionStore                     *SessionStore              // Optional: session-sticky credential routing
-	stickyAutoCacheCtrl              bool                       // Auto-inject Anthropic cache_control when session is active
-	drainUpstreamOnAbort             bool                       // Keep reading upstream after client disconnect to get real usage chunk
-	tiktokenEnabled                  bool                       // Local tiktoken-based prompt/completion token fallback estimation
+	organizationPolicies             *models.OrganizationPolicyRegistry
+	maxProviderRetries               int                 // Max same-type credential retries on provider errors
+	maxFallbackAttempts              int                 // Max fallback proxy hops per request chain
+	responseStore                    responsestore.Store // Optional: Responses API store (bbolt or Redis)
+	sessionStore                     *SessionStore       // Optional: session-sticky credential routing
+	stickyAutoCacheCtrl              bool                // Auto-inject Anthropic cache_control when session is active
+	drainUpstreamOnAbort             bool                // Keep reading upstream after client disconnect to get real usage chunk
+	tiktokenEnabled                  bool                // Local tiktoken-based prompt/completion token fallback estimation
 	strictAllTeamModelsACL           bool
 	responseHeaderMode               config.ResponseHeaderMode
 	credentialNameAsTeamID           bool
@@ -468,6 +475,7 @@ func New(cfg *Config) *Proxy {
 		kafkaLog:                         cfg.KafkaLog,
 		healthChecker:                    cfg.HealthChecker,
 		priceRegistry:                    cfg.PriceRegistry,
+		organizationPolicies:             cfg.OrganizationPolicies,
 		maxProviderRetries:               cfg.MaxProviderRetries,
 		maxFallbackAttempts:              cfg.MaxFallbackAttempts,
 		responseStore:                    cfg.ResponseStore,

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1453,8 +1453,8 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 					if publicModelID == "" {
 						publicModelID = modelID
 					}
-					retryPriceModelID, retryPrice := lookupBillingModelPrice(
-						p.priceRegistry, publicModelID, modelID, preparedRetry.realModelID,
+					retryPriceModelID, retryPrice := p.resolveRetryBillingPrice(
+						logCtx, publicModelID, modelID, preparedRetry.realModelID,
 					)
 					if retryPrice == nil && p.spendTrackingEnabled() {
 						triedCreds[candidate.Name] = true

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -361,6 +361,32 @@ func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRe
 	return string(encoded)
 }
 
+func addOrganizationPolicySpendMetadata(metadata string, logCtx *RequestLogContext) string {
+	if logCtx == nil || logCtx.OrganizationPolicy == nil {
+		return metadata
+	}
+	var doc map[string]interface{}
+	if json.Unmarshal([]byte(metadata), &doc) != nil {
+		doc = make(map[string]interface{})
+	}
+	spendMetadata, _ := doc["spend_logs_metadata"].(map[string]interface{})
+	if spendMetadata == nil {
+		spendMetadata = make(map[string]interface{})
+		doc["spend_logs_metadata"] = spendMetadata
+	}
+	spendMetadata["public_model_name"] = logCtx.PublicModelID
+	spendMetadata["canonical_model_name"] = logCtx.CanonicalModelID
+	spendMetadata["billing_profile_id"] = logCtx.BillingProfileID
+	spendMetadata["billing_profile_sha256"] = logCtx.BillingProfileSHA256
+	spendMetadata["billing_price_model_name"] = logCtx.PriceModelID
+	spendMetadata["billing_organization_id"] = logCtx.BillingOrganizationID
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return metadata
+	}
+	return string(encoded)
+}
+
 // extractEndUser extracts end_user from request headers or body
 func extractEndUser(r *http.Request) string {
 	// Check X-End-User header first

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -317,7 +317,9 @@ func buildMetadata(hashedToken string, tokenInfo *litellmdb.TokenInfo, errorMsg 
 
 func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRequest bool, modelID, publicModelID, priceModelID string) string {
 	var doc map[string]interface{}
-	if json.Unmarshal([]byte(metadata), &doc) != nil {
+	if json.Unmarshal([]byte(metadata), &doc) != nil || doc == nil {
+		// Unmarshal leaves doc nil for a decode error and also for the literal
+		// "null"; either way a fresh map is needed before assigning into it.
 		doc = make(map[string]interface{})
 	}
 	spendMetadata, _ := doc["spend_logs_metadata"].(map[string]interface{})
@@ -366,7 +368,9 @@ func addOrganizationPolicySpendMetadata(metadata string, logCtx *RequestLogConte
 		return metadata
 	}
 	var doc map[string]interface{}
-	if json.Unmarshal([]byte(metadata), &doc) != nil {
+	if json.Unmarshal([]byte(metadata), &doc) != nil || doc == nil {
+		// Unmarshal leaves doc nil for a decode error and also for the literal
+		// "null"; either way a fresh map is needed before assigning into it.
 		doc = make(map[string]interface{})
 	}
 	spendMetadata, _ := doc["spend_logs_metadata"].(map[string]interface{})

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -347,6 +347,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	overheadMs := float64(time.Since(logCtx.StartTime).Microseconds()) / 1000.0
 	metadata := buildMetadata(hashedToken, logCtx.TokenInfo, logCtx.ErrorMsg, logCtx.HTTPStatus, logCtx.TokenUsage, requesterIP, tokenCosts, logCtx.ModelID, overheadMs, kafkaFallbackReason)
 	metadata = addAIRSpendMetadata(metadata, logCtx.RequestID, logCtx.ClientResponseID, logCtx.IsProxyRequest, logCtx.ModelID, logCtx.PublicModelID, logCtx.billingPriceModelID)
+	metadata = addOrganizationPolicySpendMetadata(metadata, logCtx)
 
 	var completionStartTime *time.Time
 	if !logCtx.CompletionStartTime.IsZero() {

--- a/internal/proxy/test_helpers.go
+++ b/internal/proxy/test_helpers.go
@@ -109,6 +109,7 @@ type TestProxyConfig struct {
 	TiktokenEnabled        bool
 	ResponseHeaderMode     config.ResponseHeaderMode
 	CredentialNameAsTeamID bool
+	OrganizationPolicies   *models.OrganizationPolicyRegistry
 }
 
 // NewTestProxyBuilder creates a builder with default configuration.
@@ -308,6 +309,7 @@ func (b *TestProxyBuilder) Build() *Proxy {
 		TiktokenEnabled:        b.config.TiktokenEnabled,
 		ResponseHeaderMode:     b.config.ResponseHeaderMode,
 		CredentialNameAsTeamID: b.config.CredentialNameAsTeamID,
+		OrganizationPolicies:   b.config.OrganizationPolicies,
 	})
 }
 

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -264,15 +264,14 @@ func (r *Router) handleModels(w http.ResponseWriter, req *http.Request) {
 	}
 	if r.modelManager != nil {
 		includeGroups := strings.EqualFold(req.URL.Query().Get("include_model_access_groups"), "true")
-		if organizationPolicy != nil {
-			if includeGroups {
-				modelsResp = r.modelManager.GetAllModelsWithAccessGroupsScopedForOrganization(visibility, organizationPolicy)
-			} else {
-				modelsResp = r.modelManager.GetAllModelsScopedForOrganization(visibility, organizationPolicy)
-			}
-		} else if includeGroups {
+		switch {
+		case organizationPolicy != nil && includeGroups:
+			modelsResp = r.modelManager.GetAllModelsWithAccessGroupsScopedForOrganization(visibility, organizationPolicy)
+		case organizationPolicy != nil:
+			modelsResp = r.modelManager.GetAllModelsScopedForOrganization(visibility, organizationPolicy)
+		case includeGroups:
 			modelsResp = r.modelManager.GetAllModelsWithAccessGroupsScoped(visibility)
-		} else {
+		default:
 			modelsResp = r.modelManager.GetAllModelsScoped(visibility)
 		}
 	} else {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -253,9 +253,24 @@ func (r *Router) handleModels(w http.ResponseWriter, req *http.Request) {
 	}
 
 	var modelsResp models.ModelsResponse
+	var organizationPolicy *models.OrganizationPolicy
+	if r.proxy != nil {
+		var dangling bool
+		organizationPolicy, dangling = r.proxy.OrganizationPolicyForTokenInfo(tokenInfo)
+		if dangling {
+			proxy.WriteErrorForbidden(w, "Forbidden")
+			return
+		}
+	}
 	if r.modelManager != nil {
 		includeGroups := strings.EqualFold(req.URL.Query().Get("include_model_access_groups"), "true")
-		if includeGroups {
+		if organizationPolicy != nil {
+			if includeGroups {
+				modelsResp = r.modelManager.GetAllModelsWithAccessGroupsScopedForOrganization(visibility, organizationPolicy)
+			} else {
+				modelsResp = r.modelManager.GetAllModelsScopedForOrganization(visibility, organizationPolicy)
+			}
+		} else if includeGroups {
 			modelsResp = r.modelManager.GetAllModelsWithAccessGroupsScoped(visibility)
 		} else {
 			modelsResp = r.modelManager.GetAllModelsScoped(visibility)

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -281,7 +281,11 @@ func (r *Router) handleModels(w http.ResponseWriter, req *http.Request) {
 	if tokenInfo != nil {
 		filtered := make([]models.Model, 0, len(modelsResp.Data))
 		for _, model := range modelsResp.Data {
-			if r.proxy.IsModelAllowedForToken(tokenInfo, model.ID) {
+			allowed := r.proxy.IsModelAllowedForToken(tokenInfo, model.ID)
+			if organizationPolicy != nil {
+				allowed = r.proxy.IsOrganizationModelAllowedForToken(tokenInfo, organizationPolicy, model.ID)
+			}
+			if allowed {
 				filtered = append(filtered, model)
 			}
 		}

--- a/internal/router/router_test.go
+++ b/internal/router/router_test.go
@@ -872,6 +872,65 @@ func TestServeHTTPV1ModelsAuthAndModelACLPolicy(t *testing.T) {
 	assert.Equal(t, http.StatusForbidden, compatibilityRequest("blocked-team-key").Code)
 }
 
+func TestServeHTTPV1ModelsOrganizationPolicyUsesMappedACLTarget(t *testing.T) {
+	logger := testhelpers.NewTestLogger()
+	credential := config.CredentialConfig{Name: "catalog", Type: config.ProviderTypeOpenAI, RPM: 100}
+	modelManager := models.New(logger, 100, []config.ModelRPMConfig{{Name: "route-b", Credential: credential.Name}})
+	modelManager.SetCredentials([]config.CredentialConfig{credential})
+	modelManager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	pricePath := t.TempDir() + "/prices.json"
+	require.NoError(t, os.WriteFile(pricePath, []byte(`{"public/shared":{"input_cost_per_token":0.001}}`), 0600))
+	policies, err := models.LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+		OrganizationID:  "org-1",
+		PriceProfileID:  "profile-1",
+		ModelPricesLink: pricePath,
+		ModelMappings:   map[string]string{"public/shared": "route-b"},
+	}}, modelManager, models.OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled: true, LiteLLMDBRequired: true, DisableSpendLogsWrite: false,
+	})
+	require.NoError(t, err)
+
+	f2b := fail2ban.New(3, 0, []int{401, 403, 500})
+	rl := ratelimit.New()
+	rl.AddCredential(credential.Name, credential.RPM)
+	tokenManager := auth.NewVertexTokenManager(logger)
+	defer tokenManager.Stop()
+	prx := proxy.New(&proxy.Config{
+		Balancer:               balancer.New([]config.CredentialConfig{credential}, f2b, rl),
+		Logger:                 logger,
+		MaxBodySizeMB:          10,
+		RequestTimeout:         30 * time.Second,
+		Metrics:                monitoring.New(false),
+		MasterKey:              "test-master-key",
+		RateLimiter:            rl,
+		TokenManager:           tokenManager,
+		ModelManager:           modelManager,
+		StrictAllTeamModelsACL: true,
+		OrganizationPolicies:   policies,
+	})
+	prx.LiteLLMDB = &routerAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"organization-key": {
+			Token: "organization-hash", DirectOrganizationID: "org-1", OrganizationID: "org-1",
+			Models: []string{"route-b"},
+		},
+	}}
+	router := New(prx, modelManager, testhelpers.NewTestMonitoringConfig("/health", false, ""), logger, nil)
+	req := httptest.NewRequest(http.MethodGet, "/v1/models", nil)
+	req.Header.Set("Authorization", "Bearer organization-key")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var response models.ModelsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	ids := make([]string, 0, len(response.Data))
+	for _, model := range response.Data {
+		ids = append(ids, model.ID)
+	}
+	assert.Contains(t, ids, "public/shared")
+}
+
 func TestServeHTTPPublicPreflightDoesNotEnableWildcardCORS(t *testing.T) {
 	router := New(nil, nil, testhelpers.NewTestMonitoringConfig("/health", false, ""), testhelpers.NewTestLogger(), nil)
 	req := httptest.NewRequest(http.MethodOptions, "/v1/chat/completions", nil)


### PR DESCRIPTION
Summary
- Add organization_policies config with strict policy decoding and immutable exact tariff profiles
- Add mapped organization model admission, catalog projection, frozen pricing, and SpendLog provenance metadata
- Preserve legacy behavior when policies are omitted or no organization policy matches

Verification
- git diff --check
- go test ./...
- go test -race ./cmd/server ./internal/config ./internal/models ./internal/proxy ./internal/router ./internal/litellmdb/auth ./internal/litellmdb/models
- make lint
- make build
- make docs-build