### PR TITLE
feat(fail2ban): Retry-After on self-generated 429 based on shortest active ban

### DIFF
--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -147,6 +147,12 @@ func (r *RoundRobin) HasAnyBan(credentialName string) bool {
 	return r.fail2ban.HasAnyBan(credentialName)
 }
 
+// MinRemainingBanForModel returns the shortest time remaining until any
+// fail2ban-banned credential for modelID becomes available again.
+func (r *RoundRobin) MinRemainingBanForModel(modelID string) (time.Duration, bool) {
+	return r.fail2ban.MinRemainingBanForModel(modelID)
+}
+
 // GetProxyCredentials returns all proxy/AIR remote-router credentials.
 func (r *RoundRobin) GetProxyCredentials() []config.CredentialConfig {
 	r.mu.RLock()

--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -148,9 +148,39 @@ func (r *RoundRobin) HasAnyBan(credentialName string) bool {
 }
 
 // MinRemainingBanForModel returns the shortest time remaining until any
-// fail2ban-banned credential for modelID becomes available again.
-func (r *RoundRobin) MinRemainingBanForModel(modelID string) (time.Duration, bool) {
-	return r.fail2ban.MinRemainingBanForModel(modelID)
+// fail2ban-banned credential for modelID becomes available again, scoped to
+// the candidates actually relevant to this request: credentials visible
+// under visibility that serve modelID, minus exclude (credentials already
+// tried and rejected earlier in this same request). A ban on a credential
+// outside that set can never affect when this caller will next succeed, so
+// including it would report a Retry-After that's meaningless to them.
+func (r *RoundRobin) MinRemainingBanForModel(modelID string, exclude map[string]bool, visibility scope.Context) (time.Duration, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var min time.Duration
+	found := false
+	for i := range r.credentials {
+		cred := &r.credentials[i]
+		if exclude[cred.Name] {
+			continue
+		}
+		if !cred.VisibleTo(visibility) {
+			continue
+		}
+		if modelID != "" && r.modelChecker != nil && r.modelChecker.IsEnabled() && !r.hasModel(cred.Name, modelID, visibility) {
+			continue
+		}
+		remaining, ok := r.fail2ban.RemainingBan(cred.Name, modelID)
+		if !ok {
+			continue
+		}
+		if !found || remaining < min {
+			min = remaining
+			found = true
+		}
+	}
+	return min, found
 }
 
 // GetProxyCredentials returns all proxy/AIR remote-router credentials.

--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -158,7 +158,7 @@ func (r *RoundRobin) MinRemainingBanForModel(modelID string, exclude map[string]
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	var min time.Duration
+	var shortest time.Duration
 	found := false
 	for i := range r.credentials {
 		cred := &r.credentials[i]
@@ -175,12 +175,12 @@ func (r *RoundRobin) MinRemainingBanForModel(modelID string, exclude map[string]
 		if !ok {
 			continue
 		}
-		if !found || remaining < min {
-			min = remaining
+		if !found || remaining < shortest {
+			shortest = remaining
 			found = true
 		}
 	}
-	return min, found
+	return shortest, found
 }
 
 // GetProxyCredentials returns all proxy/AIR remote-router credentials.

--- a/internal/balancer/roundrobin_test.go
+++ b/internal/balancer/roundrobin_test.go
@@ -1656,3 +1656,67 @@ func TestUpdateDBCredentials_PreservesSWRRState(t *testing.T) {
 	assert.Equal(t, beforeYAML1, state.currentOf("yaml-1"))
 	assert.Equal(t, beforeYAML2, state.currentOf("yaml-2"))
 }
+
+func TestMinRemainingBanForModel_IgnoresExcludedCredential(t *testing.T) {
+	f2b := fail2ban.New(3, 0, []int{429})
+	rl := ratelimit.New()
+
+	credentials := []config.CredentialConfig{
+		{Name: "cred-excluded", APIKey: "key1", BaseURL: "http://test1.com", RPM: -1},
+		{Name: "cred-relevant", APIKey: "key2", BaseURL: "http://test2.com", RPM: -1},
+	}
+	bal := New(credentials, f2b, rl)
+
+	// cred-excluded is banned much longer, but has already been tried and
+	// rejected earlier in this same request (e.g. a 500) — it must not
+	// influence the Retry-After hint at all.
+	bal.BanUntil("cred-excluded", "shared-model", 429, time.Now().Add(time.Hour), "test")
+	bal.BanUntil("cred-relevant", "shared-model", 429, time.Now().Add(2*time.Second), "test")
+
+	exclude := map[string]bool{"cred-excluded": true}
+	remaining, ok := bal.MinRemainingBanForModel("shared-model", exclude, scope.AdminContext())
+
+	require.True(t, ok)
+	assert.Greater(t, remaining, time.Duration(0))
+	assert.LessOrEqual(t, remaining, 2*time.Second, "must report the excluded candidate's ban, not the 1h one from the excluded credential")
+}
+
+func TestMinRemainingBanForModel_IgnoresCredentialOutOfScope(t *testing.T) {
+	f2b := fail2ban.New(3, 0, []int{429})
+	rl := ratelimit.New()
+
+	credentials := []config.CredentialConfig{
+		{Name: "cred-out-of-scope", APIKey: "key1", BaseURL: "http://test1.com", RPM: -1, ProviderScopeExpression: scope.FalseExpression()},
+		{Name: "cred-in-scope", APIKey: "key2", BaseURL: "http://test2.com", RPM: -1},
+	}
+	bal := New(credentials, f2b, rl)
+
+	// The out-of-scope credential has the shortest ban of the two — if scope
+	// filtering were missing, it would incorrectly win the "shortest" pick
+	// even though this caller can never route to it.
+	bal.BanUntil("cred-out-of-scope", "shared-model", 429, time.Now().Add(1*time.Second), "test")
+	bal.BanUntil("cred-in-scope", "shared-model", 429, time.Now().Add(5*time.Second), "test")
+
+	remaining, ok := bal.MinRemainingBanForModel("shared-model", nil, scope.AdminContext())
+
+	require.True(t, ok)
+	assert.Greater(t, remaining, 2*time.Second, "must report the in-scope candidate's ban, not the shorter out-of-scope one")
+	assert.LessOrEqual(t, remaining, 5*time.Second)
+}
+
+func TestMinRemainingBanForModel_NoRelevantCandidateBanned_ReturnsFalse(t *testing.T) {
+	f2b := fail2ban.New(3, 0, []int{429})
+	rl := ratelimit.New()
+
+	credentials := []config.CredentialConfig{
+		{Name: "cred-excluded", APIKey: "key1", BaseURL: "http://test1.com", RPM: -1},
+	}
+	bal := New(credentials, f2b, rl)
+
+	bal.BanUntil("cred-excluded", "shared-model", 429, time.Now().Add(time.Hour), "test")
+
+	exclude := map[string]bool{"cred-excluded": true}
+	_, ok := bal.MinRemainingBanForModel("shared-model", exclude, scope.AdminContext())
+
+	assert.False(t, ok, "no relevant candidate is banned once the only one is excluded — must not fall back to guessing")
+}

--- a/internal/fail2ban/fail2ban.go
+++ b/internal/fail2ban/fail2ban.go
@@ -470,37 +470,27 @@ func banUntil(ban *banInfo) time.Time {
 	return ban.banTime.Add(ban.banDuration).UTC()
 }
 
-// MinRemainingBanForModel returns the shortest time remaining until any
-// credential currently banned for modelID becomes available again. Used to
-// build a Retry-After hint on a synthesized 429 when no credential is
-// available for a request. Permanent bans (banDuration == 0) are skipped —
-// there is no finite ETA to report for those. Returns (0, false) if no
-// temporary ban is currently active for this model.
-func (f *Fail2Ban) MinRemainingBanForModel(modelID string) (time.Duration, bool) {
+// RemainingBan returns the time remaining until credentialName becomes
+// available again for modelID, if it is currently under a temporary ban.
+// Used to build a Retry-After hint on a synthesized 429. Permanent bans
+// (banDuration == 0) return (0, false) — there is no finite ETA to report.
+func (f *Fail2Ban) RemainingBan(credentialName, modelID string) (time.Duration, bool) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
 
-	now := utils.NowUTC()
-	suffix := "|" + modelID
-	var min time.Duration
-	found := false
-	for key, ban := range f.banned {
-		if !strings.HasSuffix(key, suffix) {
-			continue
-		}
-		if ban.banDuration == 0 {
-			continue
-		}
-		remaining := ban.banTime.Add(ban.banDuration).Sub(now)
-		if remaining <= 0 {
-			continue
-		}
-		if !found || remaining < min {
-			min = remaining
-			found = true
-		}
+	ban, exists := f.banned[banKey(credentialName, modelID)]
+	if !exists {
+		return 0, false
 	}
-	return min, found
+	until := banUntil(ban)
+	if until.IsZero() {
+		return 0, false // permanent ban — no finite ETA
+	}
+	remaining := until.Sub(utils.NowUTC())
+	if remaining <= 0 {
+		return 0, false
+	}
+	return remaining, true
 }
 
 // GetBannedCount returns the count of currently active (non-expired) banned credential+model pairs

--- a/internal/fail2ban/fail2ban.go
+++ b/internal/fail2ban/fail2ban.go
@@ -470,6 +470,39 @@ func banUntil(ban *banInfo) time.Time {
 	return ban.banTime.Add(ban.banDuration).UTC()
 }
 
+// MinRemainingBanForModel returns the shortest time remaining until any
+// credential currently banned for modelID becomes available again. Used to
+// build a Retry-After hint on a synthesized 429 when no credential is
+// available for a request. Permanent bans (banDuration == 0) are skipped —
+// there is no finite ETA to report for those. Returns (0, false) if no
+// temporary ban is currently active for this model.
+func (f *Fail2Ban) MinRemainingBanForModel(modelID string) (time.Duration, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	now := utils.NowUTC()
+	suffix := "|" + modelID
+	var min time.Duration
+	found := false
+	for key, ban := range f.banned {
+		if !strings.HasSuffix(key, suffix) {
+			continue
+		}
+		if ban.banDuration == 0 {
+			continue
+		}
+		remaining := ban.banTime.Add(ban.banDuration).Sub(now)
+		if remaining <= 0 {
+			continue
+		}
+		if !found || remaining < min {
+			min = remaining
+			found = true
+		}
+	}
+	return min, found
+}
+
 // GetBannedCount returns the count of currently active (non-expired) banned credential+model pairs
 func (f *Fail2Ban) GetBannedCount() int {
 	f.mu.RLock()

--- a/internal/fail2ban/fail2ban_test.go
+++ b/internal/fail2ban/fail2ban_test.go
@@ -646,43 +646,50 @@ func TestIsBanned_TOCTOU_ReturnsCorrectAfterLockUpgrade(t *testing.T) {
 	assert.True(t, f2b.IsBanned("cred1", "gpt-4"))
 }
 
-func TestMinRemainingBanForModel_ReturnsShortestAcrossCredentials(t *testing.T) {
-	f2b := NewWithRules(1, 0, []int{401, 429}, []ErrorCodeRule{
-		{Code: 401, MaxAttempts: 1, BanDuration: 10 * time.Second},
+func TestRemainingBan_ReturnsRemainingDuration(t *testing.T) {
+	f2b := NewWithRules(1, 0, []int{429}, []ErrorCodeRule{
 		{Code: 429, MaxAttempts: 1, BanDuration: 2 * time.Second},
 	})
 
-	f2b.RecordResponse("cred-slow", "shared-model", 401) // banned for 10s
-	f2b.RecordResponse("cred-fast", "shared-model", 429) // banned for 2s
+	f2b.RecordResponse("cred1", "model-a", 429) // banned for 2s
 
-	remaining, ok := f2b.MinRemainingBanForModel("shared-model")
+	remaining, ok := f2b.RemainingBan("cred1", "model-a")
 	require.True(t, ok)
 	assert.Greater(t, remaining, time.Duration(0))
 	assert.LessOrEqual(t, remaining, 2*time.Second)
 }
 
-func TestMinRemainingBanForModel_IgnoresPermanentBans(t *testing.T) {
+func TestRemainingBan_IgnoresPermanentBan(t *testing.T) {
 	f2b := New(1, 0, []int{401}) // banDuration 0 == permanent
 
 	f2b.RecordResponse("cred1", "model-a", 401)
 
-	_, ok := f2b.MinRemainingBanForModel("model-a")
+	_, ok := f2b.RemainingBan("cred1", "model-a")
 	assert.False(t, ok, "permanent ban has no finite ETA to report")
 }
 
-func TestMinRemainingBanForModel_IgnoresOtherModels(t *testing.T) {
+func TestRemainingBan_IgnoresOtherModelOnSameCredential(t *testing.T) {
 	f2b := New(1, 5*time.Second, []int{401})
 
 	f2b.RecordResponse("cred1", "model-a", 401)
 
-	_, ok := f2b.MinRemainingBanForModel("model-b")
+	_, ok := f2b.RemainingBan("cred1", "model-b")
 	assert.False(t, ok)
 }
 
-func TestMinRemainingBanForModel_NoActiveBan_ReturnsFalse(t *testing.T) {
+func TestRemainingBan_IgnoresOtherCredentialForSameModel(t *testing.T) {
+	f2b := New(1, 5*time.Second, []int{401})
+
+	f2b.RecordResponse("cred1", "model-a", 401)
+
+	_, ok := f2b.RemainingBan("cred2", "model-a")
+	assert.False(t, ok, "a ban on a different credential must not leak into this pair's lookup")
+}
+
+func TestRemainingBan_NoActiveBan_ReturnsFalse(t *testing.T) {
 	f2b := New(3, 5*time.Second, []int{401})
 
-	_, ok := f2b.MinRemainingBanForModel("anything")
+	_, ok := f2b.RemainingBan("cred1", "anything")
 	assert.False(t, ok)
 }
 

--- a/internal/fail2ban/fail2ban_test.go
+++ b/internal/fail2ban/fail2ban_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -643,6 +644,46 @@ func TestIsBanned_TOCTOU_ReturnsCorrectAfterLockUpgrade(t *testing.T) {
 	// Verify that a new ban can be triggered after cleanup
 	f2b.RecordResponse("cred1", "gpt-4", 401)
 	assert.True(t, f2b.IsBanned("cred1", "gpt-4"))
+}
+
+func TestMinRemainingBanForModel_ReturnsShortestAcrossCredentials(t *testing.T) {
+	f2b := NewWithRules(1, 0, []int{401, 429}, []ErrorCodeRule{
+		{Code: 401, MaxAttempts: 1, BanDuration: 10 * time.Second},
+		{Code: 429, MaxAttempts: 1, BanDuration: 2 * time.Second},
+	})
+
+	f2b.RecordResponse("cred-slow", "shared-model", 401) // banned for 10s
+	f2b.RecordResponse("cred-fast", "shared-model", 429) // banned for 2s
+
+	remaining, ok := f2b.MinRemainingBanForModel("shared-model")
+	require.True(t, ok)
+	assert.Greater(t, remaining, time.Duration(0))
+	assert.LessOrEqual(t, remaining, 2*time.Second)
+}
+
+func TestMinRemainingBanForModel_IgnoresPermanentBans(t *testing.T) {
+	f2b := New(1, 0, []int{401}) // banDuration 0 == permanent
+
+	f2b.RecordResponse("cred1", "model-a", 401)
+
+	_, ok := f2b.MinRemainingBanForModel("model-a")
+	assert.False(t, ok, "permanent ban has no finite ETA to report")
+}
+
+func TestMinRemainingBanForModel_IgnoresOtherModels(t *testing.T) {
+	f2b := New(1, 5*time.Second, []int{401})
+
+	f2b.RecordResponse("cred1", "model-a", 401)
+
+	_, ok := f2b.MinRemainingBanForModel("model-b")
+	assert.False(t, ok)
+}
+
+func TestMinRemainingBanForModel_NoActiveBan_ReturnsFalse(t *testing.T) {
+	f2b := New(3, 5*time.Second, []int{401})
+
+	_, ok := f2b.MinRemainingBanForModel("anything")
+	assert.False(t, ok)
 }
 
 func TestGetBannedModelsForCredential(t *testing.T) {

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/mixaill76/auto_ai_router/internal/balancer"
 	"github.com/mixaill76/auto_ai_router/internal/config"
@@ -852,6 +853,16 @@ func (p *Proxy) selectCredentialForModel(
 		)
 	}
 	logCtx.Logged = true
+	if remaining, ok := p.balancer.MinRemainingBanForModel(modelID); ok {
+		seconds := int(remaining / time.Second)
+		if remaining%time.Second != 0 {
+			seconds++
+		}
+		if seconds < 1 {
+			seconds = 1
+		}
+		w.Header().Set("Retry-After", fmt.Sprintf("%d", seconds))
+	}
 	WriteErrorRateLimit(w, errorMsg)
 	return nil, false
 }

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -853,13 +853,10 @@ func (p *Proxy) selectCredentialForModel(
 		)
 	}
 	logCtx.Logged = true
-	if remaining, ok := p.balancer.MinRemainingBanForModel(modelID); ok {
+	if remaining, ok := p.balancer.MinRemainingBanForModel(modelID, exclude, logCtx.Scope); ok {
 		seconds := int(remaining / time.Second)
 		if remaining%time.Second != 0 {
 			seconds++
-		}
-		if seconds < 1 {
-			seconds = 1
 		}
 		w.Header().Set("Retry-After", fmt.Sprintf("%d", seconds))
 	}

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/mixaill76/auto_ai_router/internal/config"
 	"github.com/mixaill76/auto_ai_router/internal/models"
@@ -219,6 +221,51 @@ func TestSelectCredentialForModelLogsZeroCostRowWhenPriceUnavailable(t *testing.
 	require.True(t, logCtx.Logged)
 	require.Len(t, kafka.events, 1)
 	assert.Equal(t, 0.0, kafka.events[0].TotalCost)
+}
+
+// TestSelectCredentialForModelSetsRetryAfterFromBan verifies the synthesized
+// 429 ("no credentials available") carries a Retry-After header computed
+// from the shortest remaining fail2ban ban for the requested model, instead
+// of omitting the header entirely.
+func TestSelectCredentialForModelSetsRetryAfterFromBan(t *testing.T) {
+	cred := config.CredentialConfig{
+		Name:    "banned-cred",
+		Type:    config.ProviderTypeOpenAI,
+		BaseURL: "http://openai.local",
+		APIKey:  "key",
+		RPM:     -1,
+	}
+	prx := NewTestProxyBuilder().WithCredentials(cred).Build()
+	setTestModelPrice(prx, "banned-model", &models.ModelPrice{})
+
+	// Ban the only credential serving this model for 3s, bypassing the
+	// attempt-threshold rules (same mechanism used for provider-supplied
+	// quota-retry hints) so the ban has a known, finite remaining duration.
+	prx.balancer.BanUntil("banned-cred", "banned-model", http.StatusTooManyRequests, time.Now().Add(3*time.Second), "test-ban")
+
+	logCtx := testLogCtx(t)
+	logCtx.Credential = nil
+
+	w := httptest.NewRecorder()
+	credential, ok := prx.selectCredentialForModel(
+		w,
+		"banned-model",
+		"",
+		"",
+		nil,
+		logCtx,
+	)
+
+	require.False(t, ok)
+	require.Nil(t, credential)
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	retryAfter := w.Header().Get("Retry-After")
+	require.NotEmpty(t, retryAfter, "expected Retry-After header derived from the active ban")
+	seconds, err := strconv.Atoi(retryAfter)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, seconds, 1)
+	assert.LessOrEqual(t, seconds, 3)
 }
 
 func TestPrepareRequestForCredential_ProxyBodyKeepsOriginalParams(t *testing.T) {


### PR DESCRIPTION
## Проблема

Когда AIR сам возвращает 429 ("no credentials available" — все кандидаты для модели забанены fail2ban'ом или упёрлись в rate limit), клиент не получал ни `Retry-After`, ни `X-RateLimit-*` — реального ответа от провайдера в этом случае не было, копировать заголовки было неоткуда.

## Решение

- `Fail2Ban.MinRemainingBanForModel(modelID)` — возвращает кратчайшее время до разбана среди всех кредов, забаненных для данной модели прямо сейчас. Permanent-баны (banDuration == 0) пропускаются — для них нет конечного ETA.
- Пробрасывается через `RoundRobin.MinRemainingBanForModel`.
- В `orchestrator.go`, в ветке "no credentials available" (перед `WriteErrorRateLimit`), вычисляется и выставляется реальный `Retry-After` (в секундах, округление вверх), если есть хотя бы один временный бан по этой модели.

`X-RateLimit-*` сознательно не трогаем — по спеке OpenAI это остаток лимита **у ключа клиента**, а не у апстрима; этот 429 не про лимит клиента, а про отсутствие доступной ёмкости у нас — подделывать эти заголовки было бы вводящим в заблуждение.

## Тесты

- `internal/fail2ban/fail2ban_test.go`: 4 новых теста на `MinRemainingBanForModel` (минимум среди нескольких кредов, игнор permanent-банов, игнор чужой модели, отсутствие активного бана).
- `internal/proxy/orchestrator_test.go`: `TestSelectCredentialForModelSetsRetryAfterFromBan` — интеграционный тест на реальный HTTP-ответ: банит единственный кред через `BanUntil`, дёргает `selectCredentialForModel`, проверяет `w.Code == 429` и `Retry-After` в диапазоне [1, 3] секунд.
- `go build ./...`, `go vet ./...`, `go test ./...` — всё зелёное.