### PR TITLE
Map rate limit error responses

### DIFF
--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -164,6 +164,31 @@ func TestProxyRequest_NonStreamingRateLimitBodyReturns429(t *testing.T) {
 	assert.NotContains(t, w.Body.String(), "rate_limit_exceeded")
 }
 
+func TestProxyRequest_NonStreamingBadRequestRateLimitBodyReturns429(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":{"code":"rate_limit_exceeded","message":"Request failed"}}`)
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("test", config.ProviderTypeProxy, mockServer.URL, "upstream-key-1").
+		Build()
+
+	reqBody := `{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Contains(t, w.Body.String(), "rate_limit_error")
+	assert.NotContains(t, w.Body.String(), "rate_limit_exceeded")
+}
+
 func TestProxyRequest_NonStreamingFailedResponseBodyReturns500(t *testing.T) {
 	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -27,13 +27,15 @@ func clientResponseBodyForCredential(statusCode int, body []byte, _ *config.Cred
 }
 
 func statusCodeFromProviderBodyError(statusCode int, body []byte) (int, bool) {
-	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices || len(body) == 0 {
+	if len(body) == 0 {
 		return 0, false
 	}
 
 	var evt struct {
 		Type     string          `json:"type"`
 		Status   string          `json:"status"`
+		Code     string          `json:"code"`
+		Message  string          `json:"message"`
 		Error    json.RawMessage `json:"error"`
 		Response struct {
 			Status string          `json:"status"`
@@ -44,17 +46,33 @@ func statusCodeFromProviderBodyError(statusCode int, body []byte) (int, bool) {
 		return 0, false
 	}
 
-	signals := []string{evt.Type, evt.Status, evt.Response.Status}
+	signals := []string{evt.Type, evt.Status, evt.Code, evt.Message, evt.Response.Status}
 	topErrorSignals, hasTopError := providerErrorSignals(evt.Error)
 	responseErrorSignals, hasResponseError := providerErrorSignals(evt.Response.Error)
 	signals = append(signals, topErrorSignals...)
 	signals = append(signals, responseErrorSignals...)
 
 	hasFailedStatus := strings.EqualFold(evt.Status, "failed") || strings.EqualFold(evt.Response.Status, "failed")
-	if !hasTopError && !hasResponseError && !hasFailedStatus {
-		return 0, false
+	hasTopLevelError := strings.TrimSpace(evt.Code) != "" || strings.TrimSpace(evt.Message) != ""
+
+	if statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices {
+		if !hasTopError && !hasResponseError && !hasFailedStatus {
+			return 0, false
+		}
+		return statusCodeFromErrorSignals(signals), true
 	}
-	return statusCodeFromErrorSignals(signals), true
+
+	if statusCode >= http.StatusBadRequest {
+		if !hasTopError && !hasResponseError && !hasTopLevelError && !hasFailedStatus {
+			return 0, false
+		}
+		mappedStatus := statusCodeFromErrorSignals(signals)
+		if mappedStatus == http.StatusTooManyRequests && statusCode != http.StatusTooManyRequests {
+			return mappedStatus, true
+		}
+	}
+
+	return 0, false
 }
 
 const maxProxyStreamErrorCaptureBytes = 256 * 1024

--- a/internal/proxy/response_writer_terminal_error_test.go
+++ b/internal/proxy/response_writer_terminal_error_test.go
@@ -247,9 +247,23 @@ func TestStatusCodeFromProviderBodyError(t *testing.T) {
 			wantOK:     false,
 		},
 		{
-			name:       "real error status not remapped",
-			statusCode: http.StatusBadGateway,
+			name:       "error status rate limit body",
+			statusCode: http.StatusBadRequest,
 			body:       `{"error":{"code":"rate_limit_exceeded"}}`,
+			wantStatus: http.StatusTooManyRequests,
+			wantOK:     true,
+		},
+		{
+			name:       "error status top level rate limit body",
+			statusCode: http.StatusInternalServerError,
+			body:       `{"code":"rate_limit_exceeded","message":"rate limited"}`,
+			wantStatus: http.StatusTooManyRequests,
+			wantOK:     true,
+		},
+		{
+			name:       "non rate limit error status not remapped",
+			statusCode: http.StatusBadRequest,
+			body:       `{"error":{"code":"invalid_request_error","message":"invalid parameter"}}`,
 			wantOK:     false,
 		},
 	}


### PR DESCRIPTION
## Summary
- Remap upstream error responses with rate limit signals to 429
- Keep non rate limit error statuses unchanged
- Add classifier and proxy regression coverage

## Verification
- go test ./internal/proxy
- go test ./...
- go vet ./...
- make lint
- go test -race -coverprofile=coverage.out -covermode=atomic ./...