### PR TITLE
converter/anthropic: drop temperature/top_p/top_k for Opus 4.7+ models

### DIFF
--- a/internal/converter/anthropic/messages.go
+++ b/internal/converter/anthropic/messages.go
@@ -3,10 +3,52 @@ package anthropic
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
 )
+
+// SamplingRemoved reports whether the Claude model rejects the sampling parameters
+// temperature / top_p / top_k. Anthropic removed these starting with Claude Opus 4.7 —
+// setting any of them to a non-default value returns a 400 (see the Claude migration
+// guide, "Remove sampling parameters"). Opus 4.6 / Sonnet 4.6 and earlier still accept
+// them. We drop them for the affected models so an OpenAI-style temperature=0 does not
+// break the request on an Anthropic-wire route (e.g. a CometAPI / Bedrock backend).
+//
+// The version test mirrors isAdaptiveThinkingModel (same claudeVersionPattern) so the two
+// classifiers stay in lockstep as new models ship. This matters because adaptive thinking
+// forces temperature=1.0: any model new enough for adaptive thinking must also drop
+// sampling, or that forced temperature would 400. The one exception is the 4.6 generation,
+// which is adaptive yet still accepts sampling — hence the 4.7 threshold here vs 4.6 in
+// isAdaptiveThinkingModel. We drop for major >= 5 (any family), Opus/Sonnet/Haiku/Fable
+// 4.7+, and every Mythos.
+func SamplingRemoved(model string) bool {
+	lower := strings.ToLower(model)
+	// Mythos carries no numeric version in claudeVersionPattern; treat every Mythos as
+	// new-gen, matching isAdaptiveThinkingModel's short-circuit.
+	if strings.Contains(lower, "mythos") {
+		return true
+	}
+	match := claudeVersionPattern.FindStringSubmatch(lower)
+	if match == nil {
+		return false
+	}
+	major, err := strconv.Atoi(match[1])
+	if err != nil {
+		return false
+	}
+	if major >= 5 {
+		return true
+	}
+	// 4.x: sampling removed from 4.7 onward (4.6 still accepts it). A long trailing number
+	// (a date suffix, len > 2) is not a real minor, so such a bare-4 id is treated as old.
+	if major != 4 || len(match[2]) == 0 || len(match[2]) > 2 {
+		return false
+	}
+	minor, err := strconv.Atoi(match[2])
+	return err == nil && minor >= 7
+}
 
 // OpenAIToAnthropic converts an OpenAI Chat Completions request body to Anthropic Messages API
 // format.  The model parameter overrides the model field in the request body when non-empty.
@@ -53,18 +95,22 @@ func OpenAIToAnthropic(openAIBody []byte, model string, isRealAnthropicBackend b
 		Stream:    req.Stream,
 	}
 
+	// Sampling params (temperature / top_p / top_k) are dropped for models that
+	// no longer accept them (Claude Opus 4.7+ — see SamplingRemoved).
+	dropSampling := SamplingRemoved(model)
+
 	// Temperature
-	if req.Temperature != nil {
+	if req.Temperature != nil && !dropSampling {
 		anthropicReq.Temperature = req.Temperature
 	}
 
 	// TopP
-	if req.TopP != nil {
+	if req.TopP != nil && !dropSampling {
 		anthropicReq.TopP = req.TopP
 	}
 
 	// TopK (Anthropic extension, passed via extra_body)
-	if req.ExtraBody != nil {
+	if req.ExtraBody != nil && !dropSampling {
 		if topK, ok := req.ExtraBody["top_k"].(float64); ok {
 			v := int(topK)
 			anthropicReq.TopK = &v
@@ -102,7 +148,10 @@ func OpenAIToAnthropic(openAIBody []byte, model string, isRealAnthropicBackend b
 		maxTokens, betas, temp := applyThinkingSideEffects(tc, oc, anthropicReq.MaxTokens, anthropicReq.AnthropicBeta)
 		anthropicReq.MaxTokens = maxTokens
 		anthropicReq.AnthropicBeta = betas
-		anthropicReq.Temperature = &temp
+		// Do not re-introduce temperature on models that reject sampling params.
+		if !dropSampling {
+			anthropicReq.Temperature = &temp
+		}
 	} else if !isRealAnthropicBackend {
 		// This Anthropic-shaped request may be handled by a real Claude model
 		// (ProviderTypeAnthropic) or proxied by a multi-vendor gateway

--- a/internal/converter/anthropic/messages_api.go
+++ b/internal/converter/anthropic/messages_api.go
@@ -124,6 +124,16 @@ func NormalizeMessagesForPassthrough(body []byte, model string, isRealAnthropicB
 		return nil, fmt.Errorf("failed to parse Messages request: %w", err)
 	}
 
+	// Models that no longer accept sampling params (Claude Opus 4.7+ — see
+	// SamplingRemoved) reject temperature/top_p/top_k. Drop any client-supplied
+	// values so the native /v1/messages passthrough body does not 400.
+	dropSampling := SamplingRemoved(model)
+	if dropSampling {
+		delete(request, "temperature")
+		delete(request, "top_p")
+		delete(request, "top_k")
+	}
+
 	tc, oc := mapThinkingConfig(request["thinking"], "", model)
 	if tc != nil {
 		request["thinking"] = tc
@@ -140,7 +150,9 @@ func NormalizeMessagesForPassthrough(body []byte, model string, isRealAnthropicB
 			}
 			request["anthropic_beta"] = betas
 		}
-		request["temperature"] = temp
+		if !dropSampling {
+			request["temperature"] = temp
+		}
 	} else if !isRealAnthropicBackend {
 		request["thinking"] = &AnthropicThinking{Type: "disabled"}
 	}

--- a/internal/converter/anthropic/messages_api_test.go
+++ b/internal/converter/anthropic/messages_api_test.go
@@ -454,8 +454,9 @@ func roundTripFirstUserBlock(t *testing.T, messagesBody []byte) map[string]inter
 
 // TestNormalizeMessagesForPassthrough_AdaptiveThinkingBeta covers the /v1/messages
 // native-passthrough path: a client sending native Anthropic "thinking":{"type":"adaptive"}
-// straight through still needs the effort-2025-11-24 beta and temperature=1.0 that
-// OpenAIToAnthropic would otherwise have added during the Messages->Chat->Messages round trip.
+// straight through still needs the effort-2025-11-24 beta. On Opus 4.7+ the sampling params
+// (temperature/top_p/top_k) are dropped because those models reject them, so the client's
+// temperature must not survive and the thinking side-effect must not re-add it.
 func TestNormalizeMessagesForPassthrough_AdaptiveThinkingBeta(t *testing.T) {
 	body := []byte(`{
 		"model":"claude-opus-4.7",
@@ -472,10 +473,53 @@ func TestNormalizeMessagesForPassthrough_AdaptiveThinkingBeta(t *testing.T) {
 	var got map[string]interface{}
 	require.NoError(t, json.Unmarshal(out, &got))
 	assert.Equal(t, "adaptive", got["thinking"].(map[string]interface{})["type"])
-	assert.Equal(t, 1.0, got["temperature"])
+	_, hasTemp := got["temperature"]
+	assert.False(t, hasTemp, "temperature must be dropped for Opus 4.7+")
 	assert.Equal(t,
 		[]interface{}{"prompt-caching-2024-07-31", "effort-2025-11-24"},
 		got["anthropic_beta"])
+}
+
+// TestNormalizeMessagesForPassthrough_SamplingRemoved verifies the native /v1/messages
+// passthrough strips temperature/top_p/top_k for models that reject them (Opus 4.7+),
+// even with no thinking config, and preserves them for older models.
+func TestNormalizeMessagesForPassthrough_SamplingRemoved(t *testing.T) {
+	body := `{"model":"M","max_tokens":100,"temperature":0.3,"top_p":0.9,"top_k":40,"messages":[{"role":"user","content":"hi"}]}`
+
+	for _, m := range []string{"claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5"} {
+		out, err := NormalizeMessagesForPassthrough([]byte(body), m, true)
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(out, &got))
+		for _, k := range []string{"temperature", "top_p", "top_k"} {
+			_, ok := got[k]
+			assert.False(t, ok, "%s must be dropped for %s", k, m)
+		}
+	}
+	for _, m := range []string{"claude-opus-4-6", "claude-sonnet-4-6", "claude-haiku-4-5"} {
+		out, err := NormalizeMessagesForPassthrough([]byte(body), m, true)
+		require.NoError(t, err)
+		var got map[string]interface{}
+		require.NoError(t, json.Unmarshal(out, &got))
+		_, ok := got["temperature"]
+		assert.True(t, ok, "temperature must be preserved for %s", m)
+	}
+}
+
+// TestNormalizeMessagesForPassthrough_ThinkingForcesTempOnKeptModel guards the branch that
+// re-adds temperature=1.0 when thinking is enabled on a model that still accepts sampling
+// (Claude Sonnet 4.6 is adaptive-thinking but pre-4.7, so sampling is kept). Without this
+// case, deleting that branch would silently omit the required temperature and no test fails.
+func TestNormalizeMessagesForPassthrough_ThinkingForcesTempOnKeptModel(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","max_tokens":100,
+		"messages":[{"role":"user","content":"hi"}],
+		"thinking":{"type":"adaptive","effort":"high"}}`)
+
+	out, err := NormalizeMessagesForPassthrough(body, "claude-sonnet-4-6", true)
+	require.NoError(t, err)
+	var got map[string]interface{}
+	require.NoError(t, json.Unmarshal(out, &got))
+	assert.Equal(t, 1.0, got["temperature"], "thinking must force temperature=1.0 on a sampling-accepting model")
 }
 
 // TestNormalizeMessagesForPassthrough_LegacyBudgetUpgradedOnAdaptiveModel covers a client

--- a/internal/converter/anthropic/messages_test.go
+++ b/internal/converter/anthropic/messages_test.go
@@ -48,6 +48,79 @@ func TestOpenAIToAnthropic_AdaptiveThinkingDisplay(t *testing.T) {
 	}
 }
 
+func TestOpenAIToAnthropic_SamplingParamsDroppedForNewModels(t *testing.T) {
+	// temperature / top_p / top_k must be stripped for models that reject them
+	// (Claude Opus 4.7+), so an OpenAI-style temperature=0 does not 400 on an
+	// Anthropic-wire route (CometAPI / Bedrock). Older models keep them.
+	body := `{"model":"M","messages":[{"role":"user","content":"hi"}],"temperature":0,"top_p":0.5,"extra_body":{"top_k":10}}`
+
+	dropped := []string{
+		"claude-opus-4-7", "claude-opus-4-8", "claude-opus-5",
+		"claude-sonnet-5", "claude-fable-5", "claude-fable-5-1",
+		"claude-mythos-5",
+		// Future minors/families must be covered automatically by the version parser,
+		// without editing the classifier (this is the whole point of not hardcoding a list).
+		"claude-opus-4-9", "claude-opus-4-10", "claude-haiku-5",
+	}
+	for _, m := range dropped {
+		t.Run("dropped/"+m, func(t *testing.T) {
+			result, err := OpenAIToAnthropic([]byte(body), m, false)
+			require.NoError(t, err)
+			var req map[string]interface{}
+			require.NoError(t, json.Unmarshal(result, &req))
+			_, hasTemp := req["temperature"]
+			_, hasTopP := req["top_p"]
+			_, hasTopK := req["top_k"]
+			assert.False(t, hasTemp, "temperature must be dropped for %s", m)
+			assert.False(t, hasTopP, "top_p must be dropped for %s", m)
+			assert.False(t, hasTopK, "top_k must be dropped for %s", m)
+		})
+	}
+
+	kept := []string{"claude-opus-4-6", "claude-sonnet-4-6", "claude-sonnet-4-5", "claude-haiku-4-5"}
+	for _, m := range kept {
+		t.Run("kept/"+m, func(t *testing.T) {
+			result, err := OpenAIToAnthropic([]byte(body), m, false)
+			require.NoError(t, err)
+			var req map[string]interface{}
+			require.NoError(t, json.Unmarshal(result, &req))
+			assert.Equal(t, float64(0), req["temperature"], "temperature must be preserved for %s", m)
+			assert.Equal(t, 0.5, req["top_p"], "top_p must be preserved for %s", m)
+			assert.Equal(t, float64(10), req["top_k"], "top_k (from extra_body) must be preserved for %s", m)
+		})
+	}
+}
+
+// TestSamplingRemoved locks the model-classification boundary directly, so the version
+// parser cannot silently drift from the "Opus 4.7+" spec or from isAdaptiveThinkingModel.
+func TestSamplingRemoved(t *testing.T) {
+	drop := []string{
+		// current shipping models
+		"claude-opus-4-7", "claude-opus-4-8", "claude-opus-5",
+		"claude-sonnet-5", "claude-fable-5", "claude-fable-5-1", "claude-mythos-5",
+		// dotted (CometAPI) and platform/date-suffixed forms
+		"claude-opus-4.7", "us.anthropic.claude-opus-4-7-20250101-v1:0",
+		"global.anthropic.claude-opus-4-8",
+		// future minors/families the parser must catch without a code edit
+		"claude-opus-4-9", "claude-opus-4-10", "claude-haiku-5", "claude-sonnet-6",
+		// bare / preview Mythos (no claude-...-5 form) — still new-gen
+		"mythos-5", "mythos-5-preview", "claude-mythos-preview",
+	}
+	for _, m := range drop {
+		assert.True(t, SamplingRemoved(m), "SamplingRemoved(%q) should be true", m)
+	}
+
+	keep := []string{
+		"claude-opus-4-6", "claude-sonnet-4-6", "claude-opus-4-5", "claude-sonnet-4-5",
+		"claude-haiku-4-5", "claude-3-5-sonnet-20241022", "claude-3-opus-20240229",
+		"claude-opus-4-20250514", // bare 4.x base with a date suffix, not a real 4.6+ minor
+		"gpt-5", "deepseek-v4-flash", "",
+	}
+	for _, m := range keep {
+		assert.False(t, SamplingRemoved(m), "SamplingRemoved(%q) should be false", m)
+	}
+}
+
 func TestOpenAIToAnthropic_ResponseFormatJSONSchemaIncludesSchema(t *testing.T) {
 	result, err := OpenAIToAnthropic([]byte(`{
 		"model":"claude-sonnet-4-6",

--- a/internal/converter/anthropic/responses/request.go
+++ b/internal/converter/anthropic/responses/request.go
@@ -46,11 +46,13 @@ func buildAnthropicRequest(req *responses.Request, model string) (*anthropic.Ant
 		Stream:    req.Stream,
 	}
 
-	// Scalar params
-	if req.Temperature != nil {
+	// Scalar params. Drop temperature/top_p for models that no longer accept
+	// sampling params (Claude Opus 4.7+ — see anthropic.SamplingRemoved).
+	dropSampling := anthropic.SamplingRemoved(model)
+	if req.Temperature != nil && !dropSampling {
 		ar.Temperature = req.Temperature
 	}
-	if req.TopP != nil {
+	if req.TopP != nil && !dropSampling {
 		ar.TopP = req.TopP
 	}
 

--- a/internal/converter/anthropic/responses/request_test.go
+++ b/internal/converter/anthropic/responses/request_test.go
@@ -35,6 +35,31 @@ func TestResponsesRequestToAnthropic_StringInput(t *testing.T) {
 	assert.Equal(t, "Hello, world!", msg["content"])
 }
 
+func TestResponsesRequestToAnthropic_SamplingRemoved(t *testing.T) {
+	body := `{"model":"M","input":"hi","temperature":0.7,"top_p":0.9,"max_output_tokens":128}`
+
+	// Opus 4.7+ reject sampling params -> temperature/top_p must be dropped.
+	for _, m := range []string{"claude-opus-4-7", "claude-opus-4-8", "claude-opus-5", "claude-sonnet-5", "claude-fable-5"} {
+		result, err := ResponsesRequestToAnthropic([]byte(body), m)
+		require.NoError(t, err)
+		var ar map[string]interface{}
+		require.NoError(t, json.Unmarshal(result, &ar))
+		_, hasTemp := ar["temperature"]
+		_, hasTopP := ar["top_p"]
+		assert.False(t, hasTemp, "temperature must be dropped for %s", m)
+		assert.False(t, hasTopP, "top_p must be dropped for %s", m)
+	}
+
+	// Older models still accept them.
+	for _, m := range []string{"claude-opus-4-6", "claude-sonnet-4-5"} {
+		result, err := ResponsesRequestToAnthropic([]byte(body), m)
+		require.NoError(t, err)
+		var ar map[string]interface{}
+		require.NoError(t, json.Unmarshal(result, &ar))
+		assert.Equal(t, float64(0.7), ar["temperature"], "temperature must be preserved for %s", m)
+	}
+}
+
 func TestResponsesRequestToAnthropic_Instructions(t *testing.T) {
 	body := `{
 		"model": "claude-opus-4-5",


### PR DESCRIPTION
## What
Drop the sampling parameters (`temperature`, `top_p`, `top_k`) in `OpenAIToAnthropic` for Claude models that reject them: Opus 4.7 / 4.8 / 5, Sonnet 5, Fable 5 / 5.1 (and the Mythos 5 variants). Opus 4.6 / Sonnet 4.6 and earlier are unchanged.

## Why
Anthropic removed sampling parameters starting with Claude Opus 4.7 - setting any of them to a non-default value returns a 400 (see the migration guide, "Remove sampling parameters"). `OpenAIToAnthropic` forwarded the client's `temperature` as-is, so an OpenAI-style `temperature: 0` broke requests to these models on Anthropic-wire routes (observed in prod: CometAPI / Bedrock returning `ValidationException: temperature is deprecated for this model`). All Anthropic-wire traffic (CometAPI, ProMan, native /v1/messages passthrough) funnels through `OpenAIToAnthropic`, so one guard covers them.

## Change
- Add `samplingRemoved(model)` (matches Opus 4.7/4.8/5, Sonnet 5, Fable 5, Mythos 5).
- Skip assigning `temperature` / `top_p` / `top_k` for those models - both the client passthrough and the thinking side-effect that used to force `temperature=1`.
- Test: `TestOpenAIToAnthropic_SamplingParamsDroppedForNewModels` - params dropped for the new models, preserved for Opus 4.6 / Sonnet 4.6 / 4.5 / Haiku 4.5.

`go build ./internal/converter/...`, `go vet`, and `go test ./internal/converter/anthropic/` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)