### PR TITLE
fix: Retry-After on real 429 relayed after fallback chain exhausts

### DIFF
--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"time"
 
 	"github.com/mixaill76/auto_ai_router/internal/balancer"
 	"github.com/mixaill76/auto_ai_router/internal/config"
@@ -891,13 +890,7 @@ func (p *Proxy) selectCredentialForModel(
 		)
 	}
 	logCtx.Logged = true
-	if remaining, ok := p.balancer.MinRemainingBanForModel(modelID, exclude, logCtx.Scope); ok {
-		seconds := int(remaining / time.Second)
-		if remaining%time.Second != 0 {
-			seconds++
-		}
-		w.Header().Set("Retry-After", fmt.Sprintf("%d", seconds))
-	}
+	p.setRetryAfterFromBan(w, modelID, exclude, logCtx.Scope)
 	WriteErrorRateLimit(w, errorMsg)
 	return nil, false
 }

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -80,6 +80,21 @@ func isRetryableContent(respBody []byte) bool {
 	return true
 }
 
+// setRetryAfterFromBan sets the Retry-After header to the shortest remaining
+// fail2ban ban among modelID's eligible credentials, rounded up to whole
+// seconds. No-op if none of them are currently banned.
+func (p *Proxy) setRetryAfterFromBan(w http.ResponseWriter, modelID string, exclude map[string]bool, visibility scope.Context) {
+	remaining, ok := p.balancer.MinRemainingBanForModel(modelID, exclude, visibility)
+	if !ok {
+		return
+	}
+	seconds := int(remaining / time.Second)
+	if remaining%time.Second != 0 {
+		seconds++
+	}
+	w.Header().Set("Retry-After", fmt.Sprintf("%d", seconds))
+}
+
 // GetTried gets the set of tried credentials from context.
 // Returns an empty map if not found (new request without context).
 func GetTried(ctx context.Context) map[string]bool {
@@ -281,6 +296,19 @@ func (p *Proxy) writeFallbackResponse(
 	// Computed once: both branches below need the same audio-usage-contract
 	// derived from the fallback upstream's response, regardless of streaming.
 	usageOptions := tokenUsageExtractionOptionsForResponse(fallbackCred, proxyResp.Headers)
+
+	// The fallback chain is exhausted and this 429 is a real upstream response
+	// being relayed as-is — unlike the self-generated "no credentials available"
+	// 429 in selectCredentialForModel, nothing here has computed a Retry-After
+	// hint yet. Add one from the shortest active ban, but only if the upstream
+	// didn't already send its own (never override a provider's own guidance).
+	if proxyResp.StatusCode == http.StatusTooManyRequests && proxyResp.Headers.Get("Retry-After") == "" {
+		visibility := scope.PublicContext()
+		if logCtx != nil {
+			visibility = logCtx.Scope
+		}
+		p.setRetryAfterFromBan(w, modelID, nil, visibility)
+	}
 
 	if proxyResp.IsStreaming {
 		p.setCredentialResponseHeader(w, logCtx, "")

--- a/internal/proxy/retry_test.go
+++ b/internal/proxy/retry_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -327,6 +328,79 @@ func TestTryFallbackProxy_Success(t *testing.T) {
 	require.NoError(t, err, "Failed to unmarshal response")
 	assert.Equal(t, "chatcmpl-test-fallback", respData["id"])
 	assert.Equal(t, "gpt-4", respData["model"])
+}
+
+// TestTryFallbackProxy_ExhaustedSetsRetryAfterFromBan verifies that a real
+// upstream 429 relayed after the fallback chain is exhausted still carries a
+// Retry-After hint derived from the shortest active ban, not just the
+// self-generated "no credentials available" 429 in selectCredentialForModel.
+func TestTryFallbackProxy_ExhaustedSetsRetryAfterFromBan(t *testing.T) {
+	fallbackServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer fallbackServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithPrimaryAndFallback("http://primary.local", fallbackServer.URL).
+		Build()
+
+	// The original credential is banned by the time the fallback chain
+	// exhausts; MinRemainingBanForModel should still find it (exclude=nil).
+	prx.balancer.BanUntil("primary", "gpt-4", http.StatusTooManyRequests, time.Now().Add(3*time.Second), "test-ban")
+
+	bodyBytes := []byte(`{"model":"gpt-4","messages":[]}`)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(string(bodyBytes)))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	success, _ := prx.TryFallbackProxy(
+		w, req, "gpt-4", "primary", http.StatusTooManyRequests, RetryReasonRateLimit,
+		bodyBytes, time.Now().UTC(), nil,
+	)
+
+	assert.True(t, success)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	retryAfter := w.Header().Get("Retry-After")
+	require.NotEmpty(t, retryAfter, "expected Retry-After derived from the active ban on the exhausted fallback response")
+	seconds, err := strconv.Atoi(retryAfter)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, seconds, 1)
+	assert.LessOrEqual(t, seconds, 3)
+}
+
+// TestTryFallbackProxy_ExhaustedPreservesUpstreamRetryAfter verifies that a
+// Retry-After the upstream itself sent is never overridden by our own
+// ban-derived guess.
+func TestTryFallbackProxy_ExhaustedPreservesUpstreamRetryAfter(t *testing.T) {
+	fallbackServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "42")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer fallbackServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithPrimaryAndFallback("http://primary.local", fallbackServer.URL).
+		Build()
+	prx.balancer.BanUntil("primary", "gpt-4", http.StatusTooManyRequests, time.Now().Add(3*time.Second), "test-ban")
+
+	bodyBytes := []byte(`{"model":"gpt-4","messages":[]}`)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(string(bodyBytes)))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	_, _ = prx.TryFallbackProxy(
+		w, req, "gpt-4", "primary", http.StatusTooManyRequests, RetryReasonRateLimit,
+		bodyBytes, time.Now().UTC(), nil,
+	)
+
+	assert.Equal(t, "42", w.Header().Get("Retry-After"), "must not override the upstream's own Retry-After")
 }
 
 func TestWriteFallbackResponseUsesAIRUsageContractForNonStreaming(t *testing.T) {


### PR DESCRIPTION
## Summary
- The Retry-After header from an earlier fix only covers the self-generated "no credentials available" 429 in `selectCredentialForModel` — computed before any HTTP call is made (all candidates already banned/rate-limited).
- The much more common case is different: AIR actually tries a credential, gets a real 429 from the provider, retries/falls back, and eventually relays the *last* fallback's real response once the chain is exhausted (`retry.go`'s `TryFallbackProxy` -> `writeFallbackResponse` -> `writeProxyResponse`). That path never added a Retry-After — clients only saw one if the provider itself happened to include it.
- Extracted the ban-derived Retry-After computation out of `selectCredentialForModel` into a shared `setRetryAfterFromBan` helper (`internal/proxy/retry.go`), and now call it from `writeFallbackResponse` too when the final relayed status is 429 — but only if the upstream response didn't already carry its own `Retry-After` (never override a provider's own guidance).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] Existing `TestSelectCredentialForModelSetsRetryAfterFromBan` still passes after the refactor
- [x] New `TestTryFallbackProxy_ExhaustedSetsRetryAfterFromBan` — a real 429 relayed after the fallback chain exhausts now carries a ban-derived `Retry-After`
- [x] New `TestTryFallbackProxy_ExhaustedPreservesUpstreamRetryAfter` — an upstream-supplied `Retry-After` is never overridden