### PR TITLE
fix: guarantee Retry-After header on every 429 sent to the client

### DIFF
--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"sort"
 	"strings"
 	"sync"
@@ -231,6 +232,58 @@ func (r *RoundRobin) MinRemainingBanForModel(modelID string, exclude map[string]
 		}
 	}
 	return shortest, found
+}
+
+// defaultRetryAfterFallback is the last-resort Retry-After hint used when no
+// active ban and no per-credential 429 ban-duration rule can be found for a
+// model (e.g. the model has no eligible credentials left to inspect). A 429
+// reaching the client must always carry a Retry-After, so this constant
+// exists purely to guarantee that — it is never a precise ETA.
+const defaultRetryAfterFallback = 30 * time.Second
+
+// DefaultRetryAfterForModel returns a Retry-After duration to report on a 429
+// for modelID, scoped to the same candidate set as MinRemainingBanForModel.
+// It first tries an active ban (a precise ETA); if none is active, it falls
+// back to the shortest *configured* 429 ban duration among eligible
+// credentials, so the header is still meaningful; if that also yields
+// nothing (no eligible credentials, or all have permanent-ban rules),
+// it returns defaultRetryAfterFallback. This method never reports "no
+// Retry-After" — callers use it precisely to guarantee the header is always
+// present on a 429.
+func (r *RoundRobin) DefaultRetryAfterForModel(modelID string, exclude map[string]bool, visibility scope.Context) time.Duration {
+	if remaining, ok := r.MinRemainingBanForModel(modelID, exclude, visibility); ok {
+		return remaining
+	}
+
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var shortest time.Duration
+	found := false
+	for i := range r.credentials {
+		cred := &r.credentials[i]
+		if exclude[cred.Name] {
+			continue
+		}
+		if !cred.VisibleTo(visibility) {
+			continue
+		}
+		if modelID != "" && r.modelChecker != nil && r.modelChecker.IsEnabled() && !r.hasModel(cred.Name, modelID, visibility) {
+			continue
+		}
+		duration, ok := r.fail2ban.DefaultBanDuration(cred.Name, http.StatusTooManyRequests)
+		if !ok {
+			continue
+		}
+		if !found || duration < shortest {
+			shortest = duration
+			found = true
+		}
+	}
+	if !found {
+		return defaultRetryAfterFallback
+	}
+	return shortest
 }
 
 // GetProxyCredentials returns all proxy/AIR remote-router credentials.

--- a/internal/balancer/roundrobin_test.go
+++ b/internal/balancer/roundrobin_test.go
@@ -2339,3 +2339,68 @@ func TestMinRemainingBanForModel_NoRelevantCandidateBanned_ReturnsFalse(t *testi
 
 	assert.False(t, ok, "no relevant candidate is banned once the only one is excluded — must not fall back to guessing")
 }
+
+func TestDefaultRetryAfterForModel_PrefersActiveBanOverConfiguredDefault(t *testing.T) {
+	f2b := fail2ban.NewWithRules(3, 0, []int{429}, []fail2ban.ErrorCodeRule{
+		{Code: 429, MaxAttempts: 3, BanDuration: 30 * time.Second},
+	})
+	rl := ratelimit.New()
+
+	credentials := []config.CredentialConfig{
+		{Name: "cred1", APIKey: "key1", BaseURL: "http://test1.com", RPM: -1},
+	}
+	bal := New(credentials, f2b, rl)
+
+	bal.BanUntil("cred1", "shared-model", 429, time.Now().Add(2*time.Second), "test")
+
+	remaining := bal.DefaultRetryAfterForModel("shared-model", nil, scope.AdminContext())
+	assert.Greater(t, remaining, time.Duration(0))
+	assert.LessOrEqual(t, remaining, 2*time.Second, "an active ban's precise ETA must win over the configured default")
+}
+
+func TestDefaultRetryAfterForModel_NoActiveBan_FallsBackToConfiguredRuleDuration(t *testing.T) {
+	f2b := fail2ban.NewWithRules(3, 0, []int{429}, []fail2ban.ErrorCodeRule{
+		{Code: 429, MaxAttempts: 3, BanDuration: 45 * time.Second},
+	})
+	rl := ratelimit.New()
+
+	credentials := []config.CredentialConfig{
+		{Name: "cred1", APIKey: "key1", BaseURL: "http://test1.com", RPM: -1},
+	}
+	bal := New(credentials, f2b, rl)
+
+	// No RecordResponse/BanUntil at all — nothing is actively banned.
+	remaining := bal.DefaultRetryAfterForModel("shared-model", nil, scope.AdminContext())
+	assert.Equal(t, 45*time.Second, remaining,
+		"with no active ban, must still report the model's configured 429 ban duration rather than omitting a hint")
+}
+
+func TestDefaultRetryAfterForModel_NoEligibleCredentials_ReturnsHardcodedFallback(t *testing.T) {
+	f2b := fail2ban.New(3, 10*time.Second, []int{429})
+	rl := ratelimit.New()
+
+	// No credentials at all for this model.
+	bal := New(nil, f2b, rl)
+
+	remaining := bal.DefaultRetryAfterForModel("nonexistent-model", nil, scope.AdminContext())
+	assert.Equal(t, defaultRetryAfterFallback, remaining,
+		"must never return a zero/empty duration — a 429 must always carry some Retry-After hint")
+}
+
+func TestDefaultRetryAfterForModel_IgnoresExcludedAndOutOfScopeCredentials(t *testing.T) {
+	f2b := fail2ban.NewWithRules(3, 0, []int{429}, []fail2ban.ErrorCodeRule{
+		{Code: 429, MaxAttempts: 3, BanDuration: 5 * time.Second},
+	})
+	rl := ratelimit.New()
+
+	credentials := []config.CredentialConfig{
+		{Name: "cred-excluded", APIKey: "key1", BaseURL: "http://test1.com", RPM: -1},
+		{Name: "cred-out-of-scope", APIKey: "key2", BaseURL: "http://test2.com", RPM: -1, ProviderScopeExpression: scope.FalseExpression()},
+	}
+	bal := New(credentials, f2b, rl)
+
+	exclude := map[string]bool{"cred-excluded": true}
+	remaining := bal.DefaultRetryAfterForModel("shared-model", exclude, scope.AdminContext())
+	assert.Equal(t, defaultRetryAfterFallback, remaining,
+		"once the only credentials are excluded or out of scope, must land on the hardcoded fallback, not a bogus rule from an ineligible credential")
+}

--- a/internal/fail2ban/fail2ban.go
+++ b/internal/fail2ban/fail2ban.go
@@ -493,6 +493,24 @@ func (f *Fail2Ban) RemainingBan(credentialName, modelID string) (time.Duration, 
 	return remaining, true
 }
 
+// DefaultBanDuration returns the configured ban duration that would apply to
+// credentialName if it were banned for statusCode right now, regardless of
+// whether it is actually banned. Used to build a Retry-After hint on a 429
+// even when no credential has crossed the failure threshold yet — a 429
+// reaching the client must always carry a Retry-After. Returns (0, false)
+// for a permanent-ban rule (BanDuration == 0), since there is no finite ETA
+// to report.
+func (f *Fail2Ban) DefaultBanDuration(credentialName string, statusCode int) (time.Duration, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+
+	rule := f.getRule(credentialName, statusCode)
+	if rule.BanDuration <= 0 {
+		return 0, false
+	}
+	return rule.BanDuration, true
+}
+
 // GetBannedCount returns the count of currently active (non-expired) banned credential+model pairs
 func (f *Fail2Ban) GetBannedCount() int {
 	f.mu.RLock()

--- a/internal/fail2ban/fail2ban_test.go
+++ b/internal/fail2ban/fail2ban_test.go
@@ -693,6 +693,44 @@ func TestRemainingBan_NoActiveBan_ReturnsFalse(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func TestDefaultBanDuration_ReturnsConfiguredRuleDuration_WithNoPriorFailures(t *testing.T) {
+	f2b := NewWithRules(3, 0, []int{429}, []ErrorCodeRule{
+		{Code: 429, MaxAttempts: 3, BanDuration: 30 * time.Second},
+	})
+
+	// No RecordResponse call at all — credential has never failed and is not banned.
+	duration, ok := f2b.DefaultBanDuration("cred1", 429)
+	require.True(t, ok, "the configured rule duration must be reported even without an active ban")
+	assert.Equal(t, 30*time.Second, duration)
+}
+
+func TestDefaultBanDuration_FallsBackToGlobalDefault(t *testing.T) {
+	f2b := New(3, 10*time.Second, []int{429})
+
+	duration, ok := f2b.DefaultBanDuration("cred1", 429)
+	require.True(t, ok)
+	assert.Equal(t, 10*time.Second, duration)
+}
+
+func TestDefaultBanDuration_PermanentBanRule_ReturnsFalse(t *testing.T) {
+	f2b := New(1, 0, []int{401}) // banDuration 0 == permanent
+
+	_, ok := f2b.DefaultBanDuration("cred1", 401)
+	assert.False(t, ok, "permanent ban rule has no finite ETA to report")
+}
+
+func TestDefaultBanDuration_UnaffectedByActiveBanState(t *testing.T) {
+	f2b := NewWithRules(1, 0, []int{429}, []ErrorCodeRule{
+		{Code: 429, MaxAttempts: 1, BanDuration: 5 * time.Second},
+	})
+
+	f2b.RecordResponse("cred1", "model-a", 429) // now actively banned for 5s
+
+	duration, ok := f2b.DefaultBanDuration("cred1", 429)
+	require.True(t, ok)
+	assert.Equal(t, 5*time.Second, duration, "reports the configured rule regardless of active-ban state")
+}
+
 func TestGetBannedModelsForCredential(t *testing.T) {
 	f2b := New(3, 0, []int{401, 403, 500})
 

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -343,6 +343,38 @@ func TestSelectCredentialForModelSetsRetryAfterFromBan(t *testing.T) {
 	assert.LessOrEqual(t, seconds, 3)
 }
 
+// TestSelectCredentialForModelSetsRetryAfter_EvenWithoutActiveBan verifies
+// the core guarantee: the synthesized "no credentials available" 429 must
+// always carry a Retry-After header, even when there is no credential at
+// all for the model (so no active ban exists to derive a precise ETA from).
+func TestSelectCredentialForModelSetsRetryAfter_EvenWithoutActiveBan(t *testing.T) {
+	prx := NewTestProxyBuilder().Build() // no credentials configured at all
+	setTestModelPrice(prx, "nonexistent-model", &models.ModelPrice{})
+
+	logCtx := testLogCtx(t)
+	logCtx.Credential = nil
+
+	w := httptest.NewRecorder()
+	credential, ok := prx.selectCredentialForModel(
+		w,
+		"nonexistent-model",
+		"",
+		"",
+		nil,
+		logCtx,
+	)
+
+	require.False(t, ok)
+	require.Nil(t, credential)
+	require.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	retryAfter := w.Header().Get("Retry-After")
+	require.NotEmpty(t, retryAfter, "a 429 reaching the client must always carry a Retry-After header, even with no active ban")
+	seconds, err := strconv.Atoi(retryAfter)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, seconds, 1)
+}
+
 func TestPrepareRequestForCredential_ProxyBodyKeepsOriginalParams(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	cred := config.CredentialConfig{Name: "openai", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "http://openai.local", RPM: 100}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1069,6 +1069,13 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			}
 			p.logger.DebugContext(r.Context(), "Fallback retry failed, using original response",
 				"credential", cred.Name, "fallback_reason", fallbackReason)
+			if proxyResp != nil {
+				visibility := scope.PublicContext()
+				if logCtx != nil {
+					visibility = logCtx.Scope
+				}
+				p.ensureRetryAfterOn429(w, proxyResp.StatusCode, proxyResp.Headers, modelID, visibility)
+			}
 		}
 
 		// Handle transport error (no successful response at all).
@@ -1904,6 +1911,13 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 		}
 		p.logger.DebugContext(r.Context(), "Fallback retry failed, using original response",
 			"credential", cred.Name, "fallback_reason", fallbackReason)
+		if resp != nil {
+			visibility := scope.PublicContext()
+			if logCtx != nil {
+				visibility = logCtx.Scope
+			}
+			p.ensureRetryAfterOn429(w, resp.StatusCode, resp.Header, modelID, visibility)
+		}
 	}
 
 	// Handle case where all attempts were transport errors (no response at all)

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"net/textproto"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -24,6 +25,7 @@ import (
 	"github.com/mixaill76/auto_ai_router/internal/ratelimit"
 	"github.com/mixaill76/auto_ai_router/internal/requestid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -322,6 +324,42 @@ func TestProxyRequest_UpstreamError(t *testing.T) {
 	prx.ProxyRequest(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+// TestProxyRequest_SingleCredentialNoFallback_Real429SetsRetryAfter reproduces
+// the exact production scenario reported for deepseek-v4-flash-0731: a model
+// with a single direct-provider credential and zero fallback credentials
+// configured. TryFallbackProxy has nothing to even attempt (NextFallbackProxy...
+// finds no candidate), so it returns early without ever calling
+// writeFallbackResponse — the real upstream 429 falls straight through to the
+// normal response-writing path instead. That path must still guarantee
+// Retry-After via ensureRetryAfterOn429.
+func TestProxyRequest_SingleCredentialNoFallback_Real429SetsRetryAfter(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = io.WriteString(w, `{"error":{"code":"429","message":"Rate limit exceeded","param":null,"type":"rate_limit_error"}}`)
+	}))
+	defer mockServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithSingleCredential("alibabacloud-ru-international", config.ProviderTypeOpenAI, mockServer.URL, "upstream-key-1").
+		Build()
+
+	reqBody := `{"model":"deepseek-v4-flash-0731","messages":[{"role":"user","content":"Hello"}]}`
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(reqBody))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	retryAfter := w.Header().Get("Retry-After")
+	require.NotEmpty(t, retryAfter, "a model with a single credential and no fallback must still get Retry-After on a real relayed 429")
+	seconds, err := strconv.Atoi(retryAfter)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, seconds, 1)
 }
 
 func TestProxyRequest_Streaming(t *testing.T) {

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -98,6 +98,23 @@ func (p *Proxy) setRetryAfterFromBan(w http.ResponseWriter, modelID string, excl
 	w.Header().Set("Retry-After", fmt.Sprintf("%d", seconds))
 }
 
+// ensureRetryAfterOn429 sets a Retry-After header on the client response for
+// a 429 that is about to be relayed WITHOUT going through writeFallbackResponse
+// — specifically, when TryFallbackProxy found no fallback credential to even
+// attempt (e.g. the model has none configured), so the original upstream 429
+// falls straight through to the normal response-writing path instead. Same
+// guarantee as writeFallbackResponse's inline check: never override a
+// Retry-After the upstream already sent, and never omit one.
+func (p *Proxy) ensureRetryAfterOn429(w http.ResponseWriter, statusCode int, upstreamHeaders http.Header, modelID string, visibility scope.Context) {
+	if statusCode != http.StatusTooManyRequests {
+		return
+	}
+	if upstreamHeaders != nil && upstreamHeaders.Get("Retry-After") != "" {
+		return
+	}
+	p.setRetryAfterFromBan(w, modelID, nil, visibility)
+}
+
 // GetTried gets the set of tried credentials from context.
 // Returns an empty map if not found (new request without context).
 func GetTried(ctx context.Context) map[string]bool {

--- a/internal/proxy/retry.go
+++ b/internal/proxy/retry.go
@@ -80,17 +80,20 @@ func isRetryableContent(respBody []byte) bool {
 	return true
 }
 
-// setRetryAfterFromBan sets the Retry-After header to the shortest remaining
-// fail2ban ban among modelID's eligible credentials, rounded up to whole
-// seconds. No-op if none of them are currently banned.
+// setRetryAfterFromBan sets the Retry-After header for a 429 response to
+// modelID's caller. It prefers the shortest remaining fail2ban ban among
+// modelID's eligible credentials (a precise ETA); if none of them are
+// currently banned it falls back to a configured or default duration via
+// DefaultRetryAfterForModel, so a 429 reaching the client always carries a
+// Retry-After header.
 func (p *Proxy) setRetryAfterFromBan(w http.ResponseWriter, modelID string, exclude map[string]bool, visibility scope.Context) {
-	remaining, ok := p.balancer.MinRemainingBanForModel(modelID, exclude, visibility)
-	if !ok {
-		return
-	}
+	remaining := p.balancer.DefaultRetryAfterForModel(modelID, exclude, visibility)
 	seconds := int(remaining / time.Second)
 	if remaining%time.Second != 0 {
 		seconds++
+	}
+	if seconds < 1 {
+		seconds = 1
 	}
 	w.Header().Set("Retry-After", fmt.Sprintf("%d", seconds))
 }

--- a/internal/proxy/retry_test.go
+++ b/internal/proxy/retry_test.go
@@ -372,6 +372,46 @@ func TestTryFallbackProxy_ExhaustedSetsRetryAfterFromBan(t *testing.T) {
 	assert.LessOrEqual(t, seconds, 3)
 }
 
+// TestTryFallbackProxy_ExhaustedSetsRetryAfter_EvenWithoutActiveBan verifies
+// the core guarantee: a 429 relayed to the client after the fallback chain
+// is exhausted must always carry a Retry-After header, even when zero prior
+// failures mean fail2ban has no active ban to report a precise ETA from.
+func TestTryFallbackProxy_ExhaustedSetsRetryAfter_EvenWithoutActiveBan(t *testing.T) {
+	fallbackServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusTooManyRequests)
+		_, _ = w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+	}))
+	defer fallbackServer.Close()
+
+	prx := NewTestProxyBuilder().
+		WithPrimaryAndFallback("http://primary.local", fallbackServer.URL).
+		Build()
+
+	// Deliberately no BanUntil/RecordResponse call — this credential has
+	// never failed before and is not, and has never been, banned.
+
+	bodyBytes := []byte(`{"model":"gpt-4","messages":[]}`)
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(string(bodyBytes)))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	success, _ := prx.TryFallbackProxy(
+		w, req, "gpt-4", "primary", http.StatusTooManyRequests, RetryReasonRateLimit,
+		bodyBytes, time.Now().UTC(), nil,
+	)
+
+	assert.True(t, success)
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+
+	retryAfter := w.Header().Get("Retry-After")
+	require.NotEmpty(t, retryAfter, "a 429 reaching the client must always carry a Retry-After header, even with no active ban")
+	seconds, err := strconv.Atoi(retryAfter)
+	require.NoError(t, err)
+	assert.GreaterOrEqual(t, seconds, 1)
+}
+
 // TestTryFallbackProxy_ExhaustedPreservesUpstreamRetryAfter verifies that a
 // Retry-After the upstream itself sent is never overridden by our own
 // ban-derived guess.


### PR DESCRIPTION
## Summary
- Retry-After was previously only set when fail2ban had an *active* ban to derive an ETA from. Under partial rate limiting, a single success resets fail2ban's consecutive-failure counter to zero, so the ban threshold rarely triggers in practice and clients often never received Retry-After at all.
- Added `Fail2Ban.DefaultBanDuration(credentialName, statusCode)` exposing the *configured* ban duration for a credential+status pair, independent of whether it's currently banned.
- Added `RoundRobin.DefaultRetryAfterForModel(...)`, which prefers an active ban's precise remaining time, falls back to the configured rule duration for eligible credentials, and falls back further to a hardcoded default if neither is available — it never reports "nothing."
- `setRetryAfterFromBan` (used by both the synthesized "no credentials available" 429 in `selectCredentialForModel` and the relayed-429-after-fallback-exhaustion path in `writeFallbackResponse`) now always sets the header through this new fallback chain, so a 429 reaching the client is guaranteed to carry Retry-After.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] New unit tests in `internal/fail2ban/fail2ban_test.go` proving `DefaultBanDuration` returns the configured rule even with zero prior failures
- [x] New unit tests in `internal/balancer/roundrobin_test.go` proving `DefaultRetryAfterForModel` prefers an active ban, falls back to the configured rule, and falls back to the hardcoded default when no credentials are eligible
- [x] New end-to-end proxy tests in `internal/proxy/retry_test.go` and `internal/proxy/orchestrator_test.go` proving a 429 gets `Retry-After` even with no active ban