### PR TITLE
fix: fallback credentials received the unconverted Responses-API body

### DIFF
--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -401,9 +401,17 @@ func (p *Proxy) prepareRequestForCredential(
 			return req, err
 		}
 		req.body = openai.ReplaceBodyParam(realModelID, chatBody)
+		// proxyBody must stay in sync with body: TryFallbackProxy forwards
+		// proxyBody, not body, to fallback credentials. Left as the original
+		// Responses-API-shaped bytes (still keyed on "input", not "messages"),
+		// a fallback to any Chat-Completions-only backend would reject the
+		// request outright ("specify prompt or messages") instead of the
+		// converted body the primary attempt used.
+		req.proxyBody = openai.ReplaceBodyParam(modelID, chatBody)
 		req.convertedResp = true
 		if streaming {
 			req.body = injectStreamOptions(req.body)
+			req.proxyBody = injectStreamOptions(req.proxyBody)
 		}
 		req.path = strings.Replace(basePath, "/responses", "/chat/completions", 1)
 		p.logger.DebugContext(r.Context(), "Converted Responses API request to Chat Completions format",

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -584,8 +584,13 @@ func TestPrepareRequestForCredential_ResponsesRecomputesProviderMode(t *testing.
 	require.Equal(t, "/v1/responses", anthropicReq.proxyPath)
 	require.Contains(t, string(anthropicReq.body), `"messages"`)
 	require.NotContains(t, string(anthropicReq.body), `"input"`)
-	require.Contains(t, string(anthropicReq.proxyBody), `"input"`)
-	require.NotContains(t, string(anthropicReq.proxyBody), `"messages"`)
+	// proxyBody must be converted too, not just body: TryFallbackProxy forwards
+	// proxyBody to fallback credentials, and a Chat-Completions-only fallback
+	// receiving the original Responses-shaped "input" body rejects it outright
+	// ("specify prompt or messages") instead of the converted request the
+	// primary attempt used.
+	require.Contains(t, string(anthropicReq.proxyBody), `"messages"`)
+	require.NotContains(t, string(anthropicReq.proxyBody), `"input"`)
 }
 
 func TestProxyRequest_ResponsesRetryRecomputesProviderMode(t *testing.T) {


### PR DESCRIPTION
## Summary
- `prepareRequestForCredential`'s Responses→Chat Completions conversion branch (the `default:` case — used for any model with `passthrough_responses: false`, e.g. `deepseek-v4-flash-0731`) only set `req.body`, leaving `req.proxyBody` at its original, unconverted Responses-API value (keyed on `"input"`, not `"messages"`).
- `TryFallbackProxy` forwards `proxyBody`, not `body`, to fallback credentials. So a request that needed conversion, then fell back after the primary attempt(s) failed, sent the *original pre-conversion* body to the fallback credential.
- Reproduced directly against OpenRouter's real API: a body with `input` instead of `messages` (or an empty/missing `messages`) gets rejected with exactly `{"error":{"message":"Input required: specify \"prompt\" or \"messages\"","code":400}}` — matching the error reported in production for `deepseek-v4-flash-0731` falling back to OpenRouter. (Ruled out a model-name-prefix theory first — OpenRouter accepts both `deepseek-v4-flash-0731` and `deepseek/deepseek-v4-flash-0731` fine; the missing/wrong-shaped `messages` field is what triggers it.)
- Fix: update `req.proxyBody` alongside `req.body` in that branch (mirroring the sibling `PassthroughResponses` case just above it, which already keeps both in sync), scoped to the alias model ID rather than the credential-specific real model name — consistent with how `proxyBody` is used everywhere else.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite green)
- [x] `TestPrepareRequestForCredential_ResponsesRecomputesProviderMode` was actually asserting the old, broken behavior (`proxyBody` still containing `"input"` after conversion) as if it were intentional — corrected its expectations to match the fix