### PR TITLE
fix: normalize Responses API "developer" role to "system" for Chat Completions conversion

### DIFF
--- a/internal/converter/responses/request.go
+++ b/internal/converter/responses/request.go
@@ -920,8 +920,17 @@ func convertInputValue(input interface{}) ([]interface{}, error) {
 // Responses-API-only fields (type, phase, status) are intentionally dropped here because
 // Chat Completions providers reject unknown parameters on message objects.
 func convertMessage(item map[string]interface{}) (map[string]interface{}, error) {
+	role := item["role"]
+	if role == "developer" {
+		// "developer" is the Responses API's rename of "system" (also emitted by the
+		// official OpenAI SDK). Most Chat Completions providers reached through this
+		// generic converter (e.g. DeepSeek and other OpenAI-compatible backends) only
+		// recognize the classic role set and reject "developer" outright, so downgrade
+		// it to the universally-supported "system" — the two are semantically identical.
+		role = "system"
+	}
 	msg := map[string]interface{}{
-		"role": item["role"],
+		"role": role,
 	}
 
 	content := item["content"]
@@ -1051,7 +1060,8 @@ func convertInstructions(instructions interface{}) ([]interface{}, error) {
 		}
 		return []interface{}{
 			map[string]interface{}{
-				"role":    "developer",
+				// "system", not "developer": see convertMessage for why.
+				"role":    "system",
 				"content": s,
 			},
 		}, nil

--- a/internal/converter/responses/request_test.go
+++ b/internal/converter/responses/request_test.go
@@ -133,8 +133,10 @@ func TestRequestToChat_Instructions(t *testing.T) {
 	messages := parsed["messages"].([]interface{})
 	assert.Len(t, messages, 2)
 
-	// First message should be developer
-	assert.Equal(t, "developer", messages[0].(map[string]interface{})["role"])
+	// First message is "system", not "developer": most Chat Completions
+	// providers reached through this converter (DeepSeek, etc.) only
+	// recognize the classic role set and reject "developer" outright.
+	assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
 	assert.Equal(t, "You are a pirate.", messages[0].(map[string]interface{})["content"])
 
 	// Second should be user
@@ -142,6 +144,28 @@ func TestRequestToChat_Instructions(t *testing.T) {
 
 	// instructions should be removed
 	assert.NotContains(t, parsed, "instructions")
+}
+
+func TestRequestToChat_DeveloperRoleNormalizedToSystem(t *testing.T) {
+	body := `{
+		"model": "deepseek-v4-flash",
+		"input": [
+			{"role": "developer", "content": "You are a pirate."},
+			{"role": "user", "content": "Hello"}
+		]
+	}`
+	result, err := RequestToChat([]byte(body))
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	messages := parsed["messages"].([]interface{})
+	require.Len(t, messages, 2)
+
+	assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
+	assert.Equal(t, "You are a pirate.", messages[0].(map[string]interface{})["content"])
+	assert.Equal(t, "user", messages[1].(map[string]interface{})["role"])
 }
 
 func TestRequestToChat_InstructionsArray(t *testing.T) {


### PR DESCRIPTION
## Summary
- Clients using the Responses API's `instructions` field, or explicitly sending a `role: "developer"` item in `input` (the role the official OpenAI SDK uses for system prompts), get "developer" forwarded verbatim by the generic Responses→Chat Completions converter (`internal/converter/responses/request.go`) whenever the target provider doesn't have a native Responses converter and isn't in passthrough mode.
- `"developer"` is OpenAI's own rename of `"system"`, introduced for its reasoning models. Most third-party OpenAI-compatible Chat Completions backends reached through this generic path (DeepSeek and others) only recognize the classic role set and reject `"developer"` outright — every such request fails, independent of prompt size. Confirmed with a live 50/50 vs 0/50 (and 15/15 vs 0/15) comparison on two DeepSeek models, byte-identical bodies apart from the role string; DeepSeek's own official API accepts both.
- `convertInstructions` (the `instructions` field, most common path — this is what the official SDK effectively triggers) now emits `"system"` instead of hardcoding `"developer"`.
- `convertMessage` (explicit `role: "developer"` items in `input`) now downgrades to `"system"` too.
- Scope: only affects the generic conversion path used for providers without a native Responses API converter (Anthropic/Vertex/Bedrock have their own dedicated converters and are untouched); real OpenAI credentials go through native/passthrough handling and never hit this code.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] Updated `TestRequestToChat_Instructions` to assert `"system"` instead of `"developer"`
- [x] Added `TestRequestToChat_DeveloperRoleNormalizedToSystem` covering the explicit `input` item case