### PR TITLE
Preserve web search tools for non-preview OpenAI models

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -77,7 +77,7 @@ Tool handling follows the outbound endpoint contract:
 
 - Native `/v1/responses` passthrough keeps built-in tools and `tool_choice` unchanged, including `web_search`, `file_search`, `computer_use`, and `code_interpreter`.
 - `/v1/chat/completions` converts `web_search` and `web_search_preview` to top-level `web_search_options` for models whose name contains `search-preview`, including `search_context_size` and `user_location`.
-- Chat Completions requests for other models drop the unsupported built-in web-search tool locally. Ordinary function tools in the same request remain unchanged.
+- Chat Completions requests for other models preserve `web_search`, `web_search_preview`, and matching `tool_choice` values for upstream validation. Ordinary function tools in the same request also remain unchanged.
 
 ```python
 # Converted to web_search_options for Chat Completions
@@ -87,9 +87,9 @@ client.chat.completions.create(
     ...,
 )
 
-# Built-in tool is dropped for a non-search Chat Completions model
+# Built-in tool is preserved for upstream validation
 client.chat.completions.create(
-    model="gpt-4o-mini", tools=[{"type": "web_search"}], ...  # dropped
+    model="gpt-5.6-sol", tools=[{"type": "web_search"}], ...
 )
 ```
 

--- a/internal/converter/openai/openai_rules.go
+++ b/internal/converter/openai/openai_rules.go
@@ -206,24 +206,19 @@ func ReplaceBodyParam(modelID string, body []byte) []byte {
 // ConvertWebSearchTools normalises non-function tools in an OpenAI Chat
 // Completions request body.
 //
-//   - For OpenAI models specifically, web_search / web_search_preview are
-//     converted to the top-level web_search_options parameter for
-//     search-preview models (supported options copied from the built-in
-//     tool); for other OpenAI models the tool is dropped, as documented for
-//     the Chat Completions compatibility path.
-//   - For non-OpenAI models (e.g. xAI/Grok, reached through the same
-//     OpenAI-compatible provider slot), web_search / web_search_preview
-//     tools and any tool_choice referencing them are passed through
-//     unchanged instead — OpenAI's "-search-preview" naming convention and
-//     web_search_options rewrite are OpenAI-specific; other vendors run
-//     their own agentic search loop directly off the "type":"web_search"
-//     tool regardless of model name (e.g. xAI's Agent Tools API).
+//   - For OpenAI search-preview models, web_search / web_search_preview are
+//     converted to the legacy top-level web_search_options parameter
+//     (supported options copied from the built-in tool).
+//   - For every other model, web_search / web_search_preview tools and any
+//     tool_choice referencing them are passed through unchanged. The router
+//     must not silently remove a requested capability; the selected upstream
+//     owns validation of its Chat Completions tool contract.
 //   - All other non-function tools (computer_use, google_search_retrieval,
 //     code_execution, etc.) are dropped for every vendor; they have no
 //     Chat Completions equivalent and would cause a 400 upstream.
 //   - If a non-function tool_choice remains after tools are filtered, it is
 //     also removed so the provider defaults to "auto" (unless it references
-//     a web_search tool preserved for a non-OpenAI model, see above).
+//     a preserved web_search tool, see above).
 func ConvertWebSearchTools(body []byte) []byte {
 	var data map[string]any
 	if err := json.Unmarshal(body, &data); err != nil {
@@ -231,7 +226,7 @@ func ConvertWebSearchTools(body []byte) []byte {
 	}
 
 	modelID, _ := data["model"].(string)
-	preserveWebSearch := !isOpenAIModel(modelID)
+	preserveWebSearch := !isOpenAIModel(modelID) || !isWebSearchModel(modelID)
 
 	toolsRaw, ok := data["tools"]
 	if !ok {
@@ -250,7 +245,7 @@ func ConvertWebSearchTools(body []byte) []byte {
 		return body
 	}
 
-	var functionTools []any
+	var retainedTools []any
 	var webSearchOptions map[string]any
 	hasWebSearch := false
 	nonFunctionDropped := false
@@ -258,16 +253,16 @@ func ConvertWebSearchTools(body []byte) []byte {
 	for _, t := range toolsArr {
 		toolMap, ok := t.(map[string]any)
 		if !ok {
-			functionTools = append(functionTools, t)
+			retainedTools = append(retainedTools, t)
 			continue
 		}
 		toolType, _ := toolMap["type"].(string)
 		switch toolType {
 		case "web_search", "web_search_preview":
 			if preserveWebSearch {
-				// Non-OpenAI vendor: leave the built-in tool as-is rather
-				// than assuming OpenAI's own naming/rewrite rules apply.
-				functionTools = append(functionTools, t)
+				// Non-legacy model: leave the built-in tool as-is and let the
+				// selected upstream validate its own tool contract.
+				retainedTools = append(retainedTools, t)
 				continue
 			}
 			hasWebSearch = true
@@ -283,7 +278,7 @@ func ConvertWebSearchTools(body []byte) []byte {
 				}
 			}
 		case "function":
-			functionTools = append(functionTools, t)
+			retainedTools = append(retainedTools, t)
 		default:
 			// computer_use, text_editor, bash, google_search_retrieval,
 			// code_execution, etc. — not supported by OpenAI Chat Completions.
@@ -308,8 +303,8 @@ func ConvertWebSearchTools(body []byte) []byte {
 		}
 	}
 
-	if len(functionTools) > 0 {
-		data["tools"] = functionTools
+	if len(retainedTools) > 0 {
+		data["tools"] = retainedTools
 	} else {
 		delete(data, "tools")
 		delete(data, "tool_choice")
@@ -358,7 +353,7 @@ func isOpenAIModel(modelID string) bool {
 // dropNonFunctionToolChoice removes tool_choice from data if it is a
 // map-style object whose type is not "function". When preserveWebSearch is
 // true, a tool_choice referencing web_search/web_search_preview is left in
-// place instead (non-OpenAI vendor). Returns true if removed.
+// place instead. Returns true if removed.
 func dropNonFunctionToolChoice(data map[string]any, preserveWebSearch bool) bool {
 	tc, ok := data["tool_choice"].(map[string]any)
 	if !ok {

--- a/internal/converter/openai/openai_rules_test.go
+++ b/internal/converter/openai/openai_rules_test.go
@@ -626,9 +626,8 @@ func TestConvertWebSearchTools_WebSearchWithFunctions(t *testing.T) {
 	assert.Equal(t, "function", tools[0].(map[string]interface{})["type"])
 }
 
-// TestConvertWebSearchTools_NonSearchModelWithFunctions documents the local
-// compatibility policy: unsupported Chat Completions models lose the built-in
-// web-search tool while ordinary functions remain available.
+// TestConvertWebSearchTools_NonSearchModelWithFunctions verifies that ordinary
+// models keep both web-search and function tools for upstream validation.
 func TestConvertWebSearchTools_NonSearchModelWithFunctions(t *testing.T) {
 	body := []byte(`{"model":"gpt-4o-mini","tools":[{"type":"web_search_preview"},{"type":"function","function":{"name":"get_weather"}}],"tool_choice":"auto"}`)
 	result := bodyToMap(t, ConvertWebSearchTools(body))
@@ -640,12 +639,26 @@ func TestConvertWebSearchTools_NonSearchModelWithFunctions(t *testing.T) {
 	if !ok {
 		t.Fatal("tools should remain")
 	}
-	if len(tools) != 1 {
-		t.Errorf("expected one function tool, got %d", len(tools))
+	if len(tools) != 2 {
+		t.Errorf("expected web-search and function tools, got %d", len(tools))
 	}
-	assert.Equal(t, "function", tools[0].(map[string]interface{})["type"])
+	assert.Equal(t, "web_search_preview", tools[0].(map[string]interface{})["type"])
+	assert.Equal(t, "function", tools[1].(map[string]interface{})["type"])
 	if _, ok := result["tool_choice"]; !ok {
 		t.Error("tool_choice should remain")
+	}
+}
+
+func TestConvertWebSearchTools_ModernOpenAIModelsPreserveWebSearch(t *testing.T) {
+	for _, model := range []string{"gpt-5.5", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"} {
+		t.Run(model, func(t *testing.T) {
+			body := []byte(`{"model":"` + model + `","tools":[{"type":"web_search","search_context_size":"high","user_location":{"type":"approximate","country":"RU"}}],"tool_choice":{"type":"web_search"}}`)
+			result := ConvertWebSearchTools(body)
+
+			if string(result) != string(body) {
+				t.Errorf("body should be unchanged, got %s", result)
+			}
+		})
 	}
 }
 
@@ -724,24 +737,21 @@ func TestConvertWebSearchTools_PreservesExistingWebSearchOptions(t *testing.T) {
 	}
 }
 
-// TestConvertWebSearchTools_OtherNonFunctionToolsDropped: non-web-search
-// non-function tools (computer_use, code_execution, etc.) must be dropped
-// for OpenAI Chat Completions.
+// TestConvertWebSearchTools_OtherNonFunctionToolsDropped verifies that removing
+// unrelated built-ins does not also remove a preserved web-search tool.
 func TestConvertWebSearchTools_OtherNonFunctionToolsDropped(t *testing.T) {
-	body := []byte(`{"model":"gpt-4o","tools":[{"type":"computer_use"},{"type":"code_execution"},{"type":"function","function":{"name":"my_func"}}]}`)
+	body := []byte(`{"model":"gpt-5.6-sol","tools":[{"type":"web_search"},{"type":"computer_use"},{"type":"code_execution"},{"type":"function","function":{"name":"my_func"}}]}`)
 	result := bodyToMap(t, ConvertWebSearchTools(body))
 
 	tools, ok := result["tools"].([]interface{})
 	if !ok {
 		t.Fatal("tools should remain (function tool must be kept)")
 	}
-	if len(tools) != 1 {
-		t.Errorf("expected 1 function tool, got %d (non-function tools must be dropped)", len(tools))
+	if len(tools) != 2 {
+		t.Errorf("expected web-search and function tools, got %d", len(tools))
 	}
-	toolMap := tools[0].(map[string]interface{})
-	if toolMap["type"] != "function" {
-		t.Errorf("expected function tool, got %v", toolMap["type"])
-	}
+	assert.Equal(t, "web_search", tools[0].(map[string]interface{})["type"])
+	assert.Equal(t, "function", tools[1].(map[string]interface{})["type"])
 	if _, ok := result["web_search_options"]; ok {
 		t.Error("web_search_options must NOT be added (no web_search tools)")
 	}

--- a/internal/proxy/proxy_web_search_tools_e2e_test.go
+++ b/internal/proxy/proxy_web_search_tools_e2e_test.go
@@ -76,6 +76,7 @@ func TestProxyRequest_ChatCompletionsNormalizesWebSearchTools(t *testing.T) {
 		model                string
 		tools                string
 		wantWebSearchOptions bool
+		wantWebSearch        bool
 		wantFunction         bool
 	}{
 		{
@@ -92,10 +93,11 @@ func TestProxyRequest_ChatCompletionsNormalizesWebSearchTools(t *testing.T) {
 			wantFunction:         true,
 		},
 		{
-			name:         "unsupported model follows documented drop policy",
-			model:        "gpt-4o-mini",
-			tools:        `[{"type":"web_search"},{"type":"function","function":{"name":"get_weather","parameters":{"type":"object"}}}]`,
-			wantFunction: true,
+			name:          "ordinary model preserves web search for upstream",
+			model:         "gpt-5.6-sol",
+			tools:         `[{"type":"web_search"},{"type":"function","function":{"name":"get_weather","parameters":{"type":"object"}}}]`,
+			wantWebSearch: true,
+			wantFunction:  true,
 		},
 	}
 
@@ -140,10 +142,26 @@ func TestProxyRequest_ChatCompletionsNormalizesWebSearchTools(t *testing.T) {
 				assert.Equal(t, "RU", options["user_location"].(map[string]interface{})["country"])
 			}
 			tools, hasTools := outbound["tools"].([]interface{})
-			assert.Equal(t, tt.wantFunction, hasTools)
-			if tt.wantFunction {
-				require.Len(t, tools, 1)
-				assert.Equal(t, "function", tools[0].(map[string]interface{})["type"])
+			assert.Equal(t, tt.wantFunction || tt.wantWebSearch, hasTools)
+			if hasTools {
+				wantCount := 0
+				if tt.wantWebSearch {
+					wantCount++
+				}
+				if tt.wantFunction {
+					wantCount++
+				}
+				require.Len(t, tools, wantCount)
+				toolTypes := make([]string, 0, len(tools))
+				for _, tool := range tools {
+					toolTypes = append(toolTypes, tool.(map[string]interface{})["type"].(string))
+				}
+				if tt.wantWebSearch {
+					assert.Contains(t, toolTypes, "web_search")
+				}
+				if tt.wantFunction {
+					assert.Contains(t, toolTypes, "function")
+				}
 			}
 		})
 	}


### PR DESCRIPTION
## Changes

- Preserve web_search and web_search_preview tools for non-preview OpenAI models.
- Preserve matching tool_choice values for upstream validation.
- Retain conversion to web_search_options for search-preview models.
- Update the OpenAI provider documentation.

## Tests

- Add passthrough coverage for GPT-5.5 and GPT-5.6 models.
- Update converter and proxy coverage for mixed tool requests.
- Pass go test ./...