### PR TITLE
fix: classify "is not supported" and logprobs in bad-request masking

### DIFF
--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -151,10 +151,24 @@ func classifiedBadRequestError(rawBodies ...[]byte) APIError {
 		result.Message = "Invalid model"
 		result.Param = &param
 		result.Code = &code
-	case hasSignal(joined, "invalid argument", "invalid parameter", "invalid value", "unsupported parameter", "unknown parameter", "unrecognized parameter", "missing required", "required field", "must be", "should be", "does not support", "is not supported"):
+	case hasSignal(joined, "invalid argument", "invalid parameter", "invalidparameter", "invalid value", "unsupported parameter", "unknown parameter", "unrecognized parameter", "missing required", "required field", "must be", "should be", "does not support", "is not supported"):
 		code := "invalid_parameter"
 		result.Message = "Invalid request parameter"
-		result.Param = inferBadRequestParam(joined, providerParam)
+		// Precedence: an explicit "param" from the provider's own JSON is
+		// authoritative; next, a field path quoted directly in the message
+		// ("Invalid 'output[1].type': 'input_file'. Supported values are:
+		// ...") is precise even for dynamic/nested paths a fixed list can't
+		// cover; only fall back to the generic keyword list last — it does
+		// broad substring matching (e.g. "input") that a quoted path like
+		// "input_file" would otherwise shadow.
+		param := providerParam
+		if param == nil {
+			param = extractQuotedInvalidField(signals)
+		}
+		if param == nil {
+			param = inferBadRequestParam(joined, nil)
+		}
+		result.Param = param
 		result.Code = &code
 	default:
 		result.Param = providerParam
@@ -317,6 +331,31 @@ func inferBadRequestParam(joined string, providerParam *string) *string {
 			p := param
 			return &p
 		}
+	}
+	return nil
+}
+
+// extractQuotedInvalidField pulls the field path out of a provider message
+// shaped like `Invalid 'output[1].type': 'input_file'. Supported values
+// are: ...` — the quoted token right after "Invalid " is the offending
+// field/parameter path. Fixed param-name lists can't cover these because
+// the path is dynamic (array index, nested field), so this is checked as a
+// fallback once the static list in inferBadRequestParam comes up empty.
+// Tries each raw (pre-lowercased) signal in turn and returns the first hit.
+func extractQuotedInvalidField(signals []string) *string {
+	const marker = "invalid '"
+	for _, s := range signals {
+		idx := strings.Index(strings.ToLower(s), marker)
+		if idx == -1 {
+			continue
+		}
+		rest := s[idx+len(marker):]
+		end := strings.IndexByte(rest, '\'')
+		if end <= 0 {
+			continue
+		}
+		field := rest[:end]
+		return &field
 	}
 	return nil
 }

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -151,7 +151,7 @@ func classifiedBadRequestError(rawBodies ...[]byte) APIError {
 		result.Message = "Invalid model"
 		result.Param = &param
 		result.Code = &code
-	case hasSignal(joined, "invalid argument", "invalid parameter", "invalid value", "unsupported parameter", "unknown parameter", "unrecognized parameter", "missing required", "required field", "must be", "should be", "does not support"):
+	case hasSignal(joined, "invalid argument", "invalid parameter", "invalid value", "unsupported parameter", "unknown parameter", "unrecognized parameter", "missing required", "required field", "must be", "should be", "does not support", "is not supported"):
 		code := "invalid_parameter"
 		result.Message = "Invalid request parameter"
 		result.Param = inferBadRequestParam(joined, providerParam)
@@ -301,6 +301,7 @@ func inferBadRequestParam(joined string, providerParam *string) *string {
 		"stream_options",
 		"temperature",
 		"top_p",
+		"logprobs",
 		"messages",
 		"input",
 		"tools",

--- a/internal/proxy/errors_test.go
+++ b/internal/proxy/errors_test.go
@@ -140,6 +140,19 @@ func TestMaskedUpstreamErrorBodyClassifiesBadRequest(t *testing.T) {
 			notContains: []string{"unsupported parameter", "this model"},
 		},
 		{
+			// Reproduces a real production body: DeepInfra-style
+			// "is not supported" phrasing (not "does not support") with an
+			// underscore-style error code ("invalid_parameter_error", not a
+			// literal "invalid parameter" substring) — both must still land
+			// in the invalid_parameter bucket instead of the generic fallback.
+			name:        "is not supported phrasing with underscore error code",
+			body:        "{\"error\":{\"code\":\"invalid_parameter_error\",\"message\":\"The parameters `logprobs` is not supported.\",\"param\":null,\"type\":\"invalid_request_error\"},\"id\":\"chatcmpl-c851a2c6-8a54-9ca4-9561-b3ff6163be27\"}",
+			wantMessage: "Invalid request parameter",
+			wantCode:    "invalid_parameter",
+			wantParam:   stringPtr("logprobs"),
+			notContains: []string{"chatcmpl", "c851a2c6"},
+		},
+		{
 			name:        "plain text fallback",
 			body:        `vendor stack id 012345`,
 			wantMessage: "Invalid request",

--- a/internal/proxy/errors_test.go
+++ b/internal/proxy/errors_test.go
@@ -153,6 +153,21 @@ func TestMaskedUpstreamErrorBodyClassifiesBadRequest(t *testing.T) {
 			notContains: []string{"chatcmpl", "c851a2c6"},
 		},
 		{
+			// Reproduces another real production body: a PascalCase
+			// "InvalidParameter" type (lowercases to "invalidparameter",
+			// no space — doesn't match the "invalid parameter" needle) with
+			// no "param" field of its own, and a dynamic/nested offending
+			// field path ("output[1].type") that a fixed param-name list can
+			// never enumerate in advance. Must extract the path quoted right
+			// after "Invalid " in the message instead of leaving param null.
+			name:        "PascalCase InvalidParameter with quoted dynamic field path",
+			body:        `{"error":{"message":"Invalid 'output[1].type': 'input_file'. Supported values are: 'input_text', 'input_image'.","type":"InvalidParameter"}}`,
+			wantMessage: "Invalid request parameter",
+			wantCode:    "invalid_parameter",
+			wantParam:   stringPtr("output[1].type"),
+			notContains: []string{"Supported values are"},
+		},
+		{
 			name:        "plain text fallback",
 			body:        `vendor stack id 012345`,
 			wantMessage: "Invalid request",
@@ -203,6 +218,54 @@ func TestMaskedUpstreamErrorBodyKeepsGenericNonBadRequest(t *testing.T) {
 	}
 	if resp.Error.Code == nil || *resp.Error.Code != "api_error" {
 		t.Fatalf("code = %v", resp.Error.Code)
+	}
+}
+
+func TestExtractQuotedInvalidField(t *testing.T) {
+	tests := []struct {
+		name    string
+		signals []string
+		want    *string
+	}{
+		{
+			name:    "dynamic nested path",
+			signals: []string{"Invalid 'output[1].type': 'input_file'. Supported values are: 'input_text', 'input_image'."},
+			want:    stringPtr("output[1].type"),
+		},
+		{
+			name:    "case-insensitive marker",
+			signals: []string{"invalid 'tool_choice.type': unsupported value"},
+			want:    stringPtr("tool_choice.type"),
+		},
+		{
+			name:    "picks first matching signal",
+			signals: []string{"generic failure", "Invalid 'foo': bar"},
+			want:    stringPtr("foo"),
+		},
+		{
+			name:    "no marker present",
+			signals: []string{"something else went wrong"},
+			want:    nil,
+		},
+		{
+			name:    "marker with no closing quote",
+			signals: []string{"Invalid 'unterminated"},
+			want:    nil,
+		},
+		{
+			name:    "empty quoted field",
+			signals: []string{"Invalid '': something"},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractQuotedInvalidField(tt.signals)
+			if !equalStringPtr(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- The 400-classifier that builds the client-facing masked error (`classifiedBadRequestError`) only matched `"does not support"`, not the equally common `"is not supported"` phrasing, and only matched `"invalid parameter"` (with a space), not underscore-style codes some providers use (`"invalid_parameter_error"`).
- A real production error body using both forms — `"The parameters \`logprobs\` is not supported."` with `"code":"invalid_parameter_error"` — matched none of the classifier's cases and fell through to the generic `"Invalid request"` bucket, losing the only actionable detail: which parameter was rejected.

## Fix
- Added `"is not supported"` to the `invalid_parameter` case's signal list.
- Added `"logprobs"` to `inferBadRequestParam`'s known-param list, so it surfaces in the response's `"param"` field instead of staying `null`.

Before:
```json
{"error":{"message":"Invalid request","type":"invalid_request_error","param":null,"code":"invalid_request"}}
```
After:
```json
{"error":{"message":"Invalid request parameter","type":"invalid_request_error","param":"logprobs","code":"invalid_parameter"}}
```

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] New table case in `TestMaskedUpstreamErrorBodyClassifiesBadRequest` reproducing the exact reported production body