### PR TITLE
Add request id to error bodies

### DIFF
--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -5,11 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"strings"
+
+	"github.com/mixaill76/auto_ai_router/internal/requestid"
 )
 
 // APIErrorResponse represents an OpenAI-compatible error response.
 type APIErrorResponse struct {
-	Error APIError `json:"error"`
+	Error     APIError `json:"error"`
+	RequestID string   `json:"request_id,omitempty"`
 }
 
 // APIError represents the error object inside an OpenAI-compatible error response.
@@ -61,11 +64,16 @@ func WriteJSONError(w http.ResponseWriter, statusCode int, message, errorType st
 			Param:   param,
 			Code:    code,
 		},
+		RequestID: errorBodyRequestID(w.Header().Get(requestid.Header)),
 	}
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
-func maskedUpstreamErrorBody(statusCode int, rawBodies ...[]byte) []byte {
+func errorBodyRequestID(id string) string {
+	return requestid.Canonical(id)
+}
+
+func maskedUpstreamErrorBody(statusCode int, requestID string, rawBodies ...[]byte) []byte {
 	message := "Request failed"
 	code := "api_error"
 	param := (*string)(nil)
@@ -91,6 +99,7 @@ func maskedUpstreamErrorBody(statusCode int, rawBodies ...[]byte) []byte {
 			Code:    &code,
 		},
 	}
+	resp.RequestID = errorBodyRequestID(requestID)
 	body, err := json.Marshal(resp)
 	if err != nil {
 		return []byte(`{"error":{"message":"Request failed","type":"api_error","param":null,"code":"api_error"}}`)

--- a/internal/proxy/errors_test.go
+++ b/internal/proxy/errors_test.go
@@ -7,7 +7,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mixaill76/auto_ai_router/internal/requestid"
 	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWriteJSONError(t *testing.T) {
@@ -38,6 +41,26 @@ func TestWriteJSONError(t *testing.T) {
 			testhelpers.AssertJSONErrorResponse(t, recorder, tt.statusCode, tt.wantType, "test message")
 		})
 	}
+}
+
+func TestWriteJSONErrorIncludesRequestIDFromHeader(t *testing.T) {
+	const id = "0123456789abcdef0123456789abcdef"
+	recorder := httptest.NewRecorder()
+	recorder.Header().Set(requestid.Header, id)
+
+	WriteJSONError(recorder, http.StatusTooManyRequests, "test message", errorTypeForStatus(http.StatusTooManyRequests), nil, nil)
+
+	var response APIErrorResponse
+	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &response))
+	assert.Equal(t, id, response.RequestID)
+}
+
+func TestMaskedUpstreamErrorBodyIncludesRequestID(t *testing.T) {
+	const id = "0123456789abcdef0123456789abcdef"
+
+	var response APIErrorResponse
+	require.NoError(t, json.Unmarshal(maskedUpstreamErrorBody(http.StatusTooManyRequests, id), &response))
+	assert.Equal(t, id, response.RequestID)
 }
 
 func TestWriteErrorConvenienceFunctions(t *testing.T) {
@@ -126,7 +149,7 @@ func TestMaskedUpstreamErrorBodyClassifiesBadRequest(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			body := maskedUpstreamErrorBody(http.StatusBadRequest, []byte(tt.body))
+			body := maskedUpstreamErrorBody(http.StatusBadRequest, "", []byte(tt.body))
 
 			var resp APIErrorResponse
 			err := json.Unmarshal(body, &resp)
@@ -155,7 +178,7 @@ func TestMaskedUpstreamErrorBodyClassifiesBadRequest(t *testing.T) {
 }
 
 func TestMaskedUpstreamErrorBodyKeepsGenericNonBadRequest(t *testing.T) {
-	body := maskedUpstreamErrorBody(http.StatusBadGateway, []byte(`{"error":{"message":"upstream failed"}}`))
+	body := maskedUpstreamErrorBody(http.StatusBadGateway, "", []byte(`{"error":{"message":"upstream failed"}}`))
 
 	var resp APIErrorResponse
 	if err := json.Unmarshal(body, &resp); err != nil {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -821,6 +821,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 	if requestID == "" {
 		requestID = requestid.New()
 	}
+	w.Header().Set(requestid.Header, requestID)
 	if info := responseCompatRequestFromContext(r.Context()); info != nil {
 		info.RequestID = requestID
 	}
@@ -2119,7 +2120,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			resp.StatusCode = mappedStatus
 		}
 		rawErrorBody := finalResponseBody
-		clientBody, clientBodyChanged, clientBodyMasked := clientResponseBodyForCredential(resp.StatusCode, finalResponseBody, cred, modelID)
+		clientBody, clientBodyChanged, clientBodyMasked := clientResponseBodyForCredential(resp.StatusCode, finalResponseBody, cred, modelID, logCtx.RequestID)
 		if clientBodyChanged {
 			finalResponseBody = clientBody
 			bodyForTokenExtraction = clientBody
@@ -2231,7 +2232,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			p.logUpstreamError(r.Context(), "Upstream returned error status on streaming response", resp.StatusCode, cred, modelID, nil,
 				"url", targetURL,
 				"request_id", logCtx.RequestID)
-			body := maskedUpstreamErrorBody(resp.StatusCode)
+			body := maskedUpstreamErrorBody(resp.StatusCode, logCtx.RequestID)
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
 			dropRepresentationIntegrityHeaders(w.Header())

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -821,6 +821,9 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 	if requestID == "" {
 		requestID = requestid.New()
 	}
+	// Normally requestid.Middleware already set this header to the same value;
+	// re-set it so the fallback-minted ID (middleware didn't run) still reaches
+	// the client and stays consistent with what we log below.
 	w.Header().Set(requestid.Header, requestID)
 	if info := responseCompatRequestFromContext(r.Context()); info != nil {
 		info.RequestID = requestID

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/models"
 	"github.com/mixaill76/auto_ai_router/internal/monitoring"
 	"github.com/mixaill76/auto_ai_router/internal/ratelimit"
+	"github.com/mixaill76/auto_ai_router/internal/requestid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -160,7 +161,10 @@ func TestProxyRequest_NonStreamingRateLimitBodyReturns429(t *testing.T) {
 	prx.ProxyRequest(w, req)
 
 	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	id := w.Header().Get(requestid.Header)
+	assert.NotEmpty(t, id)
 	assert.Contains(t, w.Body.String(), "rate_limit_error")
+	assert.Contains(t, w.Body.String(), `"request_id":"`+id+`"`)
 	assert.NotContains(t, w.Body.String(), "rate_limit_exceeded")
 }
 

--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -12,7 +12,6 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/converter"
 	promanutils "github.com/mixaill76/auto_ai_router/internal/converter/proman/utils"
 	"github.com/mixaill76/auto_ai_router/internal/proxy/modelutils"
-	"github.com/mixaill76/auto_ai_router/internal/requestid"
 )
 
 func clientResponseBodyForCredential(statusCode int, body []byte, _ *config.CredentialConfig, displayModel, requestID string) ([]byte, bool, bool) {
@@ -272,22 +271,26 @@ func statusCodeFromErrorSignals(signals []string) int {
 	return http.StatusBadGateway
 }
 
-func writeProviderStreamErrorBeforeCommit(w http.ResponseWriter, statusCode int) {
-	body := maskedUpstreamErrorBody(statusCode, w.Header().Get(requestid.Header))
+func writeProviderStreamErrorBeforeCommit(w http.ResponseWriter, statusCode int, requestID string) {
+	body := maskedUpstreamErrorBody(statusCode, requestID)
 	header := w.Header()
 	header.Set("Content-Type", "application/json")
 	header.Set("Content-Length", itoa(len(body)))
 	header.Del(accelBufferingHeader)
 	dropRepresentationIntegrityHeaders(header)
 	w.WriteHeader(statusCode)
-	_, _ = w.Write(body) //nolint:gosec // G705 body is JSON with a canonical trace id only
+	_, _ = w.Write(body) //nolint:gosec // G705: body is our own application/json (maskedUpstreamErrorBody), not attacker-controlled HTML
 }
 
-func responseRequestID(logCtx *RequestLogContext) string {
+// logContextRequestID returns the raw request ID from logCtx (nil-safe). The
+// value is canonicalized at the sink (errorBodyRequestID), so callers pass it
+// through unnormalized — matching the other clientResponseBodyForCredential /
+// maskedUpstreamErrorBody call sites in proxy.go.
+func logContextRequestID(logCtx *RequestLogContext) string {
 	if logCtx == nil {
 		return ""
 	}
-	return errorBodyRequestID(logCtx.RequestID)
+	return logCtx.RequestID
 }
 
 // resolveCapturedProviderStreamError finalizes one or more bounded stream
@@ -360,7 +363,7 @@ func (p *Proxy) writeProxyResponse(w http.ResponseWriter, resp *ProxyResponse, c
 	if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, resp.Body); ok {
 		resp.StatusCode = mappedStatus
 	}
-	responseBody, responseBodyChanged, responseBodyMasked := clientResponseBodyForCredential(resp.StatusCode, resp.Body, cred, modelID, responseRequestID(logCtx))
+	responseBody, responseBodyChanged, responseBodyMasked := clientResponseBodyForCredential(resp.StatusCode, resp.Body, cred, modelID, logContextRequestID(logCtx))
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		endpoint := endpointFromRequest(clientReq)
 		if logCtx != nil && logCtx.Request != nil {
@@ -435,7 +438,7 @@ func (p *Proxy) writeProxyResponse(w http.ResponseWriter, resp *ProxyResponse, c
 
 	w.Header().Set("Content-Length", itoa(len(responseBody)))
 	w.WriteHeader(resp.StatusCode)
-	if _, err := w.Write(responseBody); err != nil { //nolint:gosec // G705 response body is proxied or JSON with a canonical trace id only
+	if _, err := w.Write(responseBody); err != nil { //nolint:gosec // G705: proxied upstream body / our own masked JSON error, forwarded verbatim by design; not HTML we render
 		if isClientDisconnectError(err) {
 			p.logger.DebugContext(clientReq.Context(), "Client disconnected during proxy response write", "error", err)
 			p.recordAbortedRequest(credName, endpointFromRequest(clientReq), modelID)

--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -12,11 +12,12 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/converter"
 	promanutils "github.com/mixaill76/auto_ai_router/internal/converter/proman/utils"
 	"github.com/mixaill76/auto_ai_router/internal/proxy/modelutils"
+	"github.com/mixaill76/auto_ai_router/internal/requestid"
 )
 
-func clientResponseBodyForCredential(statusCode int, body []byte, _ *config.CredentialConfig, displayModel string) ([]byte, bool, bool) {
+func clientResponseBodyForCredential(statusCode int, body []byte, _ *config.CredentialConfig, displayModel, requestID string) ([]byte, bool, bool) {
 	if statusCode >= 400 {
-		masked := maskedUpstreamErrorBody(statusCode, body)
+		masked := maskedUpstreamErrorBody(statusCode, requestID, body)
 		return masked, !bytes.Equal(body, masked), true
 	}
 	if statusCode >= 200 && statusCode < 300 {
@@ -272,14 +273,21 @@ func statusCodeFromErrorSignals(signals []string) int {
 }
 
 func writeProviderStreamErrorBeforeCommit(w http.ResponseWriter, statusCode int) {
-	body := maskedUpstreamErrorBody(statusCode)
+	body := maskedUpstreamErrorBody(statusCode, w.Header().Get(requestid.Header))
 	header := w.Header()
 	header.Set("Content-Type", "application/json")
 	header.Set("Content-Length", itoa(len(body)))
 	header.Del(accelBufferingHeader)
 	dropRepresentationIntegrityHeaders(header)
 	w.WriteHeader(statusCode)
-	_, _ = w.Write(body)
+	_, _ = w.Write(body) //nolint:gosec // G705 body is JSON with a canonical trace id only
+}
+
+func responseRequestID(logCtx *RequestLogContext) string {
+	if logCtx == nil {
+		return ""
+	}
+	return errorBodyRequestID(logCtx.RequestID)
 }
 
 // resolveCapturedProviderStreamError finalizes one or more bounded stream
@@ -352,7 +360,7 @@ func (p *Proxy) writeProxyResponse(w http.ResponseWriter, resp *ProxyResponse, c
 	if mappedStatus, ok := statusCodeFromProviderBodyError(resp.StatusCode, resp.Body); ok {
 		resp.StatusCode = mappedStatus
 	}
-	responseBody, responseBodyChanged, responseBodyMasked := clientResponseBodyForCredential(resp.StatusCode, resp.Body, cred, modelID)
+	responseBody, responseBodyChanged, responseBodyMasked := clientResponseBodyForCredential(resp.StatusCode, resp.Body, cred, modelID, responseRequestID(logCtx))
 	if resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices {
 		endpoint := endpointFromRequest(clientReq)
 		if logCtx != nil && logCtx.Request != nil {
@@ -427,7 +435,7 @@ func (p *Proxy) writeProxyResponse(w http.ResponseWriter, resp *ProxyResponse, c
 
 	w.Header().Set("Content-Length", itoa(len(responseBody)))
 	w.WriteHeader(resp.StatusCode)
-	if _, err := w.Write(responseBody); err != nil {
+	if _, err := w.Write(responseBody); err != nil { //nolint:gosec // G705 response body is proxied or JSON with a canonical trace id only
 		if isClientDisconnectError(err) {
 			p.logger.DebugContext(clientReq.Context(), "Client disconnected during proxy response write", "error", err)
 			p.recordAbortedRequest(credName, endpointFromRequest(clientReq), modelID)

--- a/internal/proxy/response_writer_usage_test.go
+++ b/internal/proxy/response_writer_usage_test.go
@@ -232,7 +232,7 @@ func TestClientResponseBodyForProManMasksErrors(t *testing.T) {
 	cred := &config.CredentialConfig{Name: "proman", Type: config.ProviderTypeProMan}
 	raw := []byte(`{"error":{"message":"litellm.BadRequestError: Received Model Group=anthropic/claude/anthropic-direct-client-0dce8b1a Available Model Group Fallbacks=None"}}`)
 
-	body, changed, masked := clientResponseBodyForCredential(400, raw, cred, "claude-haiku-4.5")
+	body, changed, masked := clientResponseBodyForCredential(400, raw, cred, "claude-haiku-4.5", "0123456789abcdef0123456789abcdef")
 
 	require.True(t, changed)
 	require.True(t, masked)
@@ -240,6 +240,7 @@ func TestClientResponseBodyForProManMasksErrors(t *testing.T) {
 	assert.NotContains(t, string(body), "anthropic-direct-client")
 	assert.NotContains(t, string(body), "Model Group")
 	assert.Contains(t, string(body), "Invalid model")
+	assert.Contains(t, string(body), `"request_id":"0123456789abcdef0123456789abcdef"`)
 }
 
 func TestWriteProxyStreamingResponseNormalizesQwenUsage(t *testing.T) {

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -1435,7 +1435,7 @@ func (p *Proxy) streamToClient(
 		if logCtx != nil {
 			logCtx.StreamOutcome = "stream_error"
 		}
-		writeProviderStreamErrorBeforeCommit(w, statusCode)
+		writeProviderStreamErrorBeforeCommit(w, statusCode, logContextRequestID(logCtx))
 		if onWriteErr != nil {
 			onWriteErr()
 		}

--- a/internal/proxy/stream_terminal_error_test.go
+++ b/internal/proxy/stream_terminal_error_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -130,6 +131,51 @@ func TestStreamingHandlersDetectFragmentedTerminalErrorsAcrossReads(t *testing.T
 			assert.Contains(t, logCtx.ErrorMsg, tt.wantMarker)
 		})
 	}
+}
+
+// TestEarlyStreamErrorBodyCarriesRequestIDFromLogContext guards the fix for the
+// PR #165 review: writeProviderStreamErrorBeforeCommit must take the request ID
+// from the in-scope RequestLogContext, not from w.Header(). The recorder here
+// has no X-Request-Id header set, yet the masked error body must still echo the
+// canonical trace ID so a client can correlate an early stream failure.
+func TestEarlyStreamErrorBodyCarriesRequestIDFromLogContext(t *testing.T) {
+	const requestID = "0123456789abcdef0123456789abcdef"
+	terminalChunks := []string{
+		"event: error\n",
+		`data: {"type":"error","error":{"type":"overloaded_error","message":"early terminal failure"}}` + "\n\n",
+	}
+
+	prx := NewTestProxyBuilder().Build()
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	credential := &config.CredentialConfig{Name: "terminal-provider", Type: config.ProviderTypeOpenAI, BaseURL: "https://provider.invalid"}
+	logCtx := &RequestLogContext{
+		RequestID:   requestID,
+		StartTime:   time.Now().UTC(),
+		Request:     request,
+		Credential:  credential,
+		ModelID:     "gpt-4o-mini",
+		RealModelID: "gpt-4o-mini",
+		TargetURL:   credential.BaseURL,
+	}
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": {"text/event-stream"}},
+		Body:       &fragmentedStreamReadCloser{chunks: stringChunks(terminalChunks)},
+		Request:    request,
+	}
+	w := httptest.NewRecorder()
+
+	err := prx.handleStreamingWithTokens(w, resp, "direct-openai", "gpt-4o-mini", logCtx)
+
+	var terminalErr proxyProviderStreamError
+	require.ErrorAs(t, err, &terminalErr)
+	require.True(t, terminalErr.beforeCommit, "error must be caught before the stream is committed")
+	assert.Empty(t, w.Header().Get("X-Request-Id"), "recorder intentionally has no request-id header")
+
+	var body APIErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &body))
+	assert.Equal(t, requestID, body.RequestID)
+	assert.NotContains(t, w.Body.String(), "early terminal failure")
 }
 
 // TestHandleAnthropicCompatibleStreamingMasksInStreamErrorForAllCredentialTypes

--- a/internal/requestid/requestid.go
+++ b/internal/requestid/requestid.go
@@ -51,12 +51,9 @@ func FromContext(ctx context.Context) string {
 	return id
 }
 
-// Valid reports whether id is a valid lowercase 32-hex trace ID.
-func Valid(id string) bool {
-	return Canonical(id) != ""
-}
-
-// Canonical returns id as a normalized trace ID, or "" when invalid.
+// Canonical returns id as a normalized trace ID, or "" when invalid. A valid
+// ID is exactly 32 lowercase hex chars and not all-zero (see New / the OTel
+// trace ID contract).
 func Canonical(id string) string {
 	tid, err := trace.TraceIDFromHex(id)
 	if err != nil || !tid.IsValid() {

--- a/internal/requestid/requestid.go
+++ b/internal/requestid/requestid.go
@@ -51,6 +51,24 @@ func FromContext(ctx context.Context) string {
 	return id
 }
 
+// Valid reports whether id is a valid lowercase 32-hex trace ID.
+func Valid(id string) bool {
+	return Canonical(id) != ""
+}
+
+// Canonical returns id as a normalized trace ID, or "" when invalid.
+func Canonical(id string) string {
+	tid, err := trace.TraceIDFromHex(id)
+	if err != nil || !tid.IsValid() {
+		return ""
+	}
+	canonical := tid.String()
+	if canonical != id {
+		return ""
+	}
+	return canonical
+}
+
 var traceparentPropagator = propagation.TraceContext{}
 
 // fromTraceparent extracts the trace ID from a trusted inbound W3C

--- a/internal/requestid/requestid_test.go
+++ b/internal/requestid/requestid_test.go
@@ -63,12 +63,13 @@ func TestMiddlewareIgnoresIncomingTraceparentWhenNotTrusted(t *testing.T) {
 	assert.NotEqual(t, "4bf92f3577b34da6a3ce929d0e0e4736", rec.Header().Get(Header))
 }
 
-func TestValid(t *testing.T) {
-	assert.True(t, Valid("4bf92f3577b34da6a3ce929d0e0e4736"))
-	assert.False(t, Valid(""))
-	assert.False(t, Valid("4BF92F3577B34DA6A3CE929D0E0E4736"))
-	assert.False(t, Valid("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"))
-	assert.False(t, Valid("00000000000000000000000000000000"))
+func TestCanonical(t *testing.T) {
+	assert.Equal(t, "4bf92f3577b34da6a3ce929d0e0e4736", Canonical("4bf92f3577b34da6a3ce929d0e0e4736"))
+	assert.Empty(t, Canonical(""))
+	assert.Empty(t, Canonical("4BF92F3577B34DA6A3CE929D0E0E4736"), "uppercase is not canonical")
+	assert.Empty(t, Canonical("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"), "non-hex is rejected")
+	assert.Empty(t, Canonical("00000000000000000000000000000000"), "all-zero trace ID is invalid")
+	assert.Empty(t, Canonical("4bf92f3577b34da6"), "short input is rejected")
 }
 
 func TestFromContextEmptyWhenUnset(t *testing.T) {

--- a/internal/requestid/requestid_test.go
+++ b/internal/requestid/requestid_test.go
@@ -63,6 +63,14 @@ func TestMiddlewareIgnoresIncomingTraceparentWhenNotTrusted(t *testing.T) {
 	assert.NotEqual(t, "4bf92f3577b34da6a3ce929d0e0e4736", rec.Header().Get(Header))
 }
 
+func TestValid(t *testing.T) {
+	assert.True(t, Valid("4bf92f3577b34da6a3ce929d0e0e4736"))
+	assert.False(t, Valid(""))
+	assert.False(t, Valid("4BF92F3577B34DA6A3CE929D0E0E4736"))
+	assert.False(t, Valid("zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz"))
+	assert.False(t, Valid("00000000000000000000000000000000"))
+}
+
 func TestFromContextEmptyWhenUnset(t *testing.T) {
 	assert.Empty(t, FromContext(context.TODO()))
 	assert.Empty(t, FromContext(httptest.NewRequest(http.MethodGet, "/", nil).Context()))


### PR DESCRIPTION
Summary

- Add request_id to OpenAI-compatible error bodies when X-Request-Id is present
- Add request_id to masked upstream error bodies
- Validate request_id as a canonical trace id before writing it to JSON
- Preserve the existing X-Request-Id header

Verification

- go test ./internal/proxy ./internal/requestid
- go test ./...
- go vet ./...
- make lint
- go test -race -coverprofile=coverage.out -covermode=atomic ./...