### PR TITLE
fix: 413 on oversized Vertex/Gemini image payloads

### DIFF
--- a/internal/converter/converterutil/errors.go
+++ b/internal/converter/converterutil/errors.go
@@ -1,13 +1,20 @@
 // Package converterutil holds helpers shared by the provider converters.
 package converterutil
 
-import "fmt"
+import (
+	"fmt"
+	"net/http"
+)
 
 // RequestValidationError marks malformed or unsupported client payload content.
 // Proxy layers should map it to 4xx without treating it as an AIR/internal failure.
+// StatusCode is 0 for the common case ("caller decides", historically always
+// mapped to 400) or a specific status (e.g. 413) when the error itself dictates
+// which 4xx applies, regardless of which proxy call site catches it.
 type RequestValidationError struct {
-	Param   string
-	Message string
+	Param      string
+	Message    string
+	StatusCode int
 }
 
 func (e *RequestValidationError) Error() string {
@@ -25,4 +32,11 @@ func (e *RequestValidationError) Error() string {
 
 func NewRequestValidationError(param, message string) error {
 	return &RequestValidationError{Param: param, Message: message}
+}
+
+// NewRequestEntityTooLargeError marks a payload that exceeds a provider-imposed
+// size limit (e.g. an inline base64 image/file). Proxy layers should map it to
+// 413 Request Entity Too Large instead of the default 400.
+func NewRequestEntityTooLargeError(param, message string) error {
+	return &RequestValidationError{Param: param, Message: message, StatusCode: http.StatusRequestEntityTooLarge}
 }

--- a/internal/converter/vertex/content.go
+++ b/internal/converter/vertex/content.go
@@ -19,59 +19,65 @@ func extractTextContent(content interface{}) string {
 	return parts[0]
 }
 
-// convertContentToParts converts OpenAI content format to genai.Part slice
-func convertContentToParts(content interface{}) []*genai.Part {
+// convertContentToParts converts OpenAI content format to genai.Part slice.
+// The only error case is a block whose content is unusable on its own terms
+// (currently: an inline data: URL payload too large to forward) — malformed
+// or unrecognized blocks are still skipped silently, as before.
+func convertContentToParts(content interface{}) ([]*genai.Part, error) {
 	switch c := content.(type) {
 	case string:
-		return []*genai.Part{{Text: c}}
+		return []*genai.Part{{Text: c}}, nil
 	case []interface{}:
 		var parts []*genai.Part
-		type partHandler func(map[string]interface{}) *genai.Part
+		type partHandler func(map[string]interface{}) (*genai.Part, error)
 
 		handlers := map[string]partHandler{
-			"text": func(block map[string]interface{}) *genai.Part {
+			"text": func(block map[string]interface{}) (*genai.Part, error) {
 				text, ok := block["text"].(string)
 				if !ok {
-					return nil
+					return nil, nil
 				}
-				return &genai.Part{Text: text}
+				return &genai.Part{Text: text}, nil
 			},
-			"image_url": func(block map[string]interface{}) *genai.Part {
+			"image_url": func(block map[string]interface{}) (*genai.Part, error) {
 				imageURL, ok := block["image_url"].(map[string]interface{})
 				if !ok {
-					return nil
+					return nil, nil
 				}
 				url, ok := imageURL["url"].(string)
 				if !ok {
-					return nil
+					return nil, nil
 				}
 				// Try to parse as data URL first, then as regular URL
-				part := parseDataURLToPart(url)
+				part, err := parseDataURLToPart(url)
+				if err != nil {
+					return nil, err
+				}
 				if part == nil {
 					// If not a data URL, treat as regular URL (http/https)
 					part = parseURLToPart(url, imageURL)
 				}
-				return part
+				return part, nil
 			},
-			"input_audio": func(block map[string]interface{}) *genai.Part {
+			"input_audio": func(block map[string]interface{}) (*genai.Part, error) {
 				audioData, ok := block["input_audio"].(map[string]interface{})
 				if !ok {
-					return nil
+					return nil, nil
 				}
 				data, ok := audioData["data"].(string)
 				if !ok {
-					return nil
+					return nil, nil
 				}
 
 				// check base64 payload size before decoding
 				if len(data) > 20*1024*1024 {
-					return nil
+					return nil, nil
 				}
 
 				// Decode base64 audio data
 				decodedData, err := base64.StdEncoding.DecodeString(data)
 				if err != nil {
-					return nil
+					return nil, nil
 				}
 
 				// Determine MIME type from format field or default to wav
@@ -85,16 +91,16 @@ func convertContentToParts(content interface{}) []*genai.Part {
 						MIMEType: mimeType,
 						Data:     decodedData,
 					},
-				}
+				}, nil
 			},
-			"video_url": func(block map[string]interface{}) *genai.Part {
+			"video_url": func(block map[string]interface{}) (*genai.Part, error) {
 				videoURL, ok := block["video_url"].(map[string]interface{})
 				if !ok {
-					return nil
+					return nil, nil
 				}
 				url, ok := videoURL["url"].(string)
 				if !ok {
-					return nil
+					return nil, nil
 				}
 
 				// Determine MIME type from format field or URL extension
@@ -115,25 +121,28 @@ func convertContentToParts(content interface{}) []*genai.Part {
 						MIMEType: mimeType,
 						FileURI:  url,
 					},
-				}
+				}, nil
 			},
-			"file": func(block map[string]interface{}) *genai.Part {
+			"file": func(block map[string]interface{}) (*genai.Part, error) {
 				fileObj, ok := block["file"].(map[string]interface{})
 				if !ok {
-					return nil
+					return nil, nil
 				}
 				fileID, ok := fileObj["file_id"].(string)
 				if !ok {
-					return nil
+					return nil, nil
 				}
 
 				// Try to parse as data URL first, then as regular URL
-				part := parseDataURLToPart(fileID)
+				part, err := parseDataURLToPart(fileID)
+				if err != nil {
+					return nil, err
+				}
 				if part == nil {
 					// If not a data URL, treat as regular URL (http/https)
 					part = parseURLToPart(fileID, fileObj)
 				}
-				return part
+				return part, nil
 			},
 		}
 
@@ -144,16 +153,20 @@ func convertContentToParts(content interface{}) []*genai.Part {
 			}
 			contentType, _ := blockMap["type"].(string)
 			if handler, ok := handlers[contentType]; ok {
-				if part := handler(blockMap); part != nil {
+				part, err := handler(blockMap)
+				if err != nil {
+					return nil, err
+				}
+				if part != nil {
 					parts = append(parts, part)
 				}
 			}
 		}
-		return parts
+		return parts, nil
 	}
 	// use json.Marshal instead of fmt.Sprintf for structured content
 	if data, err := json.Marshal(content); err == nil {
-		return []*genai.Part{{Text: string(data)}}
+		return []*genai.Part{{Text: string(data)}}, nil
 	}
-	return []*genai.Part{{Text: fmt.Sprintf("%v", content)}}
+	return []*genai.Part{{Text: fmt.Sprintf("%v", content)}}, nil
 }

--- a/internal/converter/vertex/content.go
+++ b/internal/converter/vertex/content.go
@@ -69,9 +69,12 @@ func convertContentToParts(content interface{}) ([]*genai.Part, error) {
 					return nil, nil
 				}
 
-				// check base64 payload size before decoding
-				if len(data) > 20*1024*1024 {
-					return nil, nil
+				// check base64 payload size before decoding — same limit and
+				// same explicit 413 (rather than a silent drop) as images,
+				// for the same reason: Vertex/Gemini's real inline-data cap
+				// is a single, media-agnostic 100MB (base64-encoded).
+				if len(data) > maxBase64Size {
+					return nil, converterutil.NewRequestEntityTooLargeError("input_audio.data", fmt.Sprintf("inline audio payload exceeds %dMB limit", maxBase64Size/(1024*1024)))
 				}
 
 				// Decode base64 audio data

--- a/internal/converter/vertex/content_test.go
+++ b/internal/converter/vertex/content_test.go
@@ -12,7 +12,8 @@ import (
 )
 
 func TestConvertContentToParts_InputAudioOversizedReturns413(t *testing.T) {
-	oversized := strings.Repeat("A", maxBase64Size+1)
+	withMaxBase64Size(t, 16)
+	oversized := strings.Repeat("A", 17)
 	content := []interface{}{
 		map[string]interface{}{
 			"type": "input_audio",

--- a/internal/converter/vertex/content_test.go
+++ b/internal/converter/vertex/content_test.go
@@ -1,0 +1,55 @@
+package vertex
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertContentToParts_InputAudioOversizedReturns413(t *testing.T) {
+	oversized := strings.Repeat("A", maxBase64Size+1)
+	content := []interface{}{
+		map[string]interface{}{
+			"type": "input_audio",
+			"input_audio": map[string]interface{}{
+				"data":   oversized,
+				"format": "wav",
+			},
+		},
+	}
+
+	parts, err := convertContentToParts(content)
+
+	require.Nil(t, parts)
+	require.Error(t, err)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, validationErr.StatusCode)
+}
+
+func TestConvertContentToParts_InputAudioValidDecodes(t *testing.T) {
+	raw := []byte("fake wav bytes")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	content := []interface{}{
+		map[string]interface{}{
+			"type": "input_audio",
+			"input_audio": map[string]interface{}{
+				"data":   encoded,
+				"format": "wav",
+			},
+		},
+	}
+
+	parts, err := convertContentToParts(content)
+
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].InlineData)
+	assert.Equal(t, raw, parts[0].InlineData.Data)
+	assert.Equal(t, "audio/wav", parts[0].InlineData.MIMEType)
+}

--- a/internal/converter/vertex/request.go
+++ b/internal/converter/vertex/request.go
@@ -133,7 +133,11 @@ func OpenAIToVertex(openAIBody []byte, isImageGeneration bool, isImageEdit bool,
 			// which would produce a "<nil>" text part via fmt.Sprintf.
 			if msg.Content != nil {
 				if s, ok := msg.Content.(string); !ok || s != "" {
-					parts = append(parts, convertContentToParts(msg.Content)...)
+					contentParts, err := convertContentToParts(msg.Content)
+					if err != nil {
+						return nil, err
+					}
+					parts = append(parts, contentParts...)
 				}
 			}
 			if len(msg.ToolCalls) > 0 && role == "model" {

--- a/internal/converter/vertex/responses/content.go
+++ b/internal/converter/vertex/responses/content.go
@@ -78,6 +78,13 @@ func convertInputAudioPart(partMap map[string]interface{}) ([]*genai.Part, error
 	if data == "" {
 		return nil, fmt.Errorf("input_audio: missing data")
 	}
+	// Same limit and same explicit 413 as input_image: Vertex/Gemini's real
+	// inline-data cap is a single, media-agnostic 100MB (base64-encoded), and
+	// this path previously had no size check at all — any payload, however
+	// large, was decoded in full before this fix.
+	if len(data) > maxInlineBase64Size {
+		return nil, converterutil.NewRequestEntityTooLargeError("input_audio.data", fmt.Sprintf("inline audio payload exceeds %dMB limit", maxInlineBase64Size/(1024*1024)))
+	}
 	decoded, err := base64.StdEncoding.DecodeString(data)
 	if err != nil {
 		return nil, fmt.Errorf("input_audio: base64 decode: %w", err)

--- a/internal/converter/vertex/responses/content.go
+++ b/internal/converter/vertex/responses/content.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
+	"github.com/mixaill76/auto_ai_router/internal/converter/vertex"
 	"google.golang.org/genai"
 )
 
@@ -60,8 +61,8 @@ func convertInputImageParts(partMap map[string]interface{}) ([]*genai.Part, erro
 	// data: URL that failed to parse above (unrecognized encoding, no comma,
 	// non-base64 payload) — instead of forwarding it to Vertex as a literal,
 	// potentially multi-megabyte FileURI.
-	if !isRemoteFileScheme(imgURL) {
-		return nil, converterutil.NewRequestValidationError("input_image.image_url", "unsupported image URL scheme")
+	if !isAllowedFileURL(imgURL) {
+		return nil, converterutil.NewRequestValidationError("input_image.image_url", "unsupported or blocked image URL")
 	}
 	return []*genai.Part{{
 		FileData: &genai.FileData{
@@ -92,8 +93,8 @@ func convertInputAudioPart(partMap map[string]interface{}) ([]*genai.Part, error
 func convertInputFilePart(partMap map[string]interface{}) ([]*genai.Part, error) {
 	fileURL, _ := partMap["file_url"].(string)
 	if fileURL != "" {
-		if !isRemoteFileScheme(fileURL) {
-			return nil, converterutil.NewRequestValidationError("input_file.file_url", "unsupported file URL scheme")
+		if !isAllowedFileURL(fileURL) {
+			return nil, converterutil.NewRequestValidationError("input_file.file_url", "unsupported or blocked file URL")
 		}
 		return []*genai.Part{{
 			FileData: &genai.FileData{
@@ -116,15 +117,26 @@ func convertInputFilePart(partMap map[string]interface{}) ([]*genai.Part, error)
 // anyway once decoded.
 const maxInlineBase64Size = 100 * 1024 * 1024 // 100MB encoded
 
-// isRemoteFileScheme reports whether rawURL uses a scheme Vertex can actually
-// fetch as a FileData reference. Anything else — including a data: URL that
-// failed to parse as inline data above — must never be forwarded as a
-// FileURI: Vertex would receive it as a literal, potentially multi-megabyte
-// string instead of the image/file it names.
-func isRemoteFileScheme(rawURL string) bool {
-	return strings.HasPrefix(rawURL, "http://") ||
+// isAllowedFileURL reports whether rawURL is safe to forward to Vertex as a
+// FileData reference: an allowed scheme (http/https/gs — anything else,
+// including a data: URL that failed to parse as inline data above, must
+// never be forwarded as a FileURI, since Vertex would receive it as a
+// literal, potentially multi-megabyte string instead of the image/file it
+// names), and — for http(s) — not a private/internal network address.
+// Mirrors the chat-completions path's parseURLToPart guard (vertex package);
+// duplicated here rather than shared because this package already imports
+// vertex for other reasons and the check is a handful of lines.
+func isAllowedFileURL(rawURL string) bool {
+	allowedScheme := strings.HasPrefix(rawURL, "http://") ||
 		strings.HasPrefix(rawURL, "https://") ||
 		strings.HasPrefix(rawURL, "gs://")
+	if !allowedScheme {
+		return false
+	}
+	if strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://") {
+		return !vertex.IsPrivateURL(rawURL)
+	}
+	return true
 }
 
 // parseDataURLToPart decodes a data: URL into an InlineData Part.

--- a/internal/converter/vertex/responses/content.go
+++ b/internal/converter/vertex/responses/content.go
@@ -56,7 +56,13 @@ func convertInputImageParts(partMap map[string]interface{}) ([]*genai.Part, erro
 		return []*genai.Part{part}, nil
 	}
 
-	// Regular https:// URL → fileData
+	// Regular https:// URL → fileData. Reject anything else — most notably a
+	// data: URL that failed to parse above (unrecognized encoding, no comma,
+	// non-base64 payload) — instead of forwarding it to Vertex as a literal,
+	// potentially multi-megabyte FileURI.
+	if !isRemoteFileScheme(imgURL) {
+		return nil, converterutil.NewRequestValidationError("input_image.image_url", "unsupported image URL scheme")
+	}
 	return []*genai.Part{{
 		FileData: &genai.FileData{
 			MIMEType: detectMIMEFromURL(imgURL),
@@ -86,6 +92,9 @@ func convertInputAudioPart(partMap map[string]interface{}) ([]*genai.Part, error
 func convertInputFilePart(partMap map[string]interface{}) ([]*genai.Part, error) {
 	fileURL, _ := partMap["file_url"].(string)
 	if fileURL != "" {
+		if !isRemoteFileScheme(fileURL) {
+			return nil, converterutil.NewRequestValidationError("input_file.file_url", "unsupported file URL scheme")
+		}
 		return []*genai.Part{{
 			FileData: &genai.FileData{
 				MIMEType: detectMIMEFromURL(fileURL),
@@ -107,25 +116,46 @@ func convertInputFilePart(partMap map[string]interface{}) ([]*genai.Part, error)
 // anyway once decoded.
 const maxInlineBase64Size = 100 * 1024 * 1024 // 100MB encoded
 
+// isRemoteFileScheme reports whether rawURL uses a scheme Vertex can actually
+// fetch as a FileData reference. Anything else — including a data: URL that
+// failed to parse as inline data above — must never be forwarded as a
+// FileURI: Vertex would receive it as a literal, potentially multi-megabyte
+// string instead of the image/file it names.
+func isRemoteFileScheme(rawURL string) bool {
+	return strings.HasPrefix(rawURL, "http://") ||
+		strings.HasPrefix(rawURL, "https://") ||
+		strings.HasPrefix(rawURL, "gs://")
+}
+
 // parseDataURLToPart decodes a data: URL into an InlineData Part.
 // Returns (nil, nil) if the string is not a data URL — callers fall back to
 // treating it as a regular URL. Returns a non-nil error only when the string
 // IS a data URL but is otherwise unusable (oversized or malformed base64).
+//
+// Splits on the first comma rather than requiring a literal ";base64," marker
+// right after the MIME type: real-world data URLs commonly carry extra
+// parameters first (e.g. "data:image/svg+xml;charset=utf-8;base64,...."),
+// which the stricter form used to misdetect as "not a data URL" and forward
+// to the caller's FileURI fallback (an mp3-sized string as a "URL").
 func parseDataURLToPart(dataURL string) (*genai.Part, error) {
 	if !strings.HasPrefix(dataURL, "data:") {
 		return nil, nil
 	}
-	rest := strings.TrimPrefix(dataURL, "data:")
-	semi := strings.Index(rest, ";")
-	if semi < 0 {
+	parts := strings.SplitN(dataURL, ",", 2) // SplitN to handle base64 with commas
+	if len(parts) != 2 {
 		return nil, nil
 	}
-	mimeType := rest[:semi]
-	after := rest[semi+1:]
-	if !strings.HasPrefix(after, "base64,") {
+	header := strings.TrimPrefix(parts[0], "data:")
+	encoded := parts[1]
+
+	mimeType := header
+	if semi := strings.Index(header, ";"); semi >= 0 {
+		mimeType = header[:semi]
+	}
+	if mimeType == "" {
 		return nil, nil
 	}
-	encoded := after[7:]
+
 	if len(encoded) > maxInlineBase64Size {
 		return nil, converterutil.NewRequestEntityTooLargeError("", fmt.Sprintf("inline data URL payload exceeds %dMB limit", maxInlineBase64Size/(1024*1024)))
 	}

--- a/internal/converter/vertex/responses/content.go
+++ b/internal/converter/vertex/responses/content.go
@@ -48,7 +48,11 @@ func convertInputImageParts(partMap map[string]interface{}) ([]*genai.Part, erro
 	}
 
 	// Try data: URL first (inline base64)
-	if part := parseDataURLToPart(imgURL); part != nil {
+	part, err := parseDataURLToPart(imgURL)
+	if err != nil {
+		return nil, err
+	}
+	if part != nil {
 		return []*genai.Part{part}, nil
 	}
 
@@ -97,29 +101,41 @@ func convertInputFilePart(partMap map[string]interface{}) ([]*genai.Part, error)
 	return nil, converterutil.NewRequestValidationError("input_file", "missing supported file source")
 }
 
+// maxInlineBase64Size caps the base64-encoded (not decoded) payload of an
+// inline data: URL. Above this, we reject the request with 413 instead of
+// silently dropping the media or forwarding a request Vertex would reject
+// anyway once decoded.
+const maxInlineBase64Size = 100 * 1024 * 1024 // 100MB encoded
+
 // parseDataURLToPart decodes a data: URL into an InlineData Part.
-// Returns nil if the string is not a data URL.
-func parseDataURLToPart(dataURL string) *genai.Part {
+// Returns (nil, nil) if the string is not a data URL — callers fall back to
+// treating it as a regular URL. Returns a non-nil error only when the string
+// IS a data URL but is otherwise unusable (oversized or malformed base64).
+func parseDataURLToPart(dataURL string) (*genai.Part, error) {
 	if !strings.HasPrefix(dataURL, "data:") {
-		return nil
+		return nil, nil
 	}
 	rest := strings.TrimPrefix(dataURL, "data:")
 	semi := strings.Index(rest, ";")
 	if semi < 0 {
-		return nil
+		return nil, nil
 	}
 	mimeType := rest[:semi]
 	after := rest[semi+1:]
 	if !strings.HasPrefix(after, "base64,") {
-		return nil
+		return nil, nil
 	}
-	decoded, err := base64.StdEncoding.DecodeString(after[7:])
+	encoded := after[7:]
+	if len(encoded) > maxInlineBase64Size {
+		return nil, converterutil.NewRequestEntityTooLargeError("", fmt.Sprintf("inline data URL payload exceeds %dMB limit", maxInlineBase64Size/(1024*1024)))
+	}
+	decoded, err := base64.StdEncoding.DecodeString(encoded)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 	return &genai.Part{
 		InlineData: &genai.Blob{MIMEType: mimeType, Data: decoded},
-	}
+	}, nil
 }
 
 // detectMIMEFromURL guesses a MIME type from common file extensions in a URL.

--- a/internal/converter/vertex/responses/content.go
+++ b/internal/converter/vertex/responses/content.go
@@ -122,7 +122,11 @@ func convertInputFilePart(partMap map[string]interface{}) ([]*genai.Part, error)
 // inline data: URL. Above this, we reject the request with 413 instead of
 // silently dropping the media or forwarding a request Vertex would reject
 // anyway once decoded.
-const maxInlineBase64Size = 100 * 1024 * 1024 // 100MB encoded
+//
+// A var, not a const: tests shrink it (see withMaxInlineBase64Size in
+// request_test.go) so boundary cases don't have to allocate and base64-decode
+// real ~100MB/~75MB strings just to exercise the ">" comparison.
+var maxInlineBase64Size = 100 * 1024 * 1024 // 100MB encoded
 
 // isAllowedFileURL reports whether rawURL is safe to forward to Vertex as a
 // FileData reference: an allowed scheme (http/https/gs — anything else,

--- a/internal/converter/vertex/responses/request_test.go
+++ b/internal/converter/vertex/responses/request_test.go
@@ -330,6 +330,36 @@ func TestContentPartToVertexParts_InputImage_UnsupportedSchemeRejected(t *testin
 	assert.Equal(t, "input_image.image_url", validationErr.Param)
 }
 
+func TestContentPartToVertexParts_InputAudio_OversizedReturns413(t *testing.T) {
+	oversized := strings.Repeat("A", maxInlineBase64Size+1)
+	part := map[string]interface{}{
+		"type":   "input_audio",
+		"data":   oversized,
+		"format": "wav",
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.Nil(t, parts)
+	require.Error(t, err)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, validationErr.StatusCode)
+}
+
+func TestContentPartToVertexParts_InputAudio_ValidDecodes(t *testing.T) {
+	raw := []byte("fake wav bytes")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	part := map[string]interface{}{
+		"type":   "input_audio",
+		"data":   encoded,
+		"format": "wav",
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].InlineData)
+	assert.Equal(t, raw, parts[0].InlineData.Data)
+}
+
 func TestContentPartToVertexParts_InputImage_PrivateURLRejected(t *testing.T) {
 	// http(s) is an allowed scheme, but a private/internal address must still
 	// be blocked (SSRF) — matching the chat-completions path's parseURLToPart.

--- a/internal/converter/vertex/responses/request_test.go
+++ b/internal/converter/vertex/responses/request_test.go
@@ -330,6 +330,21 @@ func TestContentPartToVertexParts_InputImage_UnsupportedSchemeRejected(t *testin
 	assert.Equal(t, "input_image.image_url", validationErr.Param)
 }
 
+func TestContentPartToVertexParts_InputImage_PrivateURLRejected(t *testing.T) {
+	// http(s) is an allowed scheme, but a private/internal address must still
+	// be blocked (SSRF) — matching the chat-completions path's parseURLToPart.
+	part := map[string]interface{}{
+		"type":      "input_image",
+		"image_url": "http://169.254.169.254/latest/meta-data/",
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.Error(t, err)
+	assert.Nil(t, parts)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "input_image.image_url", validationErr.Param)
+}
+
 func TestContentPartToVertexParts_InputFile_UnsupportedSchemeRejected(t *testing.T) {
 	part := map[string]interface{}{
 		"type":     "input_file",

--- a/internal/converter/vertex/responses/request_test.go
+++ b/internal/converter/vertex/responses/request_test.go
@@ -282,7 +282,8 @@ func TestContentPartToVertexParts_InputImage_DataURL(t *testing.T) {
 }
 
 func TestContentPartToVertexParts_InputImage_DataURLOversized(t *testing.T) {
-	oversized := strings.Repeat("A", maxInlineBase64Size+1)
+	withMaxInlineBase64Size(t, 16)
+	oversized := strings.Repeat("A", 17)
 	part := map[string]interface{}{
 		"type":      "input_image",
 		"image_url": "data:image/png;base64," + oversized,
@@ -331,7 +332,8 @@ func TestContentPartToVertexParts_InputImage_UnsupportedSchemeRejected(t *testin
 }
 
 func TestContentPartToVertexParts_InputAudio_OversizedReturns413(t *testing.T) {
-	oversized := strings.Repeat("A", maxInlineBase64Size+1)
+	withMaxInlineBase64Size(t, 16)
+	oversized := strings.Repeat("A", 17)
 	part := map[string]interface{}{
 		"type":   "input_audio",
 		"data":   oversized,
@@ -524,4 +526,16 @@ func TestVertexSchemaConversion(t *testing.T) {
 	require.NotNil(t, schema)
 	assert.Equal(t, genai.TypeObject, schema.Type)
 	assert.Contains(t, schema.Properties, "city")
+}
+
+// withMaxInlineBase64Size temporarily shrinks the package-level
+// maxInlineBase64Size for the duration of the calling test, restoring it on
+// cleanup. Lets boundary tests exercise the ">" comparison without allocating
+// and base64-decoding a real ~100MB/~75MB string. Not safe under
+// t.Parallel() — this package's tests don't use it.
+func withMaxInlineBase64Size(t *testing.T, n int) {
+	t.Helper()
+	orig := maxInlineBase64Size
+	maxInlineBase64Size = n
+	t.Cleanup(func() { maxInlineBase64Size = orig })
 }

--- a/internal/converter/vertex/responses/request_test.go
+++ b/internal/converter/vertex/responses/request_test.go
@@ -1,6 +1,7 @@
 package vertexresponses
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -292,6 +293,54 @@ func TestContentPartToVertexParts_InputImage_DataURLOversized(t *testing.T) {
 	var validationErr *converterutil.RequestValidationError
 	require.ErrorAs(t, err, &validationErr)
 	assert.Equal(t, http.StatusRequestEntityTooLarge, validationErr.StatusCode)
+}
+
+func TestContentPartToVertexParts_InputImage_DataURLWithExtraParams(t *testing.T) {
+	// A data: URL carrying an extra parameter before ";base64," (e.g. charset,
+	// as browsers commonly emit for SVGs) must still decode as inline data —
+	// not fall through and leak the whole data: URL into FileURI (see the
+	// "unsupported scheme" test below for what used to happen instead).
+	raw := []byte("<svg></svg>")
+	encoded := base64.StdEncoding.EncodeToString(raw)
+	part := map[string]interface{}{
+		"type":      "input_image",
+		"image_url": "data:image/svg+xml;charset=utf-8;base64," + encoded,
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.NoError(t, err)
+	require.Len(t, parts, 1)
+	require.NotNil(t, parts[0].InlineData)
+	assert.Equal(t, "image/svg+xml", parts[0].InlineData.MIMEType)
+	assert.Equal(t, raw, parts[0].InlineData.Data)
+}
+
+func TestContentPartToVertexParts_InputImage_UnsupportedSchemeRejected(t *testing.T) {
+	// A data: URL that fails to parse (e.g. non-base64 payload) must be
+	// rejected outright, not forwarded to Vertex as a literal FileURI
+	// containing the entire (potentially multi-megabyte) string.
+	part := map[string]interface{}{
+		"type":      "input_image",
+		"image_url": "data:image/png,not-valid-base64!!!",
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.Error(t, err)
+	assert.Nil(t, parts)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "input_image.image_url", validationErr.Param)
+}
+
+func TestContentPartToVertexParts_InputFile_UnsupportedSchemeRejected(t *testing.T) {
+	part := map[string]interface{}{
+		"type":     "input_file",
+		"file_url": "ftp://example.com/doc.pdf",
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.Error(t, err)
+	assert.Nil(t, parts)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "input_file.file_url", validationErr.Param)
 }
 
 func TestContentPartToVertexParts_InputImage_URL(t *testing.T) {

--- a/internal/converter/vertex/responses/request_test.go
+++ b/internal/converter/vertex/responses/request_test.go
@@ -3,6 +3,8 @@ package vertexresponses
 import (
 	"encoding/json"
 	"errors"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
@@ -276,6 +278,20 @@ func TestContentPartToVertexParts_InputImage_DataURL(t *testing.T) {
 	require.Len(t, parts, 1)
 	require.NotNil(t, parts[0].InlineData)
 	assert.Equal(t, "image/png", parts[0].InlineData.MIMEType)
+}
+
+func TestContentPartToVertexParts_InputImage_DataURLOversized(t *testing.T) {
+	oversized := strings.Repeat("A", maxInlineBase64Size+1)
+	part := map[string]interface{}{
+		"type":      "input_image",
+		"image_url": "data:image/png;base64," + oversized,
+	}
+	parts, err := contentPartToVertexParts(part)
+	require.Nil(t, parts)
+	require.Error(t, err)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, http.StatusRequestEntityTooLarge, validationErr.StatusCode)
 }
 
 func TestContentPartToVertexParts_InputImage_URL(t *testing.T) {

--- a/internal/converter/vertex/utils.go
+++ b/internal/converter/vertex/utils.go
@@ -18,7 +18,11 @@ import (
 // silently dropping the media or (the previous behaviour) falling through to
 // parseURLToPart, which would treat the same giant base64 string as if it
 // were a plain http(s) URL and forward a malformed request to Vertex.
-const maxBase64Size = 100 * 1024 * 1024 // 100MB encoded
+//
+// A var, not a const: tests shrink it (see withMaxBase64Size in
+// utils_test.go) so boundary cases don't have to allocate and base64-decode
+// real ~100MB/~75MB strings just to exercise the ">" comparison.
+var maxBase64Size = 100 * 1024 * 1024 // 100MB encoded
 
 // ClampInt32 narrows a caller-supplied integer to int32, saturating instead of
 // wrapping on out-of-range values. The genai SDK takes int32 for token counts,

--- a/internal/converter/vertex/utils.go
+++ b/internal/converter/vertex/utils.go
@@ -3,15 +3,22 @@ package vertex
 import (
 	"context"
 	"encoding/base64"
+	"fmt"
 	"math"
 	"net"
 	"net/url"
 	"strings"
 
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"google.golang.org/genai"
 )
 
-const maxBase64Size = 20 * 1024 * 1024 // 20MB encoded ≈ 15MB decoded
+// maxBase64Size caps the base64-encoded (not decoded) payload of an inline
+// data: URL. Above this, the request is rejected with 413 instead of either
+// silently dropping the media or (the previous behaviour) falling through to
+// parseURLToPart, which would treat the same giant base64 string as if it
+// were a plain http(s) URL and forward a malformed request to Vertex.
+const maxBase64Size = 100 * 1024 * 1024 // 100MB encoded
 
 // ClampInt32 narrows a caller-supplied integer to int32, saturating instead of
 // wrapping on out-of-range values. The genai SDK takes int32 for token counts,
@@ -29,15 +36,18 @@ func ClampInt32[T int | int64](v T) int32 {
 
 // parseDataURLToPart converts a data URL string to a genai.Part with inline data
 // Handles formats like: data:image/jpeg;base64,/9j/4AAQ...
-func parseDataURLToPart(dataURL string) *genai.Part {
+// Returns (nil, nil) if dataURL is not a data: URL at all — callers fall back
+// to treating it as a regular URL. Returns a non-nil error only when the
+// string IS a data URL but is otherwise unusable (oversized payload).
+func parseDataURLToPart(dataURL string) (*genai.Part, error) {
 	if !strings.HasPrefix(dataURL, "data:") {
-		return nil
+		return nil, nil
 	}
 
 	// Split: data:image/jpeg;base64,<data>
 	parts := strings.SplitN(dataURL, ",", 2) // SplitN to handle base64 with commas
 	if len(parts) != 2 {
-		return nil
+		return nil, nil
 	}
 
 	header := parts[0]  // data:image/jpeg;base64
@@ -46,18 +56,18 @@ func parseDataURLToPart(dataURL string) *genai.Part {
 	// Extract mime type from header
 	mimeType := extractMimeType(header)
 	if mimeType == "" {
-		return nil
+		return nil, nil
 	}
 
 	// check base64 payload size before decoding
 	if len(b64Data) > maxBase64Size {
-		return nil
+		return nil, converterutil.NewRequestEntityTooLargeError("", fmt.Sprintf("inline data URL payload exceeds %dMB limit", maxBase64Size/(1024*1024)))
 	}
 
 	// Decode base64 data to binary
 	decodedData, err := base64.StdEncoding.DecodeString(b64Data)
 	if err != nil {
-		return nil
+		return nil, nil
 	}
 
 	return &genai.Part{
@@ -65,7 +75,7 @@ func parseDataURLToPart(dataURL string) *genai.Part {
 			MIMEType: mimeType,
 			Data:     decodedData,
 		},
-	}
+	}, nil
 }
 
 // extractMimeType extracts MIME type from data URL header

--- a/internal/converter/vertex/utils.go
+++ b/internal/converter/vertex/utils.go
@@ -116,7 +116,9 @@ var mimeTypeMap = map[string]string{
 	"txt":  "text/plain",
 }
 
-// isPrivateURL checks if a URL points to a private/internal network address.
+// IsPrivateURL checks if a URL points to a private/internal network address.
+// Exported so the Responses API converter package (vertexresponses) can apply
+// the same SSRF guard to its own FileData URL fallback.
 //
 // When the hostname is not a literal IP, it is resolved once via net.LookupIP
 // and the result is checked against private ranges.  This is vulnerable to DNS
@@ -126,7 +128,7 @@ var mimeTypeMap = map[string]string{
 // may apply its own protections, and (b) exploitation requires the attacker to
 // control DNS with a very short TTL.  Do not rely on this function as the sole
 // SSRF defence in higher-trust environments.
-func isPrivateURL(rawURL string) bool {
+func IsPrivateURL(rawURL string) bool {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return true // block unparseable URLs
@@ -194,7 +196,7 @@ func parseURLToPart(rawURL string, fileObj map[string]interface{}) *genai.Part {
 	}
 
 	//  block private/internal network URLs
-	if (strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://")) && isPrivateURL(rawURL) {
+	if (strings.HasPrefix(rawURL, "http://") || strings.HasPrefix(rawURL, "https://")) && IsPrivateURL(rawURL) {
 		return nil
 	}
 

--- a/internal/converter/vertex/utils_test.go
+++ b/internal/converter/vertex/utils_test.go
@@ -2,8 +2,12 @@ package vertex
 
 import (
 	"encoding/base64"
+	"errors"
+	"net/http"
+	"strings"
 	"testing"
 
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -78,7 +82,8 @@ func TestParseDataURLToPart(t *testing.T) {
 		encoded := base64.StdEncoding.EncodeToString(rawData)
 		dataURL := "data:image/jpeg;base64," + encoded
 
-		part := parseDataURLToPart(dataURL)
+		part, err := parseDataURLToPart(dataURL)
+		require.NoError(t, err)
 		require.NotNil(t, part)
 		require.NotNil(t, part.InlineData)
 		assert.Equal(t, "image/jpeg", part.InlineData.MIMEType)
@@ -86,32 +91,58 @@ func TestParseDataURLToPart(t *testing.T) {
 	})
 
 	t.Run("not_data_url", func(t *testing.T) {
-		result := parseDataURLToPart("https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1280px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg")
+		result, err := parseDataURLToPart("https://upload.wikimedia.org/wikipedia/commons/thumb/e/ea/Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg/1280px-Van_Gogh_-_Starry_Night_-_Google_Art_Project.jpg")
+		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("invalid_base64", func(t *testing.T) {
-		result := parseDataURLToPart("data:image/jpeg;base64,!!!invalid!!!")
+		result, err := parseDataURLToPart("data:image/jpeg;base64,!!!invalid!!!")
+		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("no_comma", func(t *testing.T) {
-		result := parseDataURLToPart("data:image/jpeg;base64")
+		result, err := parseDataURLToPart("data:image/jpeg;base64")
+		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("multiple_commas", func(t *testing.T) {
 		// With Split (not SplitN), "data:image/jpeg;base64,abc,def" splits to 3 parts
-		result := parseDataURLToPart("data:image/jpeg;base64,abc,def")
+		result, err := parseDataURLToPart("data:image/jpeg;base64,abc,def")
+		require.NoError(t, err)
 		assert.Nil(t, result)
 	})
 
 	t.Run("empty_mime_type_returns_semicolon_prefix", func(t *testing.T) {
 		// "data:;base64" → extractMimeType returns ";base64" (end==0 falls through)
 		// so parseDataURLToPart still produces a part with that as MIMEType
-		result := parseDataURLToPart("data:;base64," + base64.StdEncoding.EncodeToString([]byte("test")))
+		result, err := parseDataURLToPart("data:;base64," + base64.StdEncoding.EncodeToString([]byte("test")))
+		require.NoError(t, err)
 		require.NotNil(t, result)
 		assert.Equal(t, ";base64", result.InlineData.MIMEType)
+	})
+
+	t.Run("oversized_payload_returns_413_error", func(t *testing.T) {
+		// One byte over the limit is enough; no need to allocate a real 100MB+ string twice over.
+		oversized := strings.Repeat("A", maxBase64Size+1)
+		result, err := parseDataURLToPart("data:image/jpeg;base64," + oversized)
+		require.Nil(t, result)
+		require.Error(t, err)
+		var validationErr *converterutil.RequestValidationError
+		require.ErrorAs(t, err, &validationErr)
+		assert.Equal(t, http.StatusRequestEntityTooLarge, validationErr.StatusCode)
+	})
+
+	t.Run("payload_at_limit_is_accepted", func(t *testing.T) {
+		atLimit := strings.Repeat("A", maxBase64Size)
+		_, err := parseDataURLToPart("data:image/jpeg;base64," + atLimit)
+		// "A" repeated isn't valid base64 padding at this length necessarily; we only
+		// care that the size gate itself doesn't reject it — a decode error (if any)
+		// surfaces as (nil, nil), never as the 413 error.
+		var validationErr *converterutil.RequestValidationError
+		assert.False(t, errors.As(err, &validationErr), "size check must not trigger exactly at the limit")
 	})
 }
 

--- a/internal/converter/vertex/utils_test.go
+++ b/internal/converter/vertex/utils_test.go
@@ -125,8 +125,8 @@ func TestParseDataURLToPart(t *testing.T) {
 	})
 
 	t.Run("oversized_payload_returns_413_error", func(t *testing.T) {
-		// One byte over the limit is enough; no need to allocate a real 100MB+ string twice over.
-		oversized := strings.Repeat("A", maxBase64Size+1)
+		withMaxBase64Size(t, 16)
+		oversized := strings.Repeat("A", 17) // one byte over the (test-shrunk) limit
 		result, err := parseDataURLToPart("data:image/jpeg;base64," + oversized)
 		require.Nil(t, result)
 		require.Error(t, err)
@@ -136,7 +136,8 @@ func TestParseDataURLToPart(t *testing.T) {
 	})
 
 	t.Run("payload_at_limit_is_accepted", func(t *testing.T) {
-		atLimit := strings.Repeat("A", maxBase64Size)
+		withMaxBase64Size(t, 16)
+		atLimit := strings.Repeat("A", 16)
 		_, err := parseDataURLToPart("data:image/jpeg;base64," + atLimit)
 		// "A" repeated isn't valid base64 padding at this length necessarily; we only
 		// care that the size gate itself doesn't reject it — a decode error (if any)
@@ -144,6 +145,18 @@ func TestParseDataURLToPart(t *testing.T) {
 		var validationErr *converterutil.RequestValidationError
 		assert.False(t, errors.As(err, &validationErr), "size check must not trigger exactly at the limit")
 	})
+}
+
+// withMaxBase64Size temporarily shrinks the package-level maxBase64Size for
+// the duration of the calling test, restoring it on cleanup. Lets boundary
+// tests exercise the ">" comparison without allocating and base64-decoding a
+// real ~100MB/~75MB string. Not safe under t.Parallel() — this package's
+// tests don't use it.
+func withMaxBase64Size(t *testing.T, n int) {
+	t.Helper()
+	orig := maxBase64Size
+	maxBase64Size = n
+	t.Cleanup(func() { maxBase64Size = orig })
 }
 
 func TestParseURLToPart(t *testing.T) {

--- a/internal/converter/vertex/utils_test.go
+++ b/internal/converter/vertex/utils_test.go
@@ -222,15 +222,15 @@ func TestParseURLToPart_PublicIP(t *testing.T) {
 }
 
 func TestIsPrivateURL(t *testing.T) {
-	assert.True(t, isPrivateURL("http://127.0.0.1/"))
-	assert.True(t, isPrivateURL("http://10.0.0.1/"))
-	assert.True(t, isPrivateURL("http://192.168.1.1/"))
-	assert.True(t, isPrivateURL("http://172.16.0.1/"))
-	assert.True(t, isPrivateURL("http://169.254.169.254/"))
-	assert.True(t, isPrivateURL("http://localhost/"))
-	assert.True(t, isPrivateURL("http://metadata.google.internal/"))
-	assert.False(t, isPrivateURL("http://93.184.216.34/"))
-	assert.False(t, isPrivateURL("https://8.8.8.8/"))
+	assert.True(t, IsPrivateURL("http://127.0.0.1/"))
+	assert.True(t, IsPrivateURL("http://10.0.0.1/"))
+	assert.True(t, IsPrivateURL("http://192.168.1.1/"))
+	assert.True(t, IsPrivateURL("http://172.16.0.1/"))
+	assert.True(t, IsPrivateURL("http://169.254.169.254/"))
+	assert.True(t, IsPrivateURL("http://localhost/"))
+	assert.True(t, IsPrivateURL("http://metadata.google.internal/"))
+	assert.False(t, IsPrivateURL("http://93.184.216.34/"))
+	assert.False(t, IsPrivateURL("https://8.8.8.8/"))
 	// Note: url.Parse is very lenient — "not-a-valid-url" parses with empty host,
 	// which resolves to false (not private). This is acceptable since parseURLToPart
 	// rejects non-http/https/gs URLs before calling isPrivateURL.

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -375,13 +375,13 @@ func statusForValidationError(e *converterutil.RequestValidationError) int {
 
 // writeValidationError writes the client-facing response for a converter
 // RequestValidationError, honoring its StatusCode when set instead of always
-// answering 400.
+// answering 400. Generic over the status rather than special-casing 413:
+// statusForValidationError is also what callers log as error_code/HTTPStatus,
+// so any future non-413 StatusCode must reach the client as the same status
+// it was logged under, not silently collapse to 400.
 func writeValidationError(w http.ResponseWriter, e *converterutil.RequestValidationError, message string) {
-	if statusForValidationError(e) == http.StatusRequestEntityTooLarge {
-		WriteErrorTooLarge(w, message)
-		return
-	}
-	WriteErrorBadRequest(w, message)
+	status := statusForValidationError(e)
+	WriteJSONError(w, status, message, errorTypeForStatus(status), nil, nil)
 }
 
 // WriteErrorRateLimit writes a 429 Too Many Requests JSON error.

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/requestid"
 )
 
@@ -358,6 +359,29 @@ func WriteErrorNotFound(w http.ResponseWriter, message string) {
 // WriteErrorTooLarge writes a 413 Request Entity Too Large JSON error.
 func WriteErrorTooLarge(w http.ResponseWriter, message string) {
 	WriteJSONError(w, http.StatusRequestEntityTooLarge, message, errorTypeForStatus(http.StatusRequestEntityTooLarge), nil, nil)
+}
+
+// statusForValidationError returns the HTTP status a converter-reported
+// RequestValidationError should be surfaced as. Most validation errors don't
+// specify one (StatusCode == 0) and default to 400, as they always have; a
+// few (e.g. an inline base64 payload too large to forward) carry their own,
+// more specific status.
+func statusForValidationError(e *converterutil.RequestValidationError) int {
+	if e.StatusCode != 0 {
+		return e.StatusCode
+	}
+	return http.StatusBadRequest
+}
+
+// writeValidationError writes the client-facing response for a converter
+// RequestValidationError, honoring its StatusCode when set instead of always
+// answering 400.
+func writeValidationError(w http.ResponseWriter, e *converterutil.RequestValidationError, message string) {
+	if statusForValidationError(e) == http.StatusRequestEntityTooLarge {
+		WriteErrorTooLarge(w, message)
+		return
+	}
+	WriteErrorBadRequest(w, message)
 }
 
 // WriteErrorRateLimit writes a 429 Too Many Requests JSON error.

--- a/internal/proxy/errors_test.go
+++ b/internal/proxy/errors_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/requestid"
 	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
 	"github.com/stretchr/testify/assert"
@@ -190,6 +191,52 @@ func TestMaskedUpstreamErrorBodyKeepsGenericNonBadRequest(t *testing.T) {
 	if resp.Error.Code == nil || *resp.Error.Code != "api_error" {
 		t.Fatalf("code = %v", resp.Error.Code)
 	}
+}
+
+// TestWriteValidationError_HonorsArbitraryStatusCode guards against
+// writeValidationError silently collapsing a future non-413 StatusCode (e.g.
+// 415) to 400 while statusForValidationError — what callers log as
+// error_code/HTTPStatus — reports the real value. The client-facing status
+// must match what got logged, for any StatusCode, not just 0/413.
+func TestWriteValidationError_HonorsArbitraryStatusCode(t *testing.T) {
+	e := &converterutil.RequestValidationError{
+		Param:      "content_type",
+		Message:    "unsupported media type",
+		StatusCode: http.StatusUnsupportedMediaType,
+	}
+	require.Equal(t, http.StatusUnsupportedMediaType, statusForValidationError(e),
+		"sanity check: this is what orchestrator/proxy log as error_code/HTTPStatus")
+
+	w := httptest.NewRecorder()
+	writeValidationError(w, e, e.Message)
+
+	assert.Equal(t, http.StatusUnsupportedMediaType, w.Code,
+		"client-facing status must match statusForValidationError, not silently fall back to 400")
+
+	var resp APIErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "unsupported media type", resp.Error.Message)
+}
+
+func TestWriteValidationError_DefaultsToBadRequest(t *testing.T) {
+	e := &converterutil.RequestValidationError{Param: "model", Message: "missing model"}
+
+	w := httptest.NewRecorder()
+	writeValidationError(w, e, e.Message)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestWriteValidationError_TooLarge(t *testing.T) {
+	e := &converterutil.RequestValidationError{
+		Message:    "payload too large",
+		StatusCode: http.StatusRequestEntityTooLarge,
+	}
+
+	w := httptest.NewRecorder()
+	writeValidationError(w, e, e.Message)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 }
 
 func stringPtr(s string) *string {

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -228,6 +228,11 @@ func (p *Proxy) orchestrateRequest(
 	)
 	if prepErr != nil {
 		var validationErr *converterutil.RequestValidationError
+		isValidationErr := errors.As(prepErr, &validationErr)
+		status := http.StatusBadRequest
+		if isValidationErr {
+			status = statusForValidationError(validationErr)
+		}
 		apiName := "request"
 		if isResponsesAPI {
 			apiName = "Responses API request"
@@ -235,15 +240,15 @@ func (p *Proxy) orchestrateRequest(
 			apiName = "Messages API request"
 		}
 		p.logger.ErrorContext(r.Context(), "Failed to prepare request for credential",
-			"error_code", http.StatusBadRequest,
+			"error_code", status,
 			"credential", cred.Name, "provider", string(cred.Type),
 			"model", modelID, "error", prepErr,
 			"request_id", logCtx.RequestID)
 		logCtx.Status = "failure"
-		logCtx.HTTPStatus = http.StatusBadRequest
+		logCtx.HTTPStatus = status
 		logCtx.ErrorMsg = "Failed to convert " + apiName + ": " + prepErr.Error()
-		if errors.As(prepErr, &validationErr) {
-			WriteErrorBadRequest(w, prepErr.Error())
+		if isValidationErr {
+			writeValidationError(w, validationErr, prepErr.Error())
 		} else {
 			WriteErrorBadRequest(w, "Failed to convert "+apiName)
 		}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1561,16 +1561,17 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			if convErr != nil {
 				var validationErr *converterutil.RequestValidationError
 				if errors.As(convErr, &validationErr) {
+					status := statusForValidationError(validationErr)
 					p.logger.WarnContext(r.Context(), "Invalid Responses API request for provider format",
-						"error_code", http.StatusBadRequest,
+						"error_code", status,
 						"credential", cred.Name, "provider", string(cred.Type),
 						"model", modelID, "error", convErr,
 						"request_id", logCtx.RequestID)
 					logCtx.Status = "failure"
-					logCtx.HTTPStatus = http.StatusBadRequest
+					logCtx.HTTPStatus = status
 					logCtx.ErrorMsg = convErr.Error()
 					logCtx.TargetURL = cred.BaseURL
-					WriteErrorBadRequest(w, convErr.Error())
+					writeValidationError(w, validationErr, convErr.Error())
 					return
 				}
 				p.logger.ErrorContext(r.Context(), "Failed to convert Responses API request to provider format",
@@ -1605,16 +1606,17 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			if convErr != nil {
 				var validationErr *converterutil.RequestValidationError
 				if errors.As(convErr, &validationErr) {
+					status := statusForValidationError(validationErr)
 					p.logger.WarnContext(r.Context(), "Invalid request for provider format",
-						"error_code", http.StatusBadRequest,
+						"error_code", status,
 						"credential", cred.Name, "provider", string(cred.Type),
 						"model", modelID, "error", convErr,
 						"request_id", logCtx.RequestID)
 					logCtx.Status = "failure"
-					logCtx.HTTPStatus = http.StatusBadRequest
+					logCtx.HTTPStatus = status
 					logCtx.ErrorMsg = convErr.Error()
 					logCtx.TargetURL = cred.BaseURL
-					WriteErrorBadRequest(w, convErr.Error())
+					writeValidationError(w, validationErr, convErr.Error())
 					return
 				}
 				// Fatal: conversion error won't be fixed by another credential


### PR DESCRIPTION
## Summary
- On Vertex/Gemini, an inline base64 image over the size limit used to make `parseDataURLToPart` return `nil`, which the caller treated as "not a data URL" and fell through to `parseURLToPart`, sending the same giant base64 string to the provider as if it were a plain HTTP URL — silently, with no logging.
- Both independent Vertex converter implementations (`internal/converter/vertex/utils.go` for chat, `internal/converter/vertex/responses/content.go` for the Responses API) now return a proper `413 Request Entity Too Large` when an inline image payload exceeds 100MB, instead of falling through.
- `converterutil.RequestValidationError` gained an optional `StatusCode` field (default 0 → existing 400 behavior unchanged) and a `NewRequestEntityTooLargeError` constructor; `internal/proxy/errors.go`/`proxy.go`/`orchestrator.go` now honor it at all three call sites that surface a `RequestValidationError` to the client.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] New/updated unit tests: `internal/converter/vertex/utils_test.go` (oversized payload → 413, payload at limit accepted), `internal/converter/vertex/responses/request_test.go` (same for Responses API path)