### PR TITLE
feat: support static extra_headers per credential

### DIFF
--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -170,6 +170,7 @@ Common fields for all credentials:
 | `forbidden_scopes` | list   | Alias for `denied_scopes`                                                                                                        |
 | `openai_proto`     | bool   | `cometapi` only: use CometAPI's OpenAI-compatible wire protocol ([details](../providers/cometapi.md#openai-protocol-mode))       |
 | `google_proto`     | bool   | `cometapi` only: use CometAPI's Google GenAI-compatible wire protocol ([details](../providers/cometapi.md#google-protocol-mode)) |
+| `extra_headers`    | map    | Static HTTP headers merged onto every outbound request to this credential's provider, applied after auth headers — e.g. `X-DashScope-Wait-Timeout` on an Alibaba DashScope credential, to have the provider hold the connection and retry internally on a burst instead of returning 429 immediately |
 
 ### Scoped credential visibility
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -781,6 +781,16 @@ type CredentialConfig struct {
 
 	// Proxy/AIR remote-router specific fields
 	IsFallback bool `yaml:"is_fallback,omitempty"`
+
+	// ExtraHeaders are static HTTP headers merged onto every outbound request
+	// to this credential's provider, applied after the protocol's own auth
+	// headers (Authorization, X-Api-Key, anthropic-version, etc.) — a key
+	// colliding with one of those overrides it, so avoid reusing those names
+	// here. Intended for provider-specific tuning headers the router has no
+	// built-in knowledge of, e.g. Alibaba DashScope's X-DashScope-Wait-Timeout
+	// (has the provider hold the connection open and retry internally instead
+	// of returning 429 immediately on a burst).
+	ExtraHeaders map[string]string `yaml:"extra_headers,omitempty"`
 }
 
 func (c CredentialConfig) VisibleTo(visibility scope.Context) bool {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1733,6 +1733,9 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 		default:
 			proxyReq.Header.Set("Authorization", "Bearer "+cred.APIKey)
 		}
+		for key, value := range cred.ExtraHeaders {
+			proxyReq.Header.Set(key, value)
+		}
 
 		if p.logger.Enabled(context.Background(), slog.LevelDebug) {
 			p.logger.DebugContext(r.Context(), "Proxy request details",

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -772,6 +772,40 @@ func TestProxyRequest_HeadersForwarding(t *testing.T) {
 	assert.Equal(t, http.StatusOK, w.Code)
 }
 
+// TestProxyRequest_ForwardsCredentialExtraHeaders verifies a credential's
+// configured ExtraHeaders (e.g. Alibaba DashScope's X-DashScope-Wait-Timeout,
+// which asks the provider to hold the connection open and retry internally on
+// a burst instead of returning 429 immediately) are sent on every outbound
+// request to that credential's provider.
+func TestProxyRequest_ForwardsCredentialExtraHeaders(t *testing.T) {
+	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "30", r.Header.Get("X-Dashscope-Wait-Timeout"))
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(map[string]string{"result": "ok"})
+	}))
+	defer mockServer.Close()
+
+	cred := config.CredentialConfig{
+		Name:         "alibabacloud",
+		Type:         config.ProviderTypeOpenAI,
+		BaseURL:      mockServer.URL,
+		APIKey:       "upstream-key-1",
+		RPM:          100,
+		TPM:          10000,
+		ExtraHeaders: map[string]string{"X-DashScope-Wait-Timeout": "30"},
+	}
+	prx := NewTestProxyBuilder().WithCredentials(cred).Build()
+
+	req := httptest.NewRequest("POST", "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"test"}]}`))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
 func TestProxyRequest_MultipartImageEditConvertedToJSON(t *testing.T) {
 	mockServer := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))


### PR DESCRIPTION
## Summary
- Alibaba DashScope support recommended sending `X-DashScope-Wait-Timeout` on requests, so their backend holds the connection open and retries internally on a burst instead of returning 429 immediately (see their guidance: "we strongly recommend adding the X-DashScope-Wait-Timeout header to your requests and implementing an Exponential Backoff retry strategy").
- AIR had no generic way to attach a provider-specific static header like this to outbound requests for a credential.
- Added `CredentialConfig.ExtraHeaders` (yaml: `extra_headers`), a static `map[string]string` merged onto every outbound request to that credential's provider, applied right after the protocol's own auth headers (Authorization / X-Api-Key / anthropic-version / etc.) in the direct-provider request path.
- Not tied to any specific provider — usable for any credential that needs a static provider-specific header.

## Config example
```yaml
credentials:
  - name: alibabacloud-ru-international
    type: openai
    base_url: "https://ali-dashscope-sg.vsellm.ru/compatible-mode/v1"
    api_key: "os.environ/KEY08"
    extra_headers:
      X-DashScope-Wait-Timeout: "30"
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] New test `TestProxyRequest_ForwardsCredentialExtraHeaders` proves a configured extra header reaches the upstream request

## Note on load-testing this
When testing this against a real burst, keep in mind AIR's own fail2ban: by default, 3 consecutive 429s from a credential trigger a local ban (30s by default) — during that window AIR won't even attempt the credential, so the extra header (and DashScope's wait-timeout behavior) can't matter because the request never leaves AIR. That's a separate, existing mechanism (not changed here) — worth accounting for when designing the load test.