### PR TITLE
Log thinking mode

### DIFF
--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -84,7 +84,7 @@ func (p *Proxy) orchestrateRequest(
 	}
 
 	logCtx.RequestEndpoint = r.URL.Path
-	logCtx.ReasoningRequested, logCtx.ReasoningSource = requestReasoning(body)
+	logCtx.ReasoningRequested, logCtx.ReasoningSource, logCtx.ThinkingMode = requestReasoningDetails(body)
 	routingExclusions := p.reasoningOnlyExclusions(logCtx.ReasoningRequested)
 	triedCreds := GetTried(r.Context())
 	for name := range routingExclusions {

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -57,32 +57,54 @@ func TestOrchestrateRequest_ResponsesAPIStreaming(t *testing.T) {
 
 func TestOrchestrateRequest_RecordsReasoningRequestMetadata(t *testing.T) {
 	tests := []struct {
-		name     string
-		path     string
-		body     string
-		source   string
-		endpoint string
+		name         string
+		path         string
+		body         string
+		requested    bool
+		source       string
+		thinkingMode string
+		endpoint     string
 	}{
 		{
-			name:     "chat completions",
-			path:     "/v1/chat/completions",
-			body:     `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"test"}],"reasoning_effort":"high"}`,
-			source:   "reasoning_effort",
-			endpoint: "/v1/chat/completions",
+			name:         "chat completions",
+			path:         "/v1/chat/completions",
+			body:         `{"model":"claude-opus-4-8","messages":[{"role":"user","content":"test"}],"reasoning_effort":"high"}`,
+			requested:    true,
+			source:       "reasoning_effort",
+			thinkingMode: thinkingModeUnspecified,
+			endpoint:     "/v1/chat/completions",
 		},
 		{
-			name:     "responses",
-			path:     "/v1/responses",
-			body:     `{"model":"claude-opus-4-8","input":"test","reasoning":{"effort":"high"}}`,
-			source:   "reasoning",
-			endpoint: "/v1/responses",
+			name:         "responses",
+			path:         "/v1/responses",
+			body:         `{"model":"claude-opus-4-8","input":"test","reasoning":{"effort":"high"}}`,
+			requested:    true,
+			source:       "reasoning",
+			thinkingMode: thinkingModeUnspecified,
+			endpoint:     "/v1/responses",
 		},
 		{
-			name:     "messages",
-			path:     "/v1/messages",
-			body:     `{"model":"claude-opus-4-8","max_tokens":4096,"thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`,
-			source:   "thinking",
-			endpoint: "/v1/messages",
+			name:         "messages",
+			path:         "/v1/messages",
+			body:         `{"model":"claude-opus-4-8","max_tokens":4096,"thinking":{"type":"adaptive"},"messages":[{"role":"user","content":"test"}]}`,
+			requested:    true,
+			source:       "thinking",
+			thinkingMode: thinkingModeAdaptive,
+			endpoint:     "/v1/messages",
+		},
+		{
+			name:         "messages disabled",
+			path:         "/v1/messages",
+			body:         `{"model":"claude-opus-5","max_tokens":4096,"thinking":{"type":"disabled"},"messages":[{"role":"user","content":"test"}]}`,
+			thinkingMode: thinkingModeDisabled,
+			endpoint:     "/v1/messages",
+		},
+		{
+			name:         "messages unspecified",
+			path:         "/v1/messages",
+			body:         `{"model":"claude-opus-5","max_tokens":4096,"messages":[{"role":"user","content":"test"}]}`,
+			thinkingMode: thinkingModeUnspecified,
+			endpoint:     "/v1/messages",
 		},
 	}
 
@@ -100,8 +122,9 @@ func TestOrchestrateRequest_RecordsReasoningRequestMetadata(t *testing.T) {
 
 			require.True(t, ok)
 			require.NotNil(t, prepared)
-			assert.True(t, logCtx.ReasoningRequested)
+			assert.Equal(t, tt.requested, logCtx.ReasoningRequested)
 			assert.Equal(t, tt.source, logCtx.ReasoningSource)
+			assert.Equal(t, tt.thinkingMode, logCtx.ThinkingMode)
 			assert.Equal(t, tt.endpoint, logCtx.RequestEndpoint)
 		})
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -274,6 +274,7 @@ type RequestLogContext struct {
 	WebSearchContextSize  string                   // low|medium|high from web_search_options/tool config
 	ReasoningRequested    bool
 	ReasoningSource       string
+	ThinkingMode          string
 	RequestEndpoint       string
 	Logged                bool   // True if already logged (prevents duplicate logging)
 	IsResponsesAPI        bool   // True if this is a Responses API request (converted to Chat Completions)

--- a/internal/proxy/proxy_helpers.go
+++ b/internal/proxy/proxy_helpers.go
@@ -380,6 +380,9 @@ func addRequestSpendMetadata(metadata string, logCtx *RequestLogContext) string 
 	if logCtx.ReasoningSource != "" {
 		spendMetadata["reasoning_source"] = logCtx.ReasoningSource
 	}
+	if logCtx.ThinkingMode != "" {
+		spendMetadata["thinking_mode"] = logCtx.ThinkingMode
+	}
 	if logCtx.RequestEndpoint != "" {
 		spendMetadata["request_endpoint"] = logCtx.RequestEndpoint
 	}

--- a/internal/proxy/proxy_helpers_test.go
+++ b/internal/proxy/proxy_helpers_test.go
@@ -353,8 +353,9 @@ func TestAddRequestSpendMetadata(t *testing.T) {
 	t.Run("reasoning requested", func(t *testing.T) {
 		metadata := addRequestSpendMetadata(`{"spend_logs_metadata":{"air_event_id":"event-1"}}`, &RequestLogContext{
 			ReasoningRequested: true,
-			ReasoningSource:    "extra_body.reasoning_effort",
-			RequestEndpoint:    "/v1/chat/completions",
+			ReasoningSource:    "extra_body.thinking",
+			ThinkingMode:       thinkingModeAdaptive,
+			RequestEndpoint:    "/v1/messages",
 		})
 
 		var doc map[string]interface{}
@@ -362,18 +363,36 @@ func TestAddRequestSpendMetadata(t *testing.T) {
 		spendMetadata := doc["spend_logs_metadata"].(map[string]interface{})
 		assert.Equal(t, "event-1", spendMetadata["air_event_id"])
 		assert.Equal(t, true, spendMetadata["reasoning_requested"])
-		assert.Equal(t, "extra_body.reasoning_effort", spendMetadata["reasoning_source"])
-		assert.Equal(t, "/v1/chat/completions", spendMetadata["request_endpoint"])
+		assert.Equal(t, "extra_body.thinking", spendMetadata["reasoning_source"])
+		assert.Equal(t, thinkingModeAdaptive, spendMetadata["thinking_mode"])
+		assert.Equal(t, "/v1/messages", spendMetadata["request_endpoint"])
+	})
+
+	t.Run("thinking explicitly disabled", func(t *testing.T) {
+		metadata := addRequestSpendMetadata("{}", &RequestLogContext{
+			ThinkingMode:    thinkingModeDisabled,
+			RequestEndpoint: "/v1/messages",
+		})
+
+		var doc map[string]interface{}
+		require.NoError(t, json.Unmarshal([]byte(metadata), &doc))
+		spendMetadata := doc["spend_logs_metadata"].(map[string]interface{})
+		assert.Equal(t, false, spendMetadata["reasoning_requested"])
+		assert.Equal(t, thinkingModeDisabled, spendMetadata["thinking_mode"])
 	})
 
 	t.Run("reasoning absent", func(t *testing.T) {
-		metadata := addRequestSpendMetadata("{}", &RequestLogContext{RequestEndpoint: "/v1/messages"})
+		metadata := addRequestSpendMetadata("{}", &RequestLogContext{
+			ThinkingMode:    thinkingModeUnspecified,
+			RequestEndpoint: "/v1/messages",
+		})
 
 		var doc map[string]interface{}
 		require.NoError(t, json.Unmarshal([]byte(metadata), &doc))
 		spendMetadata := doc["spend_logs_metadata"].(map[string]interface{})
 		assert.Equal(t, false, spendMetadata["reasoning_requested"])
 		assert.NotContains(t, spendMetadata, "reasoning_source")
+		assert.Equal(t, thinkingModeUnspecified, spendMetadata["thinking_mode"])
 		assert.Equal(t, "/v1/messages", spendMetadata["request_endpoint"])
 	})
 }

--- a/internal/proxy/proxy_log_kafka_fallback_test.go
+++ b/internal/proxy/proxy_log_kafka_fallback_test.go
@@ -186,8 +186,9 @@ func TestLogSpendToLiteLLMDB_UsesClientResponseID(t *testing.T) {
 	logCtx := testLogCtx(t)
 	logCtx.ClientResponseID = "chatcmpl-client-123"
 	logCtx.ReasoningRequested = true
-	logCtx.ReasoningSource = "reasoning_effort"
-	logCtx.RequestEndpoint = "/v1/chat/completions"
+	logCtx.ReasoningSource = "thinking"
+	logCtx.ThinkingMode = thinkingModeAdaptive
+	logCtx.RequestEndpoint = "/v1/messages"
 
 	require.NoError(t, prx.logSpendToLiteLLMDB(logCtx))
 	require.Len(t, dbStub.loggedEntries, 1)
@@ -203,8 +204,9 @@ func TestLogSpendToLiteLLMDB_UsesClientResponseID(t *testing.T) {
 	assert.Equal(t, "chatcmpl-client-123", spendMetadata["provider_response_id"])
 	assert.Equal(t, true, spendMetadata["accounting_eligible"])
 	assert.Equal(t, true, spendMetadata["reasoning_requested"])
-	assert.Equal(t, "reasoning_effort", spendMetadata["reasoning_source"])
-	assert.Equal(t, "/v1/chat/completions", spendMetadata["request_endpoint"])
+	assert.Equal(t, "thinking", spendMetadata["reasoning_source"])
+	assert.Equal(t, thinkingModeAdaptive, spendMetadata["thinking_mode"])
+	assert.Equal(t, "/v1/messages", spendMetadata["request_endpoint"])
 }
 
 func TestLogSpendToLiteLLMDB_PersistsInternalAIRRequestWithoutKafkaAccounting(t *testing.T) {

--- a/internal/proxy/reasoning_filter.go
+++ b/internal/proxy/reasoning_filter.go
@@ -8,6 +8,14 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/monitoring"
 )
 
+const (
+	thinkingModeAdaptive    = "adaptive"
+	thinkingModeDisabled    = "disabled"
+	thinkingModeEnabled     = "enabled"
+	thinkingModeUnknown     = "unknown"
+	thinkingModeUnspecified = "unspecified"
+)
+
 func (p *Proxy) reasoningOnlyExclusions(reasoningRequested bool) map[string]bool {
 	if reasoningRequested {
 		return nil
@@ -29,11 +37,50 @@ func requestUsesReasoning(body []byte) bool {
 }
 
 func requestReasoning(body []byte) (bool, string) {
+	requested, source, _ := requestReasoningDetails(body)
+	return requested, source
+}
+
+func requestReasoningDetails(body []byte) (bool, string, string) {
 	var request map[string]interface{}
 	if json.Unmarshal(body, &request) != nil {
-		return false, ""
+		return false, "", thinkingModeUnspecified
 	}
-	return mapReasoningSource(request, "")
+	requested, source := mapReasoningSource(request, "")
+	return requested, source, mapThinkingMode(request)
+}
+
+func mapThinkingMode(fields map[string]interface{}) string {
+	if value, ok := fields["thinking"]; ok {
+		return normalizeThinkingMode(value)
+	}
+	if nested, ok := fields["extra_body"].(map[string]interface{}); ok {
+		return mapThinkingMode(nested)
+	}
+	return thinkingModeUnspecified
+}
+
+func normalizeThinkingMode(value interface{}) string {
+	if fields, ok := value.(map[string]interface{}); ok {
+		value, ok = fields["type"]
+		if !ok {
+			return thinkingModeUnknown
+		}
+	}
+	kind, ok := value.(string)
+	if !ok {
+		return thinkingModeUnknown
+	}
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case thinkingModeAdaptive:
+		return thinkingModeAdaptive
+	case thinkingModeDisabled:
+		return thinkingModeDisabled
+	case thinkingModeEnabled:
+		return thinkingModeEnabled
+	default:
+		return thinkingModeUnknown
+	}
 }
 
 func mapReasoningSource(fields map[string]interface{}, prefix string) (bool, string) {

--- a/internal/proxy/reasoning_filter_test.go
+++ b/internal/proxy/reasoning_filter_test.go
@@ -11,32 +11,37 @@ import (
 
 func TestRequestUsesReasoning(t *testing.T) {
 	tests := []struct {
-		name       string
-		body       string
-		want       bool
-		wantSource string
+		name             string
+		body             string
+		want             bool
+		wantSource       string
+		wantThinkingMode string
 	}{
-		{name: "absent", body: `{"model":"claude","messages":[]}`},
-		{name: "effort", body: `{"reasoning_effort":"high"}`, want: true, wantSource: "reasoning_effort"},
-		{name: "disabled effort", body: `{"reasoning_effort":"none"}`},
-		{name: "responses reasoning", body: `{"reasoning":{"effort":"medium"}}`, want: true, wantSource: "reasoning"},
-		{name: "responses default effort", body: `{"reasoning":{"effort":null,"summary":"auto"}}`, want: true, wantSource: "reasoning"},
-		{name: "anthropic thinking", body: `{"thinking":{"type":"enabled","budget_tokens":1024}}`, want: true, wantSource: "thinking"},
-		{name: "adaptive thinking", body: `{"thinking":{"type":"adaptive"}}`, want: true, wantSource: "thinking"},
-		{name: "disabled thinking", body: `{"thinking":{"type":"disabled"}}`},
-		{name: "gemini budget", body: `{"thinking_budget":-1}`, want: true, wantSource: "thinking_budget"},
-		{name: "gemini disabled budget", body: `{"thinking_budget":0}`},
-		{name: "nested extra body", body: `{"extra_body":{"reasoning_effort":"low"}}`, want: true, wantSource: "extra_body.reasoning_effort"},
-		{name: "nested thinking config", body: `{"thinking_config":{"thinking_level":"high"}}`, want: true, wantSource: "thinking_config.thinking_level"},
-		{name: "include thoughts only", body: `{"thinking_config":{"include_thoughts":true}}`},
-		{name: "invalid json", body: `{`},
+		{name: "absent", body: `{"model":"claude","messages":[]}`, wantThinkingMode: thinkingModeUnspecified},
+		{name: "effort", body: `{"reasoning_effort":"high"}`, want: true, wantSource: "reasoning_effort", wantThinkingMode: thinkingModeUnspecified},
+		{name: "disabled effort", body: `{"reasoning_effort":"none"}`, wantThinkingMode: thinkingModeUnspecified},
+		{name: "responses reasoning", body: `{"reasoning":{"effort":"medium"}}`, want: true, wantSource: "reasoning", wantThinkingMode: thinkingModeUnspecified},
+		{name: "responses default effort", body: `{"reasoning":{"effort":null,"summary":"auto"}}`, want: true, wantSource: "reasoning", wantThinkingMode: thinkingModeUnspecified},
+		{name: "anthropic thinking", body: `{"thinking":{"type":"enabled","budget_tokens":1024}}`, want: true, wantSource: "thinking", wantThinkingMode: thinkingModeEnabled},
+		{name: "adaptive thinking", body: `{"thinking":{"type":"adaptive"}}`, want: true, wantSource: "thinking", wantThinkingMode: thinkingModeAdaptive},
+		{name: "disabled thinking", body: `{"thinking":{"type":"disabled"}}`, wantThinkingMode: thinkingModeDisabled},
+		{name: "unknown thinking", body: `{"thinking":{"type":"automatic"}}`, want: true, wantSource: "thinking", wantThinkingMode: thinkingModeUnknown},
+		{name: "missing thinking type", body: `{"thinking":{"display":"summarized"}}`, want: true, wantSource: "thinking", wantThinkingMode: thinkingModeUnknown},
+		{name: "gemini budget", body: `{"thinking_budget":-1}`, want: true, wantSource: "thinking_budget", wantThinkingMode: thinkingModeUnspecified},
+		{name: "gemini disabled budget", body: `{"thinking_budget":0}`, wantThinkingMode: thinkingModeUnspecified},
+		{name: "nested extra body", body: `{"extra_body":{"reasoning_effort":"low"}}`, want: true, wantSource: "extra_body.reasoning_effort", wantThinkingMode: thinkingModeUnspecified},
+		{name: "nested extra body thinking", body: `{"extra_body":{"thinking":{"type":"adaptive"}}}`, want: true, wantSource: "extra_body.thinking", wantThinkingMode: thinkingModeAdaptive},
+		{name: "nested thinking config", body: `{"thinking_config":{"thinking_level":"high"}}`, want: true, wantSource: "thinking_config.thinking_level", wantThinkingMode: thinkingModeUnspecified},
+		{name: "include thoughts only", body: `{"thinking_config":{"include_thoughts":true}}`, wantThinkingMode: thinkingModeUnspecified},
+		{name: "invalid json", body: `{`, wantThinkingMode: thinkingModeUnspecified},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			requested, source := requestReasoning([]byte(tt.body))
+			requested, source, thinkingMode := requestReasoningDetails([]byte(tt.body))
 			assert.Equal(t, tt.want, requested)
 			assert.Equal(t, tt.wantSource, source)
+			assert.Equal(t, tt.wantThinkingMode, thinkingMode)
 			assert.Equal(t, tt.want, requestUsesReasoning([]byte(tt.body)))
 		})
 	}


### PR DESCRIPTION
Store raw thinking mode in spend metadata.

Tests: `go test ./...`, `make lint`