### PR TITLE
fix: recover reasoning summary in codex passthrough for malformed items

### DIFF
--- a/internal/converter/responses/request.go
+++ b/internal/converter/responses/request.go
@@ -377,6 +377,9 @@ func outputToInputItems(output []OutputItem) []interface{} {
 //  4. instructions: array of messages → content joined as a plain string.
 //  5. tools: nested Chat Completions format ({function:{name:...}}) →
 //     flat Responses API format ({name:...}) for function-type tools.
+//  6. compaction items → synthetic user messages (native API has no compaction type).
+//  7. reasoning items missing a valid "summary" list → recovered from a
+//     non-standard "content" field, or dropped if nothing is recoverable.
 func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -490,6 +493,60 @@ func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 					})
 				}
 				// Skip empty compaction items
+			}
+			if changed {
+				raw["input"] = out
+			}
+		}
+	}
+
+	// 7. Normalize reasoning items so they satisfy OpenAI's native validation
+	// ("Invalid 'summary': summary is required and must be a list for reasoning").
+	// Some upstream client SDKs / synthetic replays echo reasoning items back using
+	// a non-standard {"content": [{"type": "reasoning_text", "text": "..."}]} shape
+	// instead of the documented {"summary": [{"type": "summary_text", "text": "..."}]}
+	// shape. Passthrough forwards the body mostly as-is, so without this the
+	// malformed item reaches the provider unmodified and the whole request is
+	// rejected — recover a valid summary from "content" when possible, otherwise
+	// drop the item (an empty/malformed reasoning item carries nothing useful).
+	if inputVal, ok := raw["input"]; ok {
+		if inputArr, ok := inputVal.([]interface{}); ok {
+			out := make([]interface{}, 0, len(inputArr))
+			changed := false
+			for _, item := range inputArr {
+				itemMap, ok := item.(map[string]interface{})
+				if !ok || itemMap["type"] != "reasoning" {
+					out = append(out, item)
+					continue
+				}
+				if summary, ok := itemMap["summary"].([]interface{}); ok && len(summary) > 0 {
+					out = append(out, item)
+					continue
+				}
+				changed = true
+				var recovered []interface{}
+				if content, ok := itemMap["content"].([]interface{}); ok {
+					for _, c := range content {
+						cm, ok := c.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						if text, _ := cm["text"].(string); text != "" {
+							recovered = append(recovered, map[string]interface{}{
+								"type": "summary_text",
+								"text": text,
+							})
+						}
+					}
+				}
+				if len(recovered) == 0 {
+					// Nothing recoverable — drop the item rather than forward it
+					// with a missing/invalid summary.
+					continue
+				}
+				itemMap["summary"] = recovered
+				delete(itemMap, "content")
+				out = append(out, itemMap)
 			}
 			if changed {
 				raw["input"] = out

--- a/internal/converter/responses/request.go
+++ b/internal/converter/responses/request.go
@@ -379,7 +379,8 @@ func outputToInputItems(output []OutputItem) []interface{} {
 //     flat Responses API format ({name:...}) for function-type tools.
 //  6. compaction items → synthetic user messages (native API has no compaction type).
 //  7. reasoning items missing a valid "summary" list → recovered from a
-//     non-standard "content" field, or dropped if nothing is recoverable.
+//     non-standard "content" field; kept as-is if they carry encrypted_content
+//     instead; dropped only if nothing usable remains.
 func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 	var raw map[string]interface{}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -507,8 +508,17 @@ func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 	// instead of the documented {"summary": [{"type": "summary_text", "text": "..."}]}
 	// shape. Passthrough forwards the body mostly as-is, so without this the
 	// malformed item reaches the provider unmodified and the whole request is
-	// rejected — recover a valid summary from "content" when possible, otherwise
-	// drop the item (an empty/malformed reasoning item carries nothing useful).
+	// rejected — recover a valid summary from "content" when possible.
+	//
+	// A "summary" key that is already a list — even an empty one — already
+	// satisfies "must be a list" and is left untouched. If it's absent (or
+	// unrecoverable) but the item still carries encrypted_content, keep the
+	// item as-is rather than drop it: this router's own outputToInputItems
+	// produces exactly that shape (no "summary" key at all) for round-tripped
+	// encrypted reasoning, and it already passes through fine without one —
+	// dropping it here would just be a self-inflicted regression. Only an item
+	// with neither a usable summary nor encrypted_content carries nothing
+	// useful for the next turn and gets dropped.
 	if inputVal, ok := raw["input"]; ok {
 		if inputArr, ok := inputVal.([]interface{}); ok {
 			out := make([]interface{}, 0, len(inputArr))
@@ -519,11 +529,10 @@ func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 					out = append(out, item)
 					continue
 				}
-				if summary, ok := itemMap["summary"].([]interface{}); ok && len(summary) > 0 {
+				if _, ok := itemMap["summary"].([]interface{}); ok {
 					out = append(out, item)
 					continue
 				}
-				changed = true
 				var recovered []interface{}
 				if content, ok := itemMap["content"].([]interface{}); ok {
 					for _, c := range content {
@@ -539,14 +548,21 @@ func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 						}
 					}
 				}
-				if len(recovered) == 0 {
-					// Nothing recoverable — drop the item rather than forward it
-					// with a missing/invalid summary.
+				if len(recovered) > 0 {
+					changed = true
+					itemMap["summary"] = recovered
+					delete(itemMap, "content")
+					out = append(out, itemMap)
 					continue
 				}
-				itemMap["summary"] = recovered
-				delete(itemMap, "content")
-				out = append(out, itemMap)
+				if ec, ok := itemMap["encrypted_content"].(string); ok && ec != "" {
+					// No summary to recover, but encrypted_content alone is
+					// known-good today — leave the item exactly as-is.
+					out = append(out, item)
+					continue
+				}
+				// Genuinely nothing useful — drop rather than forward broken.
+				changed = true
 			}
 			if changed {
 				raw["input"] = out

--- a/internal/converter/responses/request_test.go
+++ b/internal/converter/responses/request_test.go
@@ -865,6 +865,64 @@ func TestPrepareCodexPassthrough_DropsUnrecoverableReasoning(t *testing.T) {
 	}
 }
 
+// TestPrepareCodexPassthrough_KeepsEncryptedContentOnlyReasoning verifies that
+// a reasoning item with no "summary" key at all but a non-empty
+// "encrypted_content" is left untouched rather than dropped. This is exactly
+// the shape this router's own outputToInputItems produces when round-tripping
+// encrypted reasoning with an empty summary (see the "reasoning" case there:
+// the "summary" key is omitted entirely when there's no summary text, but
+// encrypted_content is preserved) — that shape already passes through fine
+// today, so normalization must not start discarding it.
+func TestPrepareCodexPassthrough_KeepsEncryptedContentOnlyReasoning(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-5",
+		"input": [
+			{"role": "user", "content": "hi"},
+			{"type": "reasoning", "id": "rs_enc", "encrypted_content": "opaque-blob"},
+			{"role": "assistant", "content": "ok"}
+		]
+	}`)
+
+	result := PrepareCodexPassthrough(body, false)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	input := parsed["input"].([]interface{})
+	require.Len(t, input, 3, "encrypted_content-only reasoning item must be kept, not dropped")
+
+	reasoningItem := input[1].(map[string]interface{})
+	assert.Equal(t, "reasoning", reasoningItem["type"])
+	assert.Equal(t, "opaque-blob", reasoningItem["encrypted_content"])
+	assert.NotContains(t, reasoningItem, "summary", "must not fabricate a summary key that wasn't there")
+}
+
+// TestPrepareCodexPassthrough_KeepsEmptyValidSummary verifies that a
+// reasoning item whose "summary" is already a list — even an empty one —
+// is left untouched. An empty list still satisfies OpenAI's "summary is
+// required and must be a list for reasoning" validation, so treating it as
+// something to recover/drop would be an unnecessary mutation.
+func TestPrepareCodexPassthrough_KeepsEmptyValidSummary(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-5",
+		"input": [
+			{"type": "reasoning", "id": "rs_empty_summary", "summary": []}
+		]
+	}`)
+
+	result := PrepareCodexPassthrough(body, false)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	input := parsed["input"].([]interface{})
+	require.Len(t, input, 1, "item with an already-valid (even empty) summary list must not be dropped")
+	reasoningItem := input[0].(map[string]interface{})
+	summary, ok := reasoningItem["summary"].([]interface{})
+	require.True(t, ok)
+	assert.Empty(t, summary)
+}
+
 func TestRequestToChat_TextFormat(t *testing.T) {
 	body := `{
 		"model": "gpt-4o",

--- a/internal/converter/responses/request_test.go
+++ b/internal/converter/responses/request_test.go
@@ -778,6 +778,93 @@ func TestPrepareCodexPassthrough_DropsReasoningNone(t *testing.T) {
 	assert.NotContains(t, parsed, "reasoning", "reasoning.effort='none' should be dropped for native passthrough")
 }
 
+// TestPrepareCodexPassthrough_RecoversReasoningSummaryFromContent reproduces the
+// reported bug: a synthetic/replayed reasoning item shaped like
+// {"content": [{"type": "reasoning_text", "text": "..."}]} instead of the
+// documented {"summary": [{"type": "summary_text", "text": "..."}]} reaches the
+// provider unmodified in passthrough mode and gets rejected with
+// "Invalid 'summary': summary is required and must be a list for reasoning."
+// The fix recovers a valid summary from "content" instead of forwarding it as-is.
+func TestPrepareCodexPassthrough_RecoversReasoningSummaryFromContent(t *testing.T) {
+	body := []byte(`{
+		"model": "deepseek/deepseek-v4-flash-0731",
+		"input": [
+			{"role": "user", "content": "hi"},
+			{"type": "reasoning", "content": [{"type": "reasoning_text", "text": "Размышляю."}]},
+			{"role": "assistant", "content": "ok"}
+		]
+	}`)
+
+	result := PrepareCodexPassthrough(body, false)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	input := parsed["input"].([]interface{})
+	require.Len(t, input, 3, "reasoning item should be recovered, not dropped")
+
+	reasoningItem := input[1].(map[string]interface{})
+	assert.Equal(t, "reasoning", reasoningItem["type"])
+	assert.NotContains(t, reasoningItem, "content", "non-standard content field must not reach the provider")
+
+	summary, ok := reasoningItem["summary"].([]interface{})
+	require.True(t, ok, "summary must be present and be a list")
+	require.Len(t, summary, 1)
+	summaryItem := summary[0].(map[string]interface{})
+	assert.Equal(t, "summary_text", summaryItem["type"])
+	assert.Equal(t, "Размышляю.", summaryItem["text"])
+}
+
+// TestPrepareCodexPassthrough_KeepsValidReasoningSummary verifies that a
+// reasoning item which already carries a proper non-empty "summary" list is
+// passed through unchanged (no double-processing of already-valid items).
+func TestPrepareCodexPassthrough_KeepsValidReasoningSummary(t *testing.T) {
+	body := []byte(`{
+		"model": "gpt-5",
+		"input": [
+			{"type": "reasoning", "id": "rs_1", "summary": [{"type": "summary_text", "text": "Already valid."}]}
+		]
+	}`)
+
+	result := PrepareCodexPassthrough(body, false)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	input := parsed["input"].([]interface{})
+	require.Len(t, input, 1)
+	reasoningItem := input[0].(map[string]interface{})
+	summary := reasoningItem["summary"].([]interface{})
+	require.Len(t, summary, 1)
+	assert.Equal(t, "Already valid.", summary[0].(map[string]interface{})["text"])
+}
+
+// TestPrepareCodexPassthrough_DropsUnrecoverableReasoning verifies that a
+// reasoning item with neither a valid "summary" nor a recoverable "content" is
+// dropped entirely, rather than forwarded with a missing/invalid summary.
+func TestPrepareCodexPassthrough_DropsUnrecoverableReasoning(t *testing.T) {
+	body := []byte(`{
+		"model": "deepseek/deepseek-v4-flash-0731",
+		"input": [
+			{"role": "user", "content": "hi"},
+			{"type": "reasoning", "id": "rs_empty"},
+			{"role": "assistant", "content": "ok"}
+		]
+	}`)
+
+	result := PrepareCodexPassthrough(body, false)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	input := parsed["input"].([]interface{})
+	require.Len(t, input, 2, "unrecoverable reasoning item should be dropped, surrounding messages kept")
+	for _, item := range input {
+		itemMap := item.(map[string]interface{})
+		assert.NotEqual(t, "reasoning", itemMap["type"])
+	}
+}
+
 func TestRequestToChat_TextFormat(t *testing.T) {
 	body := `{
 		"model": "gpt-4o",


### PR DESCRIPTION
## Summary
- `PrepareCodexPassthrough` forwards Responses API requests to `openai`-type credentials (the provider default for that type — see `providerPassthroughDefaults` in `internal/models/manager.go`) mostly as-is, with no per-item validation of `input` entries.
- When a `reasoning` item in the input history is shaped like `{"content": [{"type": "reasoning_text", "text": "..."}]}` instead of the documented `{"summary": [{"type": "summary_text", "text": "..."}]}`, it reaches the provider unmodified and the whole request is rejected with:
  ```
  Invalid 'summary': summary is required and must be a list for reasoning.
  ```
- This affects any model routed through an `openai`-type credential where the upstream validates strictly against the real Responses API schema. Reproduced on `deepseek/deepseek-v4-flash-0731` — configured across `openrouter`, `requesty-d4y`, `deepinfra-monikaprzybyl`, and `alibabacloud-ru-international` credentials, all `type: openai` — using a client-supplied load-test generator that replays production-shaped tool-calling history, including reasoning items in this non-standard shape.
- Note: the non-passthrough conversion path (`request.go` Responses→Chat Completions, used when passthrough is off) already tolerates this correctly — it only reads `summary` and silently produces nothing for the item if absent. The passthrough path had no equivalent handling.

## Fix
Added a normalization step to `PrepareCodexPassthrough`, following the existing pattern already used there for `reasoning.effort="none"` and `compaction` items (steps 4.5 and 6): for each `reasoning` input item without a valid non-empty `summary` list, recover a summary from the non-standard `content` field when present, otherwise drop the item entirely (it carries nothing useful for the next turn either way) rather than forwarding it with a missing/invalid summary. A reasoning item that already has a valid summary list is left untouched.

## Verification
- Reproduced against production (`api.vsellm.ru`, `deepseek/deepseek-v4-flash-0731`) with a client-provided synthetic load generator that builds realistic tool-calling history with reasoning items in the `content`/`reasoning_text` shape: **8/8** requests failed with `Invalid 'summary': ...` when reasoning items were present; the identical requests succeed without them.
- `go build ./...` and `go test ./...` — clean across the whole repo.
- Added `TestPrepareCodexPassthrough_RecoversReasoningSummaryFromContent` (malformed → recovered), `TestPrepareCodexPassthrough_KeepsValidReasoningSummary` (already-valid item untouched), and `TestPrepareCodexPassthrough_DropsUnrecoverableReasoning` (nothing recoverable → item dropped, surrounding messages kept). Existing `TestPrepareCodexPassthrough_DropsReasoningNone` still passes unmodified.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Live repro against production traffic profile (before/after) with a synthetic load generator matching real tool-calling history shape
- [x] Unit tests for malformed / already-valid / unrecoverable reasoning items