### PR TITLE
Log reasoning requests

### DIFF
--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -83,7 +83,9 @@ func (p *Proxy) orchestrateRequest(
 		return nil, false
 	}
 
-	routingExclusions := p.reasoningOnlyExclusions(body)
+	logCtx.RequestEndpoint = r.URL.Path
+	logCtx.ReasoningRequested, logCtx.ReasoningSource = requestReasoning(body)
+	routingExclusions := p.reasoningOnlyExclusions(logCtx.ReasoningRequested)
 	triedCreds := GetTried(r.Context())
 	for name := range routingExclusions {
 		triedCreds[name] = true

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -55,6 +55,58 @@ func TestOrchestrateRequest_ResponsesAPIStreaming(t *testing.T) {
 	require.Equal(t, true, streamOptions["include_usage"])
 }
 
+func TestOrchestrateRequest_RecordsReasoningRequestMetadata(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		body     string
+		source   string
+		endpoint string
+	}{
+		{
+			name:     "chat completions",
+			path:     "/v1/chat/completions",
+			body:     `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"test"}],"reasoning_effort":"high"}`,
+			source:   "reasoning_effort",
+			endpoint: "/v1/chat/completions",
+		},
+		{
+			name:     "responses",
+			path:     "/v1/responses",
+			body:     `{"model":"claude-opus-4-8","input":"test","reasoning":{"effort":"high"}}`,
+			source:   "reasoning",
+			endpoint: "/v1/responses",
+		},
+		{
+			name:     "messages",
+			path:     "/v1/messages",
+			body:     `{"model":"claude-opus-4-8","max_tokens":4096,"thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`,
+			source:   "thinking",
+			endpoint: "/v1/messages",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			prx := NewTestProxyBuilder().
+				WithSingleCredential("test", config.ProviderTypeAnthropic, "http://test.local", "upstream-key").
+				WithMasterKey("master-key").
+				Build()
+			req := httptest.NewRequest(http.MethodPost, tt.path, strings.NewReader(tt.body))
+			req.Header.Set("Authorization", "Bearer master-key")
+			logCtx := &RequestLogContext{}
+
+			prepared, ok := prx.orchestrateRequest(httptest.NewRecorder(), req, logCtx)
+
+			require.True(t, ok)
+			require.NotNil(t, prepared)
+			assert.True(t, logCtx.ReasoningRequested)
+			assert.Equal(t, tt.source, logCtx.ReasoningSource)
+			assert.Equal(t, tt.endpoint, logCtx.RequestEndpoint)
+		})
+	}
+}
+
 func TestOrchestrateRequest_ResponsesAPI_PassthroughForOpenAI(t *testing.T) {
 	logger := testhelpers.NewTestLogger()
 	prx := NewTestProxyBuilder().

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -272,11 +272,14 @@ type RequestLogContext struct {
 	ImageCount            int                      // Number of images to generate (from 'n' param)
 	WebSearchRequested    bool                     // True when the request enabled the built-in web search tool
 	WebSearchContextSize  string                   // low|medium|high from web_search_options/tool config
-	Logged                bool                     // True if already logged (prevents duplicate logging)
-	IsResponsesAPI        bool                     // True if this is a Responses API request (converted to Chat Completions)
-	RequestCompleted      bool                     // True only after the response was fully and successfully delivered
-	ActualCredentialName  string                   // Real credential name from upstream when Credential.Type == ProviderTypeProxy
-	IsProxyRequest        bool                     // True when this request came from another auto_ai_router (HeaderAIRProxyClient)
+	ReasoningRequested    bool
+	ReasoningSource       string
+	RequestEndpoint       string
+	Logged                bool   // True if already logged (prevents duplicate logging)
+	IsResponsesAPI        bool   // True if this is a Responses API request (converted to Chat Completions)
+	RequestCompleted      bool   // True only after the response was fully and successfully delivered
+	ActualCredentialName  string // Real credential name from upstream when Credential.Type == ProviderTypeProxy
+	IsProxyRequest        bool   // True when this request came from another auto_ai_router (HeaderAIRProxyClient)
 	Scope                 scope.Context
 	OrganizationPolicy    *models.OrganizationPolicy
 	BillingProfileID      string

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -363,6 +363,33 @@ func addAIRSpendMetadata(metadata, eventID, providerResponseID string, isProxyRe
 	return string(encoded)
 }
 
+func addRequestSpendMetadata(metadata string, logCtx *RequestLogContext) string {
+	if logCtx == nil {
+		return metadata
+	}
+	var doc map[string]interface{}
+	if json.Unmarshal([]byte(metadata), &doc) != nil || doc == nil {
+		doc = make(map[string]interface{})
+	}
+	spendMetadata, _ := doc["spend_logs_metadata"].(map[string]interface{})
+	if spendMetadata == nil {
+		spendMetadata = make(map[string]interface{})
+		doc["spend_logs_metadata"] = spendMetadata
+	}
+	spendMetadata["reasoning_requested"] = logCtx.ReasoningRequested
+	if logCtx.ReasoningSource != "" {
+		spendMetadata["reasoning_source"] = logCtx.ReasoningSource
+	}
+	if logCtx.RequestEndpoint != "" {
+		spendMetadata["request_endpoint"] = logCtx.RequestEndpoint
+	}
+	encoded, err := json.Marshal(doc)
+	if err != nil {
+		return metadata
+	}
+	return string(encoded)
+}
+
 func addOrganizationPolicySpendMetadata(metadata string, logCtx *RequestLogContext) string {
 	if logCtx == nil || logCtx.OrganizationPolicy == nil {
 		return metadata

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -349,6 +349,35 @@ func TestAddAIRSpendMetadata(t *testing.T) {
 	})
 }
 
+func TestAddRequestSpendMetadata(t *testing.T) {
+	t.Run("reasoning requested", func(t *testing.T) {
+		metadata := addRequestSpendMetadata(`{"spend_logs_metadata":{"air_event_id":"event-1"}}`, &RequestLogContext{
+			ReasoningRequested: true,
+			ReasoningSource:    "extra_body.reasoning_effort",
+			RequestEndpoint:    "/v1/chat/completions",
+		})
+
+		var doc map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(metadata), &doc))
+		spendMetadata := doc["spend_logs_metadata"].(map[string]interface{})
+		assert.Equal(t, "event-1", spendMetadata["air_event_id"])
+		assert.Equal(t, true, spendMetadata["reasoning_requested"])
+		assert.Equal(t, "extra_body.reasoning_effort", spendMetadata["reasoning_source"])
+		assert.Equal(t, "/v1/chat/completions", spendMetadata["request_endpoint"])
+	})
+
+	t.Run("reasoning absent", func(t *testing.T) {
+		metadata := addRequestSpendMetadata("{}", &RequestLogContext{RequestEndpoint: "/v1/messages"})
+
+		var doc map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(metadata), &doc))
+		spendMetadata := doc["spend_logs_metadata"].(map[string]interface{})
+		assert.Equal(t, false, spendMetadata["reasoning_requested"])
+		assert.NotContains(t, spendMetadata, "reasoning_source")
+		assert.Equal(t, "/v1/messages", spendMetadata["request_endpoint"])
+	})
+}
+
 func TestExtractEndUser(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -347,6 +347,7 @@ func (p *Proxy) logSpendToLiteLLMDB(logCtx *RequestLogContext) error {
 	overheadMs := float64(time.Since(logCtx.StartTime).Microseconds()) / 1000.0
 	metadata := buildMetadata(hashedToken, logCtx.TokenInfo, logCtx.ErrorMsg, logCtx.HTTPStatus, logCtx.TokenUsage, requesterIP, tokenCosts, logCtx.ModelID, overheadMs, kafkaFallbackReason)
 	metadata = addAIRSpendMetadata(metadata, logCtx.RequestID, logCtx.ClientResponseID, logCtx.IsProxyRequest, logCtx.ModelID, logCtx.PublicModelID, logCtx.billingPriceModelID)
+	metadata = addRequestSpendMetadata(metadata, logCtx)
 	metadata = addOrganizationPolicySpendMetadata(metadata, logCtx)
 
 	var completionStartTime *time.Time

--- a/internal/proxy/proxy_log_kafka_fallback_test.go
+++ b/internal/proxy/proxy_log_kafka_fallback_test.go
@@ -185,6 +185,9 @@ func TestLogSpendToLiteLLMDB_UsesClientResponseID(t *testing.T) {
 
 	logCtx := testLogCtx(t)
 	logCtx.ClientResponseID = "chatcmpl-client-123"
+	logCtx.ReasoningRequested = true
+	logCtx.ReasoningSource = "reasoning_effort"
+	logCtx.RequestEndpoint = "/v1/chat/completions"
 
 	require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
 	require.Len(t, dbStub.loggedEntries, 1)
@@ -199,6 +202,9 @@ func TestLogSpendToLiteLLMDB_UsesClientResponseID(t *testing.T) {
 	assert.Equal(t, "req-123", spendMetadata["air_event_id"])
 	assert.Equal(t, "chatcmpl-client-123", spendMetadata["provider_response_id"])
 	assert.Equal(t, true, spendMetadata["accounting_eligible"])
+	assert.Equal(t, true, spendMetadata["reasoning_requested"])
+	assert.Equal(t, "reasoning_effort", spendMetadata["reasoning_source"])
+	assert.Equal(t, "/v1/chat/completions", spendMetadata["request_endpoint"])
 }
 
 func TestLogSpendToLiteLLMDB_PersistsInternalAIRRequestWithoutKafkaAccounting(t *testing.T) {

--- a/internal/proxy/reasoning_filter.go
+++ b/internal/proxy/reasoning_filter.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/monitoring"
 )
 
-func (p *Proxy) reasoningOnlyExclusions(body []byte) map[string]bool {
-	if requestUsesReasoning(body) {
+func (p *Proxy) reasoningOnlyExclusions(reasoningRequested bool) map[string]bool {
+	if reasoningRequested {
 		return nil
 	}
 
@@ -24,36 +24,45 @@ func (p *Proxy) reasoningOnlyExclusions(body []byte) map[string]bool {
 }
 
 func requestUsesReasoning(body []byte) bool {
-	var request map[string]interface{}
-	if json.Unmarshal(body, &request) != nil {
-		return false
-	}
-	return mapUsesReasoning(request)
+	requested, _ := requestReasoning(body)
+	return requested
 }
 
-func mapUsesReasoning(fields map[string]interface{}) bool {
+func requestReasoning(body []byte) (bool, string) {
+	var request map[string]interface{}
+	if json.Unmarshal(body, &request) != nil {
+		return false, ""
+	}
+	return mapReasoningSource(request, "")
+}
+
+func mapReasoningSource(fields map[string]interface{}, prefix string) (bool, string) {
 	if value, ok := fields["reasoning_effort"]; ok && reasoningValueEnabled(value) {
-		return true
+		return true, prefix + "reasoning_effort"
 	}
 	if value, ok := fields["reasoning"]; ok && reasoningValueEnabled(value) {
-		return true
+		return true, prefix + "reasoning"
 	}
 	if value, ok := fields["thinking"]; ok && reasoningValueEnabled(value) {
-		return true
+		return true, prefix + "thinking"
 	}
 	if value, ok := fields["thinking_budget"]; ok && reasoningBudgetEnabled(value) {
-		return true
+		return true, prefix + "thinking_budget"
 	}
 	if value, ok := fields["thinking_level"]; ok && reasoningValueEnabled(value) {
-		return true
+		return true, prefix + "thinking_level"
 	}
-	if nested, ok := fields["thinking_config"].(map[string]interface{}); ok && mapUsesReasoning(nested) {
-		return true
+	if nested, ok := fields["thinking_config"].(map[string]interface{}); ok {
+		if requested, source := mapReasoningSource(nested, prefix+"thinking_config."); requested {
+			return true, source
+		}
 	}
-	if nested, ok := fields["extra_body"].(map[string]interface{}); ok && mapUsesReasoning(nested) {
-		return true
+	if nested, ok := fields["extra_body"].(map[string]interface{}); ok {
+		if requested, source := mapReasoningSource(nested, prefix+"extra_body."); requested {
+			return true, source
+		}
 	}
-	return false
+	return false, ""
 }
 
 func reasoningValueEnabled(value interface{}) bool {

--- a/internal/proxy/reasoning_filter_test.go
+++ b/internal/proxy/reasoning_filter_test.go
@@ -11,27 +11,32 @@ import (
 
 func TestRequestUsesReasoning(t *testing.T) {
 	tests := []struct {
-		name string
-		body string
-		want bool
+		name       string
+		body       string
+		want       bool
+		wantSource string
 	}{
 		{name: "absent", body: `{"model":"claude","messages":[]}`},
-		{name: "effort", body: `{"reasoning_effort":"high"}`, want: true},
+		{name: "effort", body: `{"reasoning_effort":"high"}`, want: true, wantSource: "reasoning_effort"},
 		{name: "disabled effort", body: `{"reasoning_effort":"none"}`},
-		{name: "responses reasoning", body: `{"reasoning":{"effort":"medium"}}`, want: true},
-		{name: "responses default effort", body: `{"reasoning":{"effort":null,"summary":"auto"}}`, want: true},
-		{name: "anthropic thinking", body: `{"thinking":{"type":"enabled","budget_tokens":1024}}`, want: true},
-		{name: "adaptive thinking", body: `{"thinking":{"type":"adaptive"}}`, want: true},
+		{name: "responses reasoning", body: `{"reasoning":{"effort":"medium"}}`, want: true, wantSource: "reasoning"},
+		{name: "responses default effort", body: `{"reasoning":{"effort":null,"summary":"auto"}}`, want: true, wantSource: "reasoning"},
+		{name: "anthropic thinking", body: `{"thinking":{"type":"enabled","budget_tokens":1024}}`, want: true, wantSource: "thinking"},
+		{name: "adaptive thinking", body: `{"thinking":{"type":"adaptive"}}`, want: true, wantSource: "thinking"},
 		{name: "disabled thinking", body: `{"thinking":{"type":"disabled"}}`},
-		{name: "gemini budget", body: `{"thinking_budget":-1}`, want: true},
+		{name: "gemini budget", body: `{"thinking_budget":-1}`, want: true, wantSource: "thinking_budget"},
 		{name: "gemini disabled budget", body: `{"thinking_budget":0}`},
-		{name: "nested extra body", body: `{"extra_body":{"reasoning_effort":"low"}}`, want: true},
+		{name: "nested extra body", body: `{"extra_body":{"reasoning_effort":"low"}}`, want: true, wantSource: "extra_body.reasoning_effort"},
+		{name: "nested thinking config", body: `{"thinking_config":{"thinking_level":"high"}}`, want: true, wantSource: "thinking_config.thinking_level"},
 		{name: "include thoughts only", body: `{"thinking_config":{"include_thoughts":true}}`},
 		{name: "invalid json", body: `{`},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			requested, source := requestReasoning([]byte(tt.body))
+			assert.Equal(t, tt.want, requested)
+			assert.Equal(t, tt.wantSource, source)
 			assert.Equal(t, tt.want, requestUsesReasoning([]byte(tt.body)))
 		})
 	}
@@ -43,8 +48,8 @@ func TestReasoningOnlyExclusions(t *testing.T) {
 		config.CredentialConfig{Name: "general", Type: config.ProviderTypeAnthropic, RPM: -1},
 	).Build()
 
-	assert.Equal(t, map[string]bool{"reasoning": true}, prx.reasoningOnlyExclusions([]byte(`{"messages":[]}`)))
-	assert.Empty(t, prx.reasoningOnlyExclusions([]byte(`{"reasoning_effort":"high"}`)))
+	assert.Equal(t, map[string]bool{"reasoning": true}, prx.reasoningOnlyExclusions(false))
+	assert.Empty(t, prx.reasoningOnlyExclusions(true))
 }
 
 func TestSelectCredentialForModelSkipsReasoningOnly(t *testing.T) {
@@ -54,7 +59,7 @@ func TestSelectCredentialForModelSkipsReasoningOnly(t *testing.T) {
 	}
 	prx := NewTestProxyBuilder().WithCredentials(credentials...).Build()
 	logCtx := testLogCtx(t)
-	exclude := prx.reasoningOnlyExclusions([]byte(`{"messages":[]}`))
+	exclude := prx.reasoningOnlyExclusions(false)
 
 	credential, ok := prx.selectCredentialForModel(httptest.NewRecorder(), "claude", "", "", exclude, logCtx)
 


### PR DESCRIPTION
Store reasoning request flag, source, and original endpoint in spend metadata.

Tests: `go test ./...`, `make lint`