### PR TITLE
Fallback on not found model errors

### DIFF
--- a/internal/proxy/chain_propagation_test.go
+++ b/internal/proxy/chain_propagation_test.go
@@ -54,7 +54,7 @@ func buildThreeRouterChain(t *testing.T, providerURL string) *Proxy {
 // TestRouterChain_ErrorStatusPropagatedThroughChain verifies that ANY error
 // status produced by the provider behind router3 travels unchanged through
 // router3 → router2 → router1 to the client. Covers both non-retryable
-// statuses (plain passthrough) and retryable ones (400, 401, 402, 403, 429,
+// statuses (plain passthrough) and retryable ones (400, 401, 402, 403, 404, 429,
 // 5xx) — with no alternative credentials at any hop, the original response
 // must be returned, never remapped to a different code.
 func TestRouterChain_ErrorStatusPropagatedThroughChain(t *testing.T) {
@@ -63,7 +63,7 @@ func TestRouterChain_ErrorStatusPropagatedThroughChain(t *testing.T) {
 		http.StatusUnauthorized,          // 401 — retryable class (auth)
 		http.StatusPaymentRequired,       // 402 — retryable class (payment)
 		http.StatusForbidden,             // 403 — retryable class (auth)
-		http.StatusNotFound,              // 404 — non-retryable passthrough
+		http.StatusNotFound,              // 404 — retryable class
 		http.StatusRequestTimeout,        // 408 — non-retryable passthrough
 		http.StatusConflict,              // 409 — non-retryable passthrough
 		http.StatusRequestEntityTooLarge, // 413 — non-retryable passthrough

--- a/internal/proxy/fallback_integration_test.go
+++ b/internal/proxy/fallback_integration_test.go
@@ -272,9 +272,7 @@ func TestFallbackPath_FallbackAlsoFails(t *testing.T) {
 	assert.Equal(t, int32(1), fallbackCalls)
 }
 
-// TestFallbackPath_NonRetryableError tests that errors like "model not found" are NOT retried
-// even if other conditions would trigger fallback.
-func TestFallbackPath_NonRetryableError(t *testing.T) {
+func TestFallbackPath_NotFoundModelErrorUsesFallback(t *testing.T) {
 	var primaryCalls, fallbackCalls int32
 
 	primaryServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -288,6 +286,7 @@ func TestFallbackPath_NonRetryableError(t *testing.T) {
 	fallbackServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&fallbackCalls, 1)
 		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(createMockChatCompletionResponse("chatcmpl-fallback", "gpt-4", "fallback response"))
 	}))
 	defer fallbackServer.Close()
 
@@ -322,10 +321,10 @@ func TestFallbackPath_NonRetryableError(t *testing.T) {
 
 	prx.ProxyRequest(w, req)
 
-	// Original error returned (no retry attempted)
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "fallback response")
 	assert.Equal(t, int32(1), primaryCalls)
-	assert.Equal(t, int32(0), fallbackCalls, "Fallback should NOT be called for non-retryable error")
+	assert.Equal(t, int32(1), fallbackCalls)
 }
 
 // TestFallbackPath_Streaming_NotSupported tests the current limitation that

--- a/internal/proxy/proxy_fallback_test.go
+++ b/internal/proxy/proxy_fallback_test.go
@@ -122,12 +122,9 @@ func TestProxyFallbackOn429(t *testing.T) {
 	assert.True(t, hasUsage, "Response should contain 'usage' field for token tracking")
 }
 
-// TestProxyFallbackOn429_ModelNotFoundBody tests that when primary returns 429
-// with a model-not-found body, fallback is NOT attempted (model errors are non-retryable).
 func TestProxyFallbackOn429_ModelNotFoundBody(t *testing.T) {
 	var primaryCalls, fallbackCalls int32
 
-	// Primary returns 429 with model not found (non-retryable)
 	primaryServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&primaryCalls, 1)
 		w.Header().Set("Content-Type", "application/json")
@@ -139,11 +136,16 @@ func TestProxyFallbackOn429_ModelNotFoundBody(t *testing.T) {
 	}))
 	defer primaryServer.Close()
 
-	// Fallback server (should NOT be called)
 	fallbackServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt32(&fallbackCalls, 1)
-		w.WriteHeader(http.StatusOK)
-		_ = json.NewEncoder(w).Encode(map[string]string{"result": "ok"})
+		_ = testhelpers.NewResponseBuilder().
+			WithStatus(http.StatusOK).
+			WithJSONBody(createMockChatCompletionResponse(
+				"chatcmpl-fallback",
+				"gpt-4",
+				"fallback response",
+			)).
+			Write(w)
 	}))
 	defer fallbackServer.Close()
 
@@ -160,8 +162,9 @@ func TestProxyFallbackOn429_ModelNotFoundBody(t *testing.T) {
 	prx.ProxyRequest(w, req)
 
 	assert.Equal(t, int32(1), atomic.LoadInt32(&primaryCalls), "Primary should be called")
-	assert.Equal(t, int32(0), atomic.LoadInt32(&fallbackCalls), "Fallback should NOT be called for model-not-found")
-	assert.Equal(t, http.StatusTooManyRequests, w.Code, "Original error code should be returned")
+	assert.Equal(t, int32(1), atomic.LoadInt32(&fallbackCalls), "Fallback should be called")
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Contains(t, w.Body.String(), "fallback response")
 }
 
 // TestProxyFallbackOn429_RequestBodyPreserved tests that the exact request body

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -40,7 +40,7 @@ func ShouldRetryWithFallback(statusCode int, respBody []byte) (bool, RetryReason
 	// Determine if status code is retryable
 	var retryReason RetryReason
 	switch {
-	case statusCode == http.StatusBadRequest:
+	case statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound:
 		retryReason = RetryReasonServerErr
 	case statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden:
 		retryReason = RetryReasonAuthErr
@@ -74,13 +74,6 @@ func isRetryableContent(respBody []byte) bool {
 	if bytes.Contains(bodyLower, []byte("content policy")) ||
 		bytes.Contains(bodyLower, []byte("content management policy")) ||
 		bytes.Contains(bodyLower, []byte("policy violation")) {
-		return false
-	}
-
-	// Don't retry if it's a model-specific error that won't be fixed by retrying
-	if bytes.Contains(bodyLower, []byte("model not found")) ||
-		bytes.Contains(bodyLower, []byte("model does not exist")) ||
-		bytes.Contains(bodyLower, []byte("unsupported model")) {
 		return false
 	}
 

--- a/internal/proxy/retry_test.go
+++ b/internal/proxy/retry_test.go
@@ -79,7 +79,6 @@ func TestShouldRetryWithFallback_NonRetryableStatus(t *testing.T) {
 	}{
 		{"200 OK", http.StatusOK},
 		{"201 Created", http.StatusCreated},
-		{"404 Not Found", http.StatusNotFound},
 	}
 
 	for _, tt := range tests {
@@ -95,6 +94,13 @@ func TestShouldRetryWithFallback_NonRetryableStatus(t *testing.T) {
 func TestShouldRetryWithFallback_BadRequest(t *testing.T) {
 	// 400 Bad Request is retried — a different credential may not produce the same error
 	shouldRetry, reason := ShouldRetryWithFallback(http.StatusBadRequest, []byte("bad request"))
+
+	assert.True(t, shouldRetry)
+	assert.Equal(t, RetryReasonServerErr, reason)
+}
+
+func TestShouldRetryWithFallback_NotFound(t *testing.T) {
+	shouldRetry, reason := ShouldRetryWithFallback(http.StatusNotFound, []byte("not found"))
 
 	assert.True(t, shouldRetry)
 	assert.Equal(t, RetryReasonServerErr, reason)
@@ -126,8 +132,7 @@ func TestShouldRetryWithFallback_ContentPolicyViolation(t *testing.T) {
 	}
 }
 
-func TestShouldRetryWithFallback_ModelNotFound(t *testing.T) {
-	// Model-specific errors should not be retried
+func TestShouldRetryWithFallback_ModelErrors(t *testing.T) {
 	tests := []struct {
 		name     string
 		respBody string
@@ -147,8 +152,8 @@ func TestShouldRetryWithFallback_ModelNotFound(t *testing.T) {
 				[]byte(tt.respBody),
 			)
 
-			assert.False(t, shouldRetry)
-			assert.Equal(t, RetryReason(""), reason)
+			assert.True(t, shouldRetry)
+			assert.Equal(t, RetryReasonServerErr, reason)
 		})
 	}
 }
@@ -216,12 +221,12 @@ func TestIsRetryableContent_ModelErrors(t *testing.T) {
 		content  string
 		expected bool
 	}{
-		{"model not found", "model not found", false},
-		{"Model Not Found uppercase", "MODEL NOT FOUND", false},
-		{"model does not exist", "model does not exist", false},
-		{"Model Does Not Exist", "MODEL DOES NOT EXIST", false},
-		{"unsupported model", "unsupported model gpt-4", false},
-		{"Unsupported Model", "UNSUPPORTED MODEL", false},
+		{"model not found", "model not found", true},
+		{"Model Not Found uppercase", "MODEL NOT FOUND", true},
+		{"model does not exist", "model does not exist", true},
+		{"Model Does Not Exist", "MODEL DOES NOT EXIST", true},
+		{"unsupported model", "unsupported model gpt-4", true},
+		{"Unsupported Model", "UNSUPPORTED MODEL", true},
 		{"other error", "validation error", true},
 		{"empty", "", true},
 	}
@@ -231,21 +236,6 @@ func TestIsRetryableContent_ModelErrors(t *testing.T) {
 			result := isRetryableContent([]byte(tt.content))
 			assert.Equal(t, tt.expected, result)
 		})
-	}
-}
-
-func TestIsRetryableContent_CaseInsensitive(t *testing.T) {
-	// Verify case-insensitive matching works for model-not-found patterns
-	testCases := []string{
-		"Model not Found",
-		"MODEL NOT FOUND",
-		"Unsupported MODEL",
-		"MODEL DOES NOT EXIST",
-	}
-
-	for _, tc := range testCases {
-		result := isRetryableContent([]byte(tc))
-		assert.False(t, result, "should not be retryable for: %s", tc)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Retry upstream 404 responses through credential retry and fallback paths
- Keep model not found, model does not exist, and unsupported model bodies retryable
- Update fallback and propagation tests

## Tests
- go test ./...