### PR TITLE
Add organization credential denylist

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -260,6 +260,8 @@ models:
 #       - anthropic/claude-sonnet-4
 #     model_mappings:
 #       openai/gpt-5.5-pro: gpt-5.5-pro
+#     credential_denylist:
+#       - untrusted-provider-credential
 
 # Optional: Redis/Valkey backend for distributed rate limiting and response storage.
 # When enabled, all replicas share a single counter namespace — RPM/TPM limits are

--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -41,6 +41,8 @@ organization_policies:
       - openai/gpt-5.5-pro
     model_mappings:
       openai/gpt-5.5-pro: gpt-5.5-pro
+    credential_denylist:
+      - untrusted-provider-credential
 ```
 
 The section is disabled when omitted. When present, it requires `litellm_db.enabled: true`, `litellm_db.is_required: true`, and `litellm_db.disable_spend_logs_write: false`.
@@ -50,6 +52,12 @@ Organization profile lookup is exact and case-sensitive. AIR prices mapped reque
 The organization tariff JSON is strict. Duplicate exact keys, unknown row fields, `null` rows, and empty price objects fail startup. An explicit free model must still include at least one recognized price field with a zero value.
 
 When `model_allowlist` is omitted, the organization sees the global callable surface plus organization mapping keys, subject to exact profile prices in `/v1/models`. A callable request without an exact profile row returns `503` before provider selection. When `model_allowlist` is present and empty, the organization surface is empty. When present and non-empty, every listed ID must be routable and have an exact profile row at startup.
+
+### Provider credential exclusion
+
+`credential_denylist` contains exact case-sensitive provider credential names. Matching provider credentials are excluded from initial selection, session affinity, retries, and fallback. Router credentials remain eligible. The restriction follows a request through chained AIR routers. Unknown names are ignored locally and remain available to downstream routers.
+
+The list accepts up to 128 names and 4096 encoded bytes. Each name may contain up to 256 bytes. Empty names, duplicate names, and control characters fail configuration loading. An omitted or empty list preserves standard routing.
 
 ### Refresh interval
 

--- a/docs/litellm-integration/pricing.md
+++ b/docs/litellm-integration/pricing.md
@@ -57,7 +57,7 @@ When `model_allowlist` is omitted, the organization sees the global callable sur
 
 `credential_denylist` contains exact case-sensitive provider credential names. Matching provider credentials are excluded from initial selection, session affinity, retries, and fallback. Router credentials remain eligible. The restriction follows a request through chained AIR routers. Unknown names are ignored locally and remain available to downstream routers.
 
-The list accepts up to 128 names and 4096 encoded bytes. Each name may contain up to 256 bytes. Empty names, duplicate names, and control characters fail configuration loading. An omitted or empty list preserves standard routing.
+The list accepts up to 1024 names and 65536 encoded bytes. Each name may contain up to 256 bytes. Empty names, duplicate names, and control characters fail configuration loading. An omitted or empty list preserves standard routing.
 
 ### Refresh interval
 

--- a/internal/config/organization_policy.go
+++ b/internal/config/organization_policy.go
@@ -11,9 +11,9 @@ import (
 )
 
 const (
-	maxOrganizationCredentialDenylistEntries = 128
+	maxOrganizationCredentialDenylistEntries = 1024
 	maxOrganizationCredentialNameBytes       = 256
-	maxOrganizationCredentialDenylistBytes   = 4096
+	maxOrganizationCredentialDenylistBytes   = 64 * 1024
 )
 
 type OrganizationPolicyConfig struct {

--- a/internal/config/organization_policy.go
+++ b/internal/config/organization_policy.go
@@ -1,19 +1,29 @@
 package config
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 
 	"gopkg.in/yaml.v3"
 )
 
+const (
+	maxOrganizationCredentialDenylistEntries = 128
+	maxOrganizationCredentialNameBytes       = 256
+	maxOrganizationCredentialDenylistBytes   = 4096
+)
+
 type OrganizationPolicyConfig struct {
-	OrganizationID  string            `yaml:"organization_id"`
-	PriceProfileID  string            `yaml:"price_profile_id"`
-	ModelPricesLink string            `yaml:"model_prices_link"`
-	ModelAllowlist  []string          `yaml:"model_allowlist,omitempty"`
-	AllowlistSet    bool              `yaml:"-"`
-	ModelMappings   map[string]string `yaml:"model_mappings,omitempty"`
+	OrganizationID     string            `yaml:"organization_id"`
+	PriceProfileID     string            `yaml:"price_profile_id"`
+	ModelPricesLink    string            `yaml:"model_prices_link"`
+	ModelAllowlist     []string          `yaml:"model_allowlist,omitempty"`
+	AllowlistSet       bool              `yaml:"-"`
+	ModelMappings      map[string]string `yaml:"model_mappings,omitempty"`
+	CredentialDenylist []string          `yaml:"credential_denylist,omitempty"`
 }
 
 func (p *OrganizationPolicyConfig) UnmarshalYAML(value *yaml.Node) error {
@@ -22,18 +32,20 @@ func (p *OrganizationPolicyConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 
 	allowedFields := map[string]struct{}{
-		"organization_id":   {},
-		"price_profile_id":  {},
-		"model_prices_link": {},
-		"model_allowlist":   {},
-		"model_mappings":    {},
+		"organization_id":     {},
+		"price_profile_id":    {},
+		"model_prices_link":   {},
+		"model_allowlist":     {},
+		"model_mappings":      {},
+		"credential_denylist": {},
 	}
 
 	var raw struct {
-		OrganizationID  string   `yaml:"organization_id"`
-		PriceProfileID  string   `yaml:"price_profile_id"`
-		ModelPricesLink string   `yaml:"model_prices_link"`
-		ModelAllowlist  []string `yaml:"model_allowlist,omitempty"`
+		OrganizationID     string   `yaml:"organization_id"`
+		PriceProfileID     string   `yaml:"price_profile_id"`
+		ModelPricesLink    string   `yaml:"model_prices_link"`
+		ModelAllowlist     []string `yaml:"model_allowlist,omitempty"`
+		CredentialDenylist []string `yaml:"credential_denylist,omitempty"`
 	}
 	mappings := make(map[string]string)
 
@@ -76,6 +88,16 @@ func (p *OrganizationPolicyConfig) UnmarshalYAML(value *yaml.Node) error {
 	for _, modelID := range raw.ModelAllowlist {
 		p.ModelAllowlist = append(p.ModelAllowlist, strings.TrimSpace(resolveEnvString(modelID)))
 	}
+	seenCredentials := make(map[string]struct{}, len(raw.CredentialDenylist))
+	p.CredentialDenylist = make([]string, 0, len(raw.CredentialDenylist))
+	for _, credentialName := range raw.CredentialDenylist {
+		credentialName = strings.TrimSpace(resolveEnvString(credentialName))
+		if _, exists := seenCredentials[credentialName]; exists {
+			return fmt.Errorf("organization policy: duplicate credential_denylist entry %q", credentialName)
+		}
+		seenCredentials[credentialName] = struct{}{}
+		p.CredentialDenylist = append(p.CredentialDenylist, credentialName)
+	}
 	p.ModelMappings = mappings
 	return nil
 }
@@ -100,6 +122,26 @@ func ValidateOrganizationPolicies(policies []OrganizationPolicyConfig) error {
 			if modelID == "" {
 				return fmt.Errorf("organization policy %q: model_allowlist contains an empty model ID", policy.OrganizationID)
 			}
+		}
+		for _, credentialName := range policy.CredentialDenylist {
+			if credentialName == "" {
+				return fmt.Errorf("organization policy %q: credential_denylist contains an empty credential name", policy.OrganizationID)
+			}
+			if !utf8.ValidString(credentialName) || len(credentialName) > maxOrganizationCredentialNameBytes {
+				return fmt.Errorf("organization policy %q: credential_denylist contains an invalid credential name", policy.OrganizationID)
+			}
+			for _, character := range credentialName {
+				if unicode.IsControl(character) {
+					return fmt.Errorf("organization policy %q: credential_denylist contains an invalid credential name", policy.OrganizationID)
+				}
+			}
+		}
+		if len(policy.CredentialDenylist) > maxOrganizationCredentialDenylistEntries {
+			return fmt.Errorf("organization policy %q: credential_denylist exceeds %d entries", policy.OrganizationID, maxOrganizationCredentialDenylistEntries)
+		}
+		encodedDenylist, err := json.Marshal(policy.CredentialDenylist)
+		if err != nil || len(encodedDenylist) > maxOrganizationCredentialDenylistBytes {
+			return fmt.Errorf("organization policy %q: credential_denylist exceeds %d bytes", policy.OrganizationID, maxOrganizationCredentialDenylistBytes)
 		}
 		allowlisted := make(map[string]struct{}, len(policy.ModelAllowlist))
 		for _, modelID := range policy.ModelAllowlist {

--- a/internal/config/organization_policy_test.go
+++ b/internal/config/organization_policy_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -116,9 +117,31 @@ func TestValidateOrganizationPolicies(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "empty credential name")
 
-	largeDenylist := make([]string, 20)
+	validDenylist := make([]string, maxOrganizationCredentialDenylistEntries)
+	for index := range validDenylist {
+		validDenylist[index] = fmt.Sprintf("credential-%04d", index)
+	}
+	err = ValidateOrganizationPolicies([]OrganizationPolicyConfig{{
+		OrganizationID:     "org-1",
+		PriceProfileID:     "profile-1",
+		ModelPricesLink:    "/tmp/prices.json",
+		CredentialDenylist: validDenylist,
+	}})
+	require.NoError(t, err)
+
+	err = ValidateOrganizationPolicies([]OrganizationPolicyConfig{{
+		OrganizationID:     "org-1",
+		PriceProfileID:     "profile-1",
+		ModelPricesLink:    "/tmp/prices.json",
+		CredentialDenylist: append(validDenylist, "credential-overflow"),
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential_denylist exceeds 1024 entries")
+
+	largeDenylist := make([]string, 300)
 	for index := range largeDenylist {
-		largeDenylist[index] = strings.Repeat(string(rune('a'+index)), maxOrganizationCredentialNameBytes)
+		prefix := fmt.Sprintf("%03d-", index)
+		largeDenylist[index] = prefix + strings.Repeat("x", maxOrganizationCredentialNameBytes-len(prefix))
 	}
 	err = ValidateOrganizationPolicies([]OrganizationPolicyConfig{{
 		OrganizationID:     "org-1",
@@ -127,5 +150,5 @@ func TestValidateOrganizationPolicies(t *testing.T) {
 		CredentialDenylist: largeDenylist,
 	}})
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "credential_denylist exceeds 4096 bytes")
+	assert.Contains(t, err.Error(), "credential_denylist exceeds 65536 bytes")
 }

--- a/internal/config/organization_policy_test.go
+++ b/internal/config/organization_policy_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,6 +19,9 @@ organization_policies:
     model_allowlist: []
     model_mappings:
       public/model: route-model
+    credential_denylist:
+      - " provider-a "
+      - provider-b
 `), &cfg)
 
 	require.NoError(t, err)
@@ -27,6 +31,7 @@ organization_policies:
 	assert.True(t, policy.AllowlistSet)
 	assert.Empty(t, policy.ModelAllowlist)
 	assert.Equal(t, map[string]string{"public/model": "route-model"}, policy.ModelMappings)
+	assert.Equal(t, []string{"provider-a", "provider-b"}, policy.CredentialDenylist)
 }
 
 func TestOrganizationPolicyConfig_RejectsUnknownField(t *testing.T) {
@@ -59,6 +64,22 @@ organization_policies:
 	assert.Contains(t, err.Error(), "duplicate model mapping key")
 }
 
+func TestOrganizationPolicyConfig_RejectsDuplicateCredentialDenylistEntry(t *testing.T) {
+	var cfg Config
+	err := yaml.Unmarshal([]byte(`
+organization_policies:
+  - organization_id: org-1
+    price_profile_id: profile-1
+    model_prices_link: /tmp/prices.json
+    credential_denylist:
+      - provider-a
+      - " provider-a "
+`), &cfg)
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate credential_denylist entry")
+}
+
 func TestValidateOrganizationPolicies(t *testing.T) {
 	err := ValidateOrganizationPolicies([]OrganizationPolicyConfig{
 		{
@@ -85,4 +106,26 @@ func TestValidateOrganizationPolicies(t *testing.T) {
 	}})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "outside model_allowlist")
+
+	err = ValidateOrganizationPolicies([]OrganizationPolicyConfig{{
+		OrganizationID:     "org-1",
+		PriceProfileID:     "profile-1",
+		ModelPricesLink:    "/tmp/prices.json",
+		CredentialDenylist: []string{""},
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty credential name")
+
+	largeDenylist := make([]string, 20)
+	for index := range largeDenylist {
+		largeDenylist[index] = strings.Repeat(string(rune('a'+index)), maxOrganizationCredentialNameBytes)
+	}
+	err = ValidateOrganizationPolicies([]OrganizationPolicyConfig{{
+		OrganizationID:     "org-1",
+		PriceProfileID:     "profile-1",
+		ModelPricesLink:    "/tmp/prices.json",
+		CredentialDenylist: largeDenylist,
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential_denylist exceeds 4096 bytes")
 }

--- a/internal/models/organization_policy.go
+++ b/internal/models/organization_policy.go
@@ -28,9 +28,10 @@ type OrganizationPolicy struct {
 	ProfileSHA256   string
 	AllowlistSet    bool
 
-	allowlist map[string]struct{}
-	mappings  map[string]string
-	prices    map[string]*ModelPrice
+	allowlist          map[string]struct{}
+	mappings           map[string]string
+	prices             map[string]*ModelPrice
+	credentialDenylist []string
 }
 
 type OrganizationModelResolution struct {
@@ -99,14 +100,15 @@ func LoadOrganizationPolicies(
 		profiles[cfg.PriceProfileID] = identity
 
 		policy := &OrganizationPolicy{
-			OrganizationID:  cfg.OrganizationID,
-			PriceProfileID:  cfg.PriceProfileID,
-			ModelPricesLink: cfg.ModelPricesLink,
-			ProfileSHA256:   identity.sha256,
-			AllowlistSet:    cfg.AllowlistSet,
-			allowlist:       make(map[string]struct{}, len(cfg.ModelAllowlist)),
-			mappings:        make(map[string]string, len(cfg.ModelMappings)),
-			prices:          priceRows,
+			OrganizationID:     cfg.OrganizationID,
+			PriceProfileID:     cfg.PriceProfileID,
+			ModelPricesLink:    cfg.ModelPricesLink,
+			ProfileSHA256:      identity.sha256,
+			AllowlistSet:       cfg.AllowlistSet,
+			allowlist:          make(map[string]struct{}, len(cfg.ModelAllowlist)),
+			mappings:           make(map[string]string, len(cfg.ModelMappings)),
+			prices:             priceRows,
+			credentialDenylist: append([]string(nil), cfg.CredentialDenylist...),
 		}
 		for _, modelID := range cfg.ModelAllowlist {
 			policy.allowlist[modelID] = struct{}{}
@@ -130,6 +132,13 @@ func LoadOrganizationPolicies(
 		registry.byOrganization[policy.OrganizationID] = policy
 	}
 	return registry, nil
+}
+
+func (p *OrganizationPolicy) CredentialDenylist() []string {
+	if p == nil || len(p.credentialDenylist) == 0 {
+		return nil
+	}
+	return append([]string(nil), p.credentialDenylist...)
 }
 
 func (r *OrganizationPolicyRegistry) Empty() bool {

--- a/internal/proxy/credential_denylist.go
+++ b/internal/proxy/credential_denylist.go
@@ -19,9 +19,9 @@ import (
 const (
 	HeaderAIRCredentialDenylist = "Air-Credential-Denylist" //nolint:gosec // G101 header name
 
-	maxCredentialDenylistEntries = 128
+	maxCredentialDenylistEntries = 1024
 	maxCredentialNameBytes       = 256
-	maxCredentialDenylistBytes   = 4096
+	maxCredentialDenylistBytes   = 64 * 1024
 )
 
 var errInvalidCredentialDenylist = errors.New("invalid AIR credential denylist")
@@ -132,6 +132,14 @@ func mergeCredentialDenylists(lists ...[]string) []string {
 func setCredentialDenylistHeader(header http.Header, denylist []string) error {
 	if len(denylist) == 0 {
 		return nil
+	}
+	if len(denylist) > maxCredentialDenylistEntries {
+		return errInvalidCredentialDenylist
+	}
+	for _, name := range denylist {
+		if !validCredentialDenylistName(name) {
+			return errInvalidCredentialDenylist
+		}
 	}
 	value, err := json.Marshal(denylist)
 	if err != nil || len(value) > maxCredentialDenylistBytes || bytes.ContainsAny(value, "\r\n") {

--- a/internal/proxy/credential_denylist.go
+++ b/internal/proxy/credential_denylist.go
@@ -1,0 +1,167 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+)
+
+const (
+	HeaderAIRCredentialDenylist = "Air-Credential-Denylist" //nolint:gosec // G101 header name
+
+	maxCredentialDenylistEntries = 128
+	maxCredentialNameBytes       = 256
+	maxCredentialDenylistBytes   = 4096
+)
+
+var errInvalidCredentialDenylist = errors.New("invalid AIR credential denylist")
+
+type credentialDenylistContextKey struct{}
+
+type credentialDenylistContext struct {
+	markerPresent bool
+	inboundValues []string
+	effective     []string
+}
+
+func captureCredentialDenylist(r *http.Request, markerPresent bool) *http.Request {
+	values := append([]string(nil), r.Header.Values(HeaderAIRCredentialDenylist)...)
+	r.Header.Del(HeaderAIRCredentialDenylist)
+	state := credentialDenylistContext{
+		markerPresent: markerPresent,
+		inboundValues: values,
+	}
+	return r.WithContext(context.WithValue(r.Context(), credentialDenylistContextKey{}, state))
+}
+
+func credentialDenylistState(ctx context.Context) credentialDenylistContext {
+	state, _ := ctx.Value(credentialDenylistContextKey{}).(credentialDenylistContext)
+	return state
+}
+
+func withEffectiveCredentialDenylist(r *http.Request, values []string) *http.Request {
+	state := credentialDenylistState(r.Context())
+	state.effective = append([]string(nil), values...)
+	return r.WithContext(context.WithValue(r.Context(), credentialDenylistContextKey{}, state))
+}
+
+func effectiveCredentialDenylist(ctx context.Context) []string {
+	state := credentialDenylistState(ctx)
+	return append([]string(nil), state.effective...)
+}
+
+func trustedInboundCredentialDenylist(ctx context.Context, masterKeyAuthenticated bool) ([]string, error) {
+	state := credentialDenylistState(ctx)
+	if !state.markerPresent || !masterKeyAuthenticated || len(state.inboundValues) == 0 {
+		return nil, nil
+	}
+	if len(state.inboundValues) != 1 {
+		return nil, errInvalidCredentialDenylist
+	}
+	return parseCredentialDenylist(state.inboundValues[0])
+}
+
+func parseCredentialDenylist(value string) ([]string, error) {
+	if value == "" || len(value) > maxCredentialDenylistBytes {
+		return nil, errInvalidCredentialDenylist
+	}
+	decoder := json.NewDecoder(strings.NewReader(value))
+	var names []string
+	if err := decoder.Decode(&names); err != nil {
+		return nil, errInvalidCredentialDenylist
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		return nil, errInvalidCredentialDenylist
+	}
+	if len(names) > maxCredentialDenylistEntries {
+		return nil, errInvalidCredentialDenylist
+	}
+	seen := make(map[string]struct{}, len(names))
+	result := make([]string, 0, len(names))
+	for _, name := range names {
+		if !validCredentialDenylistName(name) {
+			return nil, errInvalidCredentialDenylist
+		}
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
+func validCredentialDenylistName(name string) bool {
+	if name == "" || strings.TrimSpace(name) != name || !utf8.ValidString(name) || len(name) > maxCredentialNameBytes {
+		return false
+	}
+	for _, character := range name {
+		if unicode.IsControl(character) {
+			return false
+		}
+	}
+	return true
+}
+
+func mergeCredentialDenylists(lists ...[]string) []string {
+	seen := make(map[string]struct{})
+	for _, list := range lists {
+		for _, name := range list {
+			seen[name] = struct{}{}
+		}
+	}
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result
+}
+
+func setCredentialDenylistHeader(header http.Header, denylist []string) error {
+	if len(denylist) == 0 {
+		return nil
+	}
+	value, err := json.Marshal(denylist)
+	if err != nil || len(value) > maxCredentialDenylistBytes || bytes.ContainsAny(value, "\r\n") {
+		return errors.New("serialize AIR credential denylist")
+	}
+	header.Set(HeaderAIRCredentialDenylist, string(value))
+	return nil
+}
+
+func carriesCredentialDenylist(credential *config.CredentialConfig) bool {
+	if credential == nil {
+		return false
+	}
+	if credential.Type == config.ProviderTypeAIR {
+		return true
+	}
+	if credential.Type != config.ProviderTypeProxy {
+		return false
+	}
+	parsed, err := url.Parse(credential.BaseURL)
+	if err != nil || parsed.Scheme != "http" {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	if !strings.HasPrefix(host, "air-") {
+		return false
+	}
+	labels := strings.Split(host, ".")
+	return len(labels) == 1 ||
+		len(labels) == 2 && labels[1] == "production" ||
+		strings.HasSuffix(host, ".svc") ||
+		strings.HasSuffix(host, ".svc.cluster.local")
+}

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -71,6 +71,7 @@ func isHopByHopHeader(key string) bool {
 func isInternalAIRRequestHeader(key string) bool {
 	return strings.EqualFold(key, HeaderAIRProxyClient) ||
 		strings.EqualFold(key, HeaderLegacyAIRProxyClient) ||
+		strings.EqualFold(key, HeaderAIRCredentialDenylist) ||
 		strings.EqualFold(key, HeaderAIRUsageAudioTokens)
 }
 

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -77,6 +77,22 @@ func (p *Proxy) orchestrateRequest(
 	if !p.authenticateRequest(w, r, logCtx, isLiteLLMHealthy) {
 		return nil, false
 	}
+	markerPresent := credentialDenylistState(r.Context()).markerPresent
+	masterKeyAuthenticated := p.isMasterKey(logCtx.Token)
+	logCtx.IsProxyRequest = markerPresent && masterKeyAuthenticated
+	if markerPresent && !masterKeyAuthenticated {
+		p.logger.WarnContext(r.Context(), "Ignoring untrusted AIR proxy marker",
+			"request_id", logCtx.RequestID,
+		)
+	}
+	inboundDenylist, err := trustedInboundCredentialDenylist(r.Context(), masterKeyAuthenticated)
+	if err != nil {
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusBadRequest
+		logCtx.ErrorMsg = "Invalid internal routing policy"
+		WriteErrorBadRequest(w, "Invalid internal routing policy")
+		return nil, false
+	}
 
 	body, modelID, realModelID, streaming, ok := p.readRequestBodyAndSelectModel(w, r, logCtx)
 	if !ok {
@@ -85,7 +101,22 @@ func (p *Proxy) orchestrateRequest(
 
 	logCtx.RequestEndpoint = r.URL.Path
 	logCtx.ReasoningRequested, logCtx.ReasoningSource, logCtx.ThinkingMode = requestReasoningDetails(body)
+	var policyDenylist []string
+	if logCtx.OrganizationPolicy != nil {
+		policyDenylist = logCtx.OrganizationPolicy.CredentialDenylist()
+	}
+	effectiveDenylist := mergeCredentialDenylists(inboundDenylist, policyDenylist)
+	r = withEffectiveCredentialDenylist(r, effectiveDenylist)
 	routingExclusions := p.reasoningOnlyExclusions(logCtx.ReasoningRequested)
+	for _, credentialName := range effectiveDenylist {
+		if p.balancer.IsProxyCredential(credentialName) {
+			continue
+		}
+		if routingExclusions == nil {
+			routingExclusions = make(map[string]bool)
+		}
+		routingExclusions[credentialName] = true
+	}
 	triedCreds := GetTried(r.Context())
 	for name := range routingExclusions {
 		triedCreds[name] = true

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -90,6 +90,11 @@ func (p *Proxy) orchestrateRequest(
 		logCtx.Status = "failure"
 		logCtx.HTTPStatus = http.StatusBadRequest
 		logCtx.ErrorMsg = "Invalid internal routing policy"
+		p.logger.WarnContext(r.Context(), "Rejected invalid internal routing policy",
+			"error_code", http.StatusBadRequest,
+			"error", err,
+			"request_id", logCtx.RequestID,
+		)
 		WriteErrorBadRequest(w, "Invalid internal routing policy")
 		return nil, false
 	}

--- a/internal/proxy/organization_credential_denylist_test.go
+++ b/internal/proxy/organization_credential_denylist_test.go
@@ -1,0 +1,492 @@
+package proxy
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	routermodels "github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type denylistHostRewriteTransport struct {
+	targets map[string]*url.URL
+}
+
+func (transport denylistHostRewriteTransport) RoundTrip(request *http.Request) (*http.Response, error) {
+	target := transport.targets[request.URL.Hostname()]
+	if target == nil {
+		return http.DefaultTransport.RoundTrip(request)
+	}
+	clone := request.Clone(request.Context())
+	clone.URL.Scheme = target.Scheme
+	clone.URL.Host = target.Host
+	clone.Host = target.Host
+	return http.DefaultTransport.RoundTrip(clone)
+}
+
+func setDenylistHostRewrite(t *testing.T, proxy *Proxy, host, target string) {
+	t.Helper()
+	parsed, err := url.Parse(target)
+	require.NoError(t, err)
+	proxy.client.Transport = denylistHostRewriteTransport{targets: map[string]*url.URL{host: parsed}}
+}
+
+func denylistProvider(t *testing.T, calls *atomic.Int32, receivedHeader *atomic.Bool) *httptest.Server {
+	t.Helper()
+	return newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Header.Get(HeaderAIRCredentialDenylist) != "" {
+			receivedHeader.Store(true)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(createMockChatCompletionResponse(
+			"chatcmpl-denylist",
+			"route-a",
+			"ok",
+		))
+	}))
+}
+
+func directDenylistCredential(name, baseURL string) config.CredentialConfig {
+	return config.CredentialConfig{
+		Name: name, Type: config.ProviderTypeOpenAI, BaseURL: baseURL,
+		APIKey: "provider-key", RPM: -1, TPM: -1,
+	}
+}
+
+func newDenylistRootProxy(
+	t *testing.T,
+	leafURL string,
+	db *organizationPolicyTestDB,
+	denylist []string,
+) *Proxy {
+	t.Helper()
+	credential := proxyCred("leaf-router", leafURL, 1)
+	manager := routermodels.New(testhelpers.NewTestLogger(), 100, []config.ModelRPMConfig{{
+		Name: "route-a", Credential: credential.Name,
+	}})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+	manager.SetCredentials([]config.CredentialConfig{credential})
+	registry, err := routermodels.LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+		OrganizationID:     "org-1",
+		PriceProfileID:     "profile-1",
+		ModelPricesLink:    writeProxyPolicyPrices(t, `{"route-a":{"input_cost_per_token":0.001,"output_cost_per_token":0.001}}`),
+		CredentialDenylist: denylist,
+	}}, manager, routermodels.OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      true,
+		LiteLLMDBRequired:     true,
+		DisableSpendLogsWrite: false,
+	})
+	require.NoError(t, err)
+
+	builder := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("root-master-key")
+	builder.config.ModelManager = manager
+	builder.config.OrganizationPolicies = registry
+	root := builder.Build()
+	root.LiteLLMDB = db
+	return root
+}
+
+func newLocalDenylistPolicyProxy(
+	t *testing.T,
+	credentials []config.CredentialConfig,
+	db *organizationPolicyTestDB,
+	denylist []string,
+) *Proxy {
+	t.Helper()
+	models := make([]config.ModelRPMConfig, 0, len(credentials))
+	for _, credential := range credentials {
+		models = append(models, config.ModelRPMConfig{Name: "route-a", Credential: credential.Name})
+	}
+	manager := routermodels.New(testhelpers.NewTestLogger(), 100, models)
+	manager.LoadModelsFromConfig(credentials)
+	manager.SetCredentials(credentials)
+	registry, err := routermodels.LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+		OrganizationID:     "org-1",
+		PriceProfileID:     "profile-1",
+		ModelPricesLink:    writeProxyPolicyPrices(t, `{"route-a":{"input_cost_per_token":0.001,"output_cost_per_token":0.001}}`),
+		CredentialDenylist: denylist,
+	}}, manager, routermodels.OrganizationPolicyLoadOptions{
+		LiteLLMDBEnabled:      true,
+		LiteLLMDBRequired:     true,
+		DisableSpendLogsWrite: false,
+	})
+	require.NoError(t, err)
+
+	builder := NewTestProxyBuilder().WithCredentials(credentials...).WithMasterKey("master-key")
+	builder.config.ModelManager = manager
+	builder.config.OrganizationPolicies = registry
+	proxy := builder.Build()
+	proxy.LiteLLMDB = db
+	return proxy
+}
+
+func TestOrganizationCredentialDenylistIsOrganizationScopedAndAppliesLocally(t *testing.T) {
+	var deniedCalls, allowedCalls atomic.Int32
+	var deniedHeader, allowedHeader atomic.Bool
+	deniedProvider := denylistProvider(t, &deniedCalls, &deniedHeader)
+	defer deniedProvider.Close()
+	allowedProvider := denylistProvider(t, &allowedCalls, &allowedHeader)
+	defer allowedProvider.Close()
+	deniedCredential := directDenylistCredential("denied-provider", deniedProvider.URL)
+	deniedCredential.Weight = 100
+	credentials := []config.CredentialConfig{
+		deniedCredential,
+		directDenylistCredential("allowed-provider", allowedProvider.URL),
+	}
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"restricted-token": {
+			Token: "restricted-hash", UserID: "restricted-user",
+			DirectOrganizationID: "org-1", OrganizationID: "org-1",
+		},
+		"control-token": {
+			Token: "control-hash", UserID: "control-user",
+			DirectOrganizationID: "org-2", OrganizationID: "org-2",
+		},
+	}}
+	proxy := newLocalDenylistPolicyProxy(t, credentials, db, []string{"denied-provider"})
+	setTestModelPrice(proxy, "route-a", &routermodels.ModelPrice{})
+
+	request := func(token string) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+			`{"model":"route-a","messages":[]}`,
+		))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		w := httptest.NewRecorder()
+		proxy.ProxyRequest(w, req)
+		return w
+	}
+
+	require.Equal(t, http.StatusOK, request("restricted-token").Code)
+	assert.Zero(t, deniedCalls.Load())
+	assert.Equal(t, int32(1), allowedCalls.Load())
+
+	require.Equal(t, http.StatusOK, request("control-token").Code)
+	assert.Equal(t, int32(1), deniedCalls.Load())
+}
+
+func TestOrganizationCredentialDenylistPropagatesAndKeepsRouterEligible(t *testing.T) {
+	var deniedCalls, allowedCalls atomic.Int32
+	var deniedHeader, allowedHeader atomic.Bool
+	deniedProvider := denylistProvider(t, &deniedCalls, &deniedHeader)
+	defer deniedProvider.Close()
+	allowedProvider := denylistProvider(t, &allowedCalls, &allowedHeader)
+	defer allowedProvider.Close()
+
+	deniedCredential := directDenylistCredential("denied-provider", deniedProvider.URL)
+	allowedCredential := directDenylistCredential("allowed-provider", allowedProvider.URL)
+	leaf := NewTestProxyBuilder().
+		WithCredentials(deniedCredential, allowedCredential).
+		WithMasterKey("master-key").
+		Build()
+	registerTestModel(leaf, deniedCredential.Name, "route-a")
+	registerTestModel(leaf, allowedCredential.Name, "route-a")
+	leafServer := newIPv4Server(t, http.HandlerFunc(leaf.ProxyRequest))
+	defer leafServer.Close()
+	middleCredential := proxyCred("leaf-router", "http://air-leaf.production", 1)
+	middle := NewTestProxyBuilder().
+		WithCredentials(middleCredential).
+		WithMasterKey("master-key").
+		Build()
+	registerTestModel(middle, middleCredential.Name, "route-a")
+	setDenylistHostRewrite(t, middle, "air-leaf.production", leafServer.URL)
+	middleServer := newIPv4Server(t, http.HandlerFunc(middle.ProxyRequest))
+	defer middleServer.Close()
+
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"org-token": {
+			Token: "token-hash", UserID: "user-1",
+			DirectOrganizationID: "org-1", OrganizationID: "org-1",
+		},
+	}}
+	root := newDenylistRootProxy(t, "http://air-middle", db, []string{"denied-provider", "leaf-router"})
+	setDenylistHostRewrite(t, root, "air-middle", middleServer.URL)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[{"role":"user","content":"test"}]}`,
+	))
+	req.Header.Set("Authorization", "Bearer org-token")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	root.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Zero(t, deniedCalls.Load())
+	assert.Equal(t, int32(1), allowedCalls.Load())
+	assert.False(t, deniedHeader.Load())
+	assert.False(t, allowedHeader.Load())
+}
+
+func TestOrganizationCredentialDenylistRejectsAllProviderCandidates(t *testing.T) {
+	var calls atomic.Int32
+	var receivedHeader atomic.Bool
+	provider := denylistProvider(t, &calls, &receivedHeader)
+	defer provider.Close()
+	credential := directDenylistCredential("provider", provider.URL)
+	leaf := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key").Build()
+	registerTestModel(leaf, credential.Name, "route-a")
+
+	header, err := json.Marshal([]string{"provider"})
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[]}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAIRProxyClient, "1")
+	req.Header.Set(HeaderAIRCredentialDenylist, string(header))
+	w := httptest.NewRecorder()
+	leaf.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Zero(t, calls.Load())
+	assert.False(t, receivedHeader.Load())
+}
+
+func TestOrganizationCredentialDenylistIgnoresUntrustedHeader(t *testing.T) {
+	var calls atomic.Int32
+	var receivedHeader atomic.Bool
+	provider := denylistProvider(t, &calls, &receivedHeader)
+	defer provider.Close()
+	credential := directDenylistCredential("provider", provider.URL)
+	db := &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+		"virtual-key": {Token: "token-hash", UserID: "user-1"},
+	}}
+	leaf := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key").Build()
+	leaf.LiteLLMDB = db
+	registerTestModel(leaf, credential.Name, "route-a")
+	setTestModelPrice(leaf, "route-a", &routermodels.ModelPrice{})
+
+	for _, testCase := range []struct {
+		name   string
+		token  string
+		marker bool
+	}{
+		{name: "virtual key with marker", token: "virtual-key", marker: true},
+		{name: "master key without marker", token: "master-key", marker: false},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+				`{"model":"route-a","messages":[]}`,
+			))
+			req.Header.Set("Authorization", "Bearer "+testCase.token)
+			req.Header.Set("Content-Type", "application/json")
+			if testCase.marker {
+				req.Header.Set(HeaderAIRProxyClient, "1")
+			}
+			req.Header.Set(HeaderAIRCredentialDenylist, `["provider"]`)
+			w := httptest.NewRecorder()
+			leaf.ProxyRequest(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+		})
+	}
+	assert.Equal(t, int32(2), calls.Load())
+	assert.False(t, receivedHeader.Load())
+}
+
+func TestOrganizationCredentialDenylistRejectsMalformedTrustedHeader(t *testing.T) {
+	var calls atomic.Int32
+	var receivedHeader atomic.Bool
+	provider := denylistProvider(t, &calls, &receivedHeader)
+	defer provider.Close()
+	credential := directDenylistCredential("provider", provider.URL)
+	leaf := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key").Build()
+	registerTestModel(leaf, credential.Name, "route-a")
+
+	for _, value := range []string{`{"not":"a-list"}`, strings.Repeat("x", maxCredentialDenylistBytes+1)} {
+		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+			`{"model":"route-a","messages":[]}`,
+		))
+		req.Header.Set("Authorization", "Bearer master-key")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set(HeaderAIRProxyClient, "1")
+		req.Header.Set(HeaderAIRCredentialDenylist, value)
+		w := httptest.NewRecorder()
+		leaf.ProxyRequest(w, req)
+
+		assert.Equal(t, http.StatusBadRequest, w.Code)
+	}
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[]}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAIRProxyClient, "1")
+	req.Header.Add(HeaderAIRCredentialDenylist, `["provider"]`)
+	req.Header.Add(HeaderAIRCredentialDenylist, `["other-provider"]`)
+	w := httptest.NewRecorder()
+	leaf.ProxyRequest(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	assert.Zero(t, calls.Load())
+	assert.False(t, receivedHeader.Load())
+}
+
+func TestParseCredentialDenylistRejectsInvalidValues(t *testing.T) {
+	tooMany, err := json.Marshal(make([]string, maxCredentialDenylistEntries+1))
+	require.NoError(t, err)
+	oversizedName, err := json.Marshal([]string{strings.Repeat("x", maxCredentialNameBytes+1)})
+	require.NoError(t, err)
+
+	for _, value := range []string{
+		`{"not":"a-list"}`,
+		`["provider"] trailing`,
+		`[" provider"]`,
+		`["provider\n"]`,
+		string(tooMany),
+		string(oversizedName),
+	} {
+		_, err := parseCredentialDenylist(value)
+		require.ErrorIs(t, err, errInvalidCredentialDenylist)
+	}
+
+	parsed, err := parseCredentialDenylist(`["provider","provider"]`)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"provider"}, parsed)
+}
+
+func TestOrganizationCredentialDenylistOverridesSessionBinding(t *testing.T) {
+	var deniedCalls, allowedCalls atomic.Int32
+	var deniedHeader, allowedHeader atomic.Bool
+	deniedProvider := denylistProvider(t, &deniedCalls, &deniedHeader)
+	defer deniedProvider.Close()
+	allowedProvider := denylistProvider(t, &allowedCalls, &allowedHeader)
+	defer allowedProvider.Close()
+
+	deniedCredential := directDenylistCredential("denied-provider", deniedProvider.URL)
+	allowedCredential := directDenylistCredential("allowed-provider", allowedProvider.URL)
+	leaf := NewTestProxyBuilder().
+		WithCredentials(deniedCredential, allowedCredential).
+		WithMasterKey("master-key").
+		WithSessionSticky(5 * time.Minute).
+		Build()
+	registerTestModel(leaf, deniedCredential.Name, "route-a")
+	registerTestModel(leaf, allowedCredential.Name, "route-a")
+	leaf.sessionStore.Set("session-1", "route-a", deniedCredential.Name)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[],"user":"session-1"}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAIRProxyClient, "1")
+	req.Header.Set(HeaderAIRCredentialDenylist, `["denied-provider"]`)
+	w := httptest.NewRecorder()
+	leaf.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Zero(t, deniedCalls.Load())
+	assert.Equal(t, int32(1), allowedCalls.Load())
+}
+
+func TestOrganizationCredentialDenylistSurvivesRetry(t *testing.T) {
+	var failingCalls, deniedCalls, allowedCalls atomic.Int32
+	failingProvider := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		failingCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"error":{"message":"failed"}}`))
+	}))
+	defer failingProvider.Close()
+	var deniedHeader, allowedHeader atomic.Bool
+	deniedProvider := denylistProvider(t, &deniedCalls, &deniedHeader)
+	defer deniedProvider.Close()
+	allowedProvider := denylistProvider(t, &allowedCalls, &allowedHeader)
+	defer allowedProvider.Close()
+
+	failingCredential := directDenylistCredential("failing-provider", failingProvider.URL)
+	failingCredential.Weight = 100
+	deniedCredential := directDenylistCredential("denied-provider", deniedProvider.URL)
+	allowedCredential := directDenylistCredential("allowed-provider", allowedProvider.URL)
+	leaf := NewTestProxyBuilder().
+		WithCredentials(failingCredential, deniedCredential, allowedCredential).
+		WithMasterKey("master-key").
+		WithMaxProviderRetries(1).
+		Build()
+	for _, credential := range []config.CredentialConfig{failingCredential, deniedCredential, allowedCredential} {
+		registerTestModel(leaf, credential.Name, "route-a")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[]}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAIRProxyClient, "1")
+	req.Header.Set(HeaderAIRCredentialDenylist, `["denied-provider"]`)
+	w := httptest.NewRecorder()
+	leaf.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(1), failingCalls.Load())
+	assert.Zero(t, deniedCalls.Load())
+	assert.Equal(t, int32(1), allowedCalls.Load())
+}
+
+func TestOrganizationCredentialDenylistAllowsFallback(t *testing.T) {
+	var deniedCalls, fallbackCalls atomic.Int32
+	var deniedHeader, fallbackHeader atomic.Bool
+	deniedProvider := denylistProvider(t, &deniedCalls, &deniedHeader)
+	defer deniedProvider.Close()
+	fallbackProvider := denylistProvider(t, &fallbackCalls, &fallbackHeader)
+	defer fallbackProvider.Close()
+
+	deniedCredential := directDenylistCredential("denied-provider", deniedProvider.URL)
+	fallbackCredential := directDenylistCredential("fallback-provider", fallbackProvider.URL)
+	fallbackCredential.IsFallback = true
+	leaf := NewTestProxyBuilder().
+		WithCredentials(deniedCredential, fallbackCredential).
+		WithMasterKey("master-key").
+		Build()
+	registerTestModel(leaf, deniedCredential.Name, "route-a")
+	registerTestModel(leaf, fallbackCredential.Name, "route-a")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[]}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAIRProxyClient, "1")
+	req.Header.Set(HeaderAIRCredentialDenylist, `["denied-provider"]`)
+	w := httptest.NewRecorder()
+	leaf.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Zero(t, deniedCalls.Load())
+	assert.Equal(t, int32(1), fallbackCalls.Load())
+}
+
+func TestOrganizationCredentialDenylistDoesNotReachGenericProxy(t *testing.T) {
+	var calls atomic.Int32
+	var receivedHeader atomic.Bool
+	provider := denylistProvider(t, &calls, &receivedHeader)
+	defer provider.Close()
+	credential := proxyCred("generic-proxy", provider.URL, 1)
+	leaf := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key").Build()
+	registerTestModel(leaf, credential.Name, "route-a")
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
+		`{"model":"route-a","messages":[]}`,
+	))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(HeaderAIRProxyClient, "1")
+	req.Header.Set(HeaderAIRCredentialDenylist, `["other-provider"]`)
+	w := httptest.NewRecorder()
+	leaf.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, int32(1), calls.Load())
+	assert.False(t, receivedHeader.Load())
+}

--- a/internal/proxy/organization_credential_denylist_test.go
+++ b/internal/proxy/organization_credential_denylist_test.go
@@ -1,7 +1,10 @@
 package proxy
 
 import (
+	"bytes"
 	"encoding/json"
+	"fmt"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -303,8 +306,11 @@ func TestOrganizationCredentialDenylistRejectsMalformedTrustedHeader(t *testing.
 	credential := directDenylistCredential("provider", provider.URL)
 	leaf := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key").Build()
 	registerTestModel(leaf, credential.Name, "route-a")
+	var logs bytes.Buffer
+	leaf.logger = slog.New(slog.NewJSONHandler(&logs, nil))
 
-	for _, value := range []string{`{"not":"a-list"}`, strings.Repeat("x", maxCredentialDenylistBytes+1)} {
+	const privateHeaderValue = `{"private-review-marker":"not-a-list"}`
+	for _, value := range []string{privateHeaderValue, strings.Repeat("x", maxCredentialDenylistBytes+1)} {
 		req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(
 			`{"model":"route-a","messages":[]}`,
 		))
@@ -331,11 +337,11 @@ func TestOrganizationCredentialDenylistRejectsMalformedTrustedHeader(t *testing.
 
 	assert.Zero(t, calls.Load())
 	assert.False(t, receivedHeader.Load())
+	assert.Contains(t, logs.String(), "Rejected invalid internal routing policy")
+	assert.NotContains(t, logs.String(), "private-review-marker")
 }
 
 func TestParseCredentialDenylistRejectsInvalidValues(t *testing.T) {
-	tooMany, err := json.Marshal(make([]string, maxCredentialDenylistEntries+1))
-	require.NoError(t, err)
 	oversizedName, err := json.Marshal([]string{strings.Repeat("x", maxCredentialNameBytes+1)})
 	require.NoError(t, err)
 
@@ -344,7 +350,6 @@ func TestParseCredentialDenylistRejectsInvalidValues(t *testing.T) {
 		`["provider"] trailing`,
 		`[" provider"]`,
 		`["provider\n"]`,
-		string(tooMany),
 		string(oversizedName),
 	} {
 		_, err := parseCredentialDenylist(value)
@@ -354,6 +359,36 @@ func TestParseCredentialDenylistRejectsInvalidValues(t *testing.T) {
 	parsed, err := parseCredentialDenylist(`["provider","provider"]`)
 	require.NoError(t, err)
 	assert.Equal(t, []string{"provider"}, parsed)
+}
+
+func TestCredentialDenylistCodecLimits(t *testing.T) {
+	names := make([]string, maxCredentialDenylistEntries)
+	for index := range names {
+		names[index] = fmt.Sprintf("credential-%04d", index)
+	}
+	header := make(http.Header)
+	require.NoError(t, setCredentialDenylistHeader(header, names))
+	parsed, err := parseCredentialDenylist(header.Get(HeaderAIRCredentialDenylist))
+	require.NoError(t, err)
+	assert.Equal(t, names, parsed)
+
+	overflow := append(names, "credential-overflow")
+	header = make(http.Header)
+	require.ErrorIs(t, setCredentialDenylistHeader(header, overflow), errInvalidCredentialDenylist)
+	assert.Empty(t, header.Get(HeaderAIRCredentialDenylist))
+	encoded, err := json.Marshal(overflow)
+	require.NoError(t, err)
+	_, err = parseCredentialDenylist(string(encoded))
+	require.ErrorIs(t, err, errInvalidCredentialDenylist)
+
+	large := make([]string, 300)
+	for index := range large {
+		prefix := fmt.Sprintf("%03d-", index)
+		large[index] = prefix + strings.Repeat("x", maxCredentialNameBytes-len(prefix))
+	}
+	header = make(http.Header)
+	require.Error(t, setCredentialDenylistHeader(header, large))
+	assert.Empty(t, header.Get(HeaderAIRCredentialDenylist))
 }
 
 func TestOrganizationCredentialDenylistOverridesSessionBinding(t *testing.T) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -661,6 +661,11 @@ func (p *Proxy) executeProxyRequest(
 	// knows to include the X-Credential-Name response header.
 	proxyReq.Header.Set(HeaderAIRProxyClient, "1")
 	proxyReq.Header.Set(HeaderLegacyAIRProxyClient, "1")
+	if carriesCredentialDenylist(cred) {
+		if err := setCredentialDenylistHeader(proxyReq.Header, effectiveCredentialDenylist(r.Context())); err != nil {
+			return nil, err
+		}
+	}
 
 	// Send request
 	resp, err := p.client.Do(proxyReq) //nolint:gosec // G704: same targetURL as above, host isn't attacker-controlled
@@ -844,6 +849,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 		r.Header.Get(HeaderLegacyAIRProxyClient) == "1"
 	r.Header.Del(HeaderAIRProxyClient)
 	r.Header.Del(HeaderLegacyAIRProxyClient)
+	r = captureCredentialDenylist(r, proxyMarkerPresent)
 
 	// Create logging context that will be filled throughout request processing
 	// and logged at the end via defer to ensure all requests are logged
@@ -884,15 +890,6 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if proxyMarkerPresent {
-		logCtx.IsProxyRequest = p.isMasterKey(logCtx.Token)
-		if !logCtx.IsProxyRequest {
-			p.logger.WarnContext(r.Context(), "Ignoring untrusted AIR proxy marker",
-				"request_id", requestID,
-			)
-		}
-	}
-
 	r = prepared.request
 	logCtx.Request = r
 	body := prepared.body


### PR DESCRIPTION
## Summary

Adds an organization policy credential denylist.

Applies exact provider credential exclusions across chained AIR routers.

Preserves router credentials and standard routing when the list is absent.

Supports up to 1024 names and 64 KiB of encoded policy data.

Validates outbound policy data before forwarding.

Rejects malformed trusted policy headers and logs the rejection without recording header values.

## Validation

- go test ./...
- go test -race ./internal/config ./internal/proxy
- go vet ./...
- golangci-lint run ./...
- zensical build --clean

## Rollout

Deploy the new AIR build to every reachable router before configuring a non-empty denylist.