### PR TITLE
fix: normalize "developer" role for direct /v1/chat/completions requests

### DIFF
--- a/internal/converter/openai/openai_rules.go
+++ b/internal/converter/openai/openai_rules.go
@@ -203,6 +203,53 @@ func ReplaceBodyParam(modelID string, body []byte) []byte {
 	return body
 }
 
+// NormalizeDeveloperRole downgrades a "developer"-role Chat Completions message
+// to "system" — the same rename the Responses→Chat converter already applies
+// (see converter/responses.convertMessage), but for requests that arrive
+// already Chat-Completions-shaped and never go through that converter (a
+// client calling /v1/chat/completions directly, or one of the OpenAI SDKs
+// that emits "developer" for reasoning models). "developer" is OpenAI's own
+// rename of "system"; most Chat Completions providers reached through this
+// generic path (DeepSeek and other OpenAI-compatible backends) only
+// recognize the classic role set and reject "developer" outright. Returns
+// body unchanged if there's no "messages" array or nothing to rename.
+func NormalizeDeveloperRole(body []byte) []byte {
+	var data map[string]any
+	if err := json.Unmarshal(body, &data); err != nil {
+		return body
+	}
+
+	messagesRaw, ok := data["messages"]
+	if !ok {
+		return body
+	}
+	messages, ok := messagesRaw.([]any)
+	if !ok {
+		return body
+	}
+
+	changed := false
+	for _, m := range messages {
+		msg, ok := m.(map[string]any)
+		if !ok {
+			continue
+		}
+		if role, ok := msg["role"].(string); ok && role == "developer" {
+			msg["role"] = "system"
+			changed = true
+		}
+	}
+	if !changed {
+		return body
+	}
+
+	result, err := json.Marshal(data)
+	if err != nil {
+		return body
+	}
+	return result
+}
+
 // ConvertWebSearchTools normalises non-function tools in an OpenAI Chat
 // Completions request body.
 //

--- a/internal/converter/openai/openai_rules_test.go
+++ b/internal/converter/openai/openai_rules_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // helper: unmarshal body into map for assertions
@@ -755,4 +756,40 @@ func TestConvertWebSearchTools_OtherNonFunctionToolsDropped(t *testing.T) {
 	if _, ok := result["web_search_options"]; ok {
 		t.Error("web_search_options must NOT be added (no web_search tools)")
 	}
+}
+
+// TestNormalizeDeveloperRole_DowngradesToSystem reproduces a real production
+// failure: a client sends an already Chat-Completions-shaped body with a
+// "developer"-role message straight to /v1/chat/completions (this path never
+// goes through the Responses→Chat converter, which already handles this rename
+// — see converter/responses.convertMessage). Most OpenAI-compatible backends
+// reached this way (DeepSeek, etc.) reject "developer" outright.
+func TestNormalizeDeveloperRole_DowngradesToSystem(t *testing.T) {
+	body := []byte(`{"model":"deepseek-v4-flash-0731","messages":[{"role":"developer","content":"You are a pirate."},{"role":"user","content":"Hello"}]}`)
+	result := bodyToMap(t, NormalizeDeveloperRole(body))
+
+	messages := result["messages"].([]interface{})
+	require.Len(t, messages, 2)
+	assert.Equal(t, "system", messages[0].(map[string]interface{})["role"])
+	assert.Equal(t, "You are a pirate.", messages[0].(map[string]interface{})["content"])
+	assert.Equal(t, "user", messages[1].(map[string]interface{})["role"])
+}
+
+// TestNormalizeDeveloperRole_LeavesOtherRolesUntouched verifies messages with
+// roles other than "developer" (including the already-correct "system") pass
+// through unchanged, and no rewrite/re-marshal happens when there's nothing
+// to rename.
+func TestNormalizeDeveloperRole_LeavesOtherRolesUntouched(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","messages":[{"role":"system","content":"sys"},{"role":"user","content":"hi"},{"role":"assistant","content":"hey"}]}`)
+	result := NormalizeDeveloperRole(body)
+	assert.JSONEq(t, string(body), string(result))
+}
+
+// TestNormalizeDeveloperRole_NoMessagesArray verifies bodies without a
+// "messages" field (e.g. a malformed or non-chat request) are returned as-is
+// instead of erroring or fabricating a messages array.
+func TestNormalizeDeveloperRole_NoMessagesArray(t *testing.T) {
+	body := []byte(`{"model":"gpt-4o","input":"hi"}`)
+	result := NormalizeDeveloperRole(body)
+	assert.JSONEq(t, string(body), string(result))
 }

--- a/internal/proxy/cometapi_test.go
+++ b/internal/proxy/cometapi_test.go
@@ -54,47 +54,52 @@ func TestIsCometAPICredential(t *testing.T) {
 	}
 }
 
-func TestIsRealOpenAICredential(t *testing.T) {
+func TestIsDeepSeekModel(t *testing.T) {
 	tests := []struct {
-		name string
-		cred *config.CredentialConfig
-		want bool
+		name    string
+		modelID string
+		want    bool
 	}{
 		{
-			name: "real openai host",
-			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "https://api.openai.com/v1"},
-			want: true,
+			name:    "plain client-facing alias",
+			modelID: "deepseek-v4-flash-0731",
+			want:    true,
 		},
 		{
-			name: "real openai host without scheme",
-			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "api.openai.com"},
-			want: true,
+			name:    "vendor-prefixed on openrouter",
+			modelID: "deepseek/deepseek-v4-flash-0731",
+			want:    true,
 		},
 		{
-			name: "openai-compatible third party (openrouter)",
-			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "https://openrouter.ai/api/v1"},
-			want: false,
+			name:    "policy-aliased on requesty",
+			modelID: "policy/deepseek-v4-flash-0731-ateam",
+			want:    true,
 		},
 		{
-			name: "openai-compatible third party (deepinfra)",
-			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "https://api.deepinfra.com/v1"},
-			want: false,
+			name:    "differently-cased on deepinfra",
+			modelID: "deepseek-ai/DeepSeek-V4-Flash-0731",
+			want:    true,
 		},
 		{
-			name: "wrong provider type on openai.com host",
-			cred: &config.CredentialConfig{Type: config.ProviderTypeAnthropic, BaseURL: "https://api.openai.com/v1"},
-			want: false,
+			name:    "unrelated model on the same OpenAI-compatible credential",
+			modelID: "glm-5.3",
+			want:    false,
 		},
 		{
-			name: "nil credential",
-			cred: nil,
-			want: false,
+			name:    "real openai model",
+			modelID: "gpt-5.6-sol",
+			want:    false,
+		},
+		{
+			name:    "empty",
+			modelID: "",
+			want:    false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isRealOpenAICredential(tt.cred))
+			assert.Equal(t, tt.want, isDeepSeekModel(tt.modelID))
 		})
 	}
 }

--- a/internal/proxy/cometapi_test.go
+++ b/internal/proxy/cometapi_test.go
@@ -54,6 +54,51 @@ func TestIsCometAPICredential(t *testing.T) {
 	}
 }
 
+func TestIsRealOpenAICredential(t *testing.T) {
+	tests := []struct {
+		name string
+		cred *config.CredentialConfig
+		want bool
+	}{
+		{
+			name: "real openai host",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "https://api.openai.com/v1"},
+			want: true,
+		},
+		{
+			name: "real openai host without scheme",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "api.openai.com"},
+			want: true,
+		},
+		{
+			name: "openai-compatible third party (openrouter)",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "https://openrouter.ai/api/v1"},
+			want: false,
+		},
+		{
+			name: "openai-compatible third party (deepinfra)",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeOpenAI, BaseURL: "https://api.deepinfra.com/v1"},
+			want: false,
+		},
+		{
+			name: "wrong provider type on openai.com host",
+			cred: &config.CredentialConfig{Type: config.ProviderTypeAnthropic, BaseURL: "https://api.openai.com/v1"},
+			want: false,
+		},
+		{
+			name: "nil credential",
+			cred: nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isRealOpenAICredential(tt.cred))
+		})
+	}
+}
+
 func TestAppendResponseBodyForLogs_CometKeepsMaskedFlagAndLogsBody(t *testing.T) {
 	cred := &config.CredentialConfig{Type: config.ProviderTypeCometAPI}
 	body := `{"error":{"code":"permission_denied","message":"` + strings.Repeat("model access denied ", 50) + `","type":"comet_api_error"}}`

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -384,7 +384,14 @@ func (p *Proxy) prepareRequestForCredential(
 		return req, nil
 	}
 	if !isResponsesAPI {
-		req.body = openai.ReplaceBodyParam(realModelID, body)
+		// Normalize "developer" role here too, not just in the Responses→Chat
+		// converter: a client can send an already Chat-Completions-shaped body
+		// straight to /v1/chat/completions (or an SDK can emit "developer" for
+		// reasoning models), and this path never goes through that converter.
+		// proxyBody must stay in sync with body: TryFallbackProxy forwards
+		// proxyBody, not body, to fallback credentials.
+		req.body = openai.NormalizeDeveloperRole(openai.ReplaceBodyParam(realModelID, body))
+		req.proxyBody = openai.NormalizeDeveloperRole(proxyBody)
 		return req, nil
 	}
 

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -388,10 +388,21 @@ func (p *Proxy) prepareRequestForCredential(
 		// converter: a client can send an already Chat-Completions-shaped body
 		// straight to /v1/chat/completions (or an SDK can emit "developer" for
 		// reasoning models), and this path never goes through that converter.
+		// Skip real OpenAI destinations: "developer" exists specifically for
+		// OpenAI's own reasoning models, and reports on whether OpenAI treats
+		// a plain "system" as a true equivalent for them are inconsistent —
+		// only rewrite it for OpenAI-wire-compatible third-party backends
+		// (DeepSeek via OpenRouter/Requesty/etc.) that reject "developer"
+		// outright and have no stake in preserving the distinction.
 		// proxyBody must stay in sync with body: TryFallbackProxy forwards
 		// proxyBody, not body, to fallback credentials.
-		req.body = openai.NormalizeDeveloperRole(openai.ReplaceBodyParam(realModelID, body))
-		req.proxyBody = openai.NormalizeDeveloperRole(proxyBody)
+		normalizedBody, normalizedProxyBody := body, proxyBody
+		if !isRealOpenAICredential(cred) {
+			normalizedBody = openai.NormalizeDeveloperRole(body)
+			normalizedProxyBody = openai.NormalizeDeveloperRole(proxyBody)
+		}
+		req.body = openai.ReplaceBodyParam(realModelID, normalizedBody)
+		req.proxyBody = normalizedProxyBody
 		return req, nil
 	}
 

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -388,16 +388,17 @@ func (p *Proxy) prepareRequestForCredential(
 		// converter: a client can send an already Chat-Completions-shaped body
 		// straight to /v1/chat/completions (or an SDK can emit "developer" for
 		// reasoning models), and this path never goes through that converter.
-		// Skip real OpenAI destinations: "developer" exists specifically for
-		// OpenAI's own reasoning models, and reports on whether OpenAI treats
-		// a plain "system" as a true equivalent for them are inconsistent —
-		// only rewrite it for OpenAI-wire-compatible third-party backends
-		// (DeepSeek via OpenRouter/Requesty/etc.) that reject "developer"
-		// outright and have no stake in preserving the distinction.
+		// Scoped to DeepSeek specifically (by model ID, not credential — the
+		// same OpenRouter/Requesty/DeepInfra/etc. credential also serves many
+		// other models): that's the only backend this rejection has actually
+		// been confirmed on. "developer" exists for OpenAI's own reasoning
+		// models in the first place, and reports on whether OpenAI treats a
+		// plain "system" as a true equivalent for them are inconsistent, so
+		// nothing else is touched until confirmed to need it too.
 		// proxyBody must stay in sync with body: TryFallbackProxy forwards
 		// proxyBody, not body, to fallback credentials.
 		normalizedBody, normalizedProxyBody := body, proxyBody
-		if !isRealOpenAICredential(cred) {
+		if isDeepSeekModel(realModelID) || isDeepSeekModel(modelID) {
 			normalizedBody = openai.NormalizeDeveloperRole(body)
 			normalizedProxyBody = openai.NormalizeDeveloperRole(proxyBody)
 		}

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -412,6 +412,50 @@ func TestPrepareRequestForCredential_ProxyBodyKeepsOriginalParams(t *testing.T) 
 	require.Contains(t, forwarded, "temperature")
 }
 
+// TestPrepareRequestForCredential_ChatCompletionsNormalizesDeveloperRole
+// reproduces a real production failure: a client sends an already
+// Chat-Completions-shaped body straight to /v1/chat/completions with a
+// "developer"-role message (this path never goes through the Responses→Chat
+// converter, which already handles this rename). Most OpenAI-compatible
+// backends reached this way (DeepSeek, etc.) reject "developer" outright, so
+// both body and proxyBody must be normalized — proxyBody must stay in sync
+// with body since TryFallbackProxy forwards proxyBody, not body, to fallback
+// credentials.
+func TestPrepareRequestForCredential_ChatCompletionsNormalizesDeveloperRole(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	cred := config.CredentialConfig{Name: "deepseek-via-openrouter", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "http://openrouter.local", RPM: 100}
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	body := []byte(`{"model":"deepseek-v4-flash-0731","messages":[{"role":"developer","content":"You are a pirate."},{"role":"user","content":"Hello"}]}`)
+	proxyBody := []byte(`{"model":"deepseek-v4-flash-0731-alias","messages":[{"role":"developer","content":"You are a pirate."},{"role":"user","content":"Hello"}]}`)
+
+	prepared, err := prx.prepareRequestForCredential(
+		req,
+		body,
+		proxyBody,
+		"deepseek-v4-flash-0731-alias",
+		"deepseek-v4-flash-0731",
+		"/v1/chat/completions",
+		false,
+		&cred,
+		false,
+		false,
+		false,
+	)
+
+	require.NoError(t, err)
+
+	var direct map[string]interface{}
+	require.NoError(t, json.Unmarshal(prepared.body, &direct))
+	directMessages := direct["messages"].([]interface{})
+	require.Equal(t, "system", directMessages[0].(map[string]interface{})["role"])
+
+	var forwarded map[string]interface{}
+	require.NoError(t, json.Unmarshal(prepared.proxyBody, &forwarded))
+	forwardedMessages := forwarded["messages"].([]interface{})
+	require.Equal(t, "system", forwardedMessages[0].(map[string]interface{})["role"],
+		"proxyBody must also be normalized, or a fallback credential would hit the same rejection")
+}
+
 func TestPrepareRequestForCredential_MessagesKeepsOriginalProxyRequest(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	cred := config.CredentialConfig{Name: "openai", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "http://openai.local", RPM: 100}

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -456,6 +456,46 @@ func TestPrepareRequestForCredential_ChatCompletionsNormalizesDeveloperRole(t *t
 		"proxyBody must also be normalized, or a fallback credential would hit the same rejection")
 }
 
+// TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForRealOpenAI
+// verifies the normalization is skipped for a genuine OpenAI credential
+// (api.openai.com): "developer" exists specifically for OpenAI's own
+// reasoning models, so a client that deliberately sent it must not have it
+// silently rewritten to "system" for that destination.
+func TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForRealOpenAI(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	cred := config.CredentialConfig{Name: "openai-real", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "https://api.openai.com/v1", RPM: 100}
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	body := []byte(`{"model":"gpt-5.6-sol","messages":[{"role":"developer","content":"You are a pirate."},{"role":"user","content":"Hello"}]}`)
+	proxyBody := []byte(`{"model":"gpt-5.6-sol-alias","messages":[{"role":"developer","content":"You are a pirate."},{"role":"user","content":"Hello"}]}`)
+
+	prepared, err := prx.prepareRequestForCredential(
+		req,
+		body,
+		proxyBody,
+		"gpt-5.6-sol-alias",
+		"gpt-5.6-sol",
+		"/v1/chat/completions",
+		false,
+		&cred,
+		false,
+		false,
+		false,
+	)
+
+	require.NoError(t, err)
+
+	var direct map[string]interface{}
+	require.NoError(t, json.Unmarshal(prepared.body, &direct))
+	directMessages := direct["messages"].([]interface{})
+	require.Equal(t, "developer", directMessages[0].(map[string]interface{})["role"],
+		"a real OpenAI destination must keep the client's own developer role untouched")
+
+	var forwarded map[string]interface{}
+	require.NoError(t, json.Unmarshal(prepared.proxyBody, &forwarded))
+	forwardedMessages := forwarded["messages"].([]interface{})
+	require.Equal(t, "developer", forwardedMessages[0].(map[string]interface{})["role"])
+}
+
 func TestPrepareRequestForCredential_MessagesKeepsOriginalProxyRequest(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	cred := config.CredentialConfig{Name: "openai", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "http://openai.local", RPM: 100}

--- a/internal/proxy/orchestrator_test.go
+++ b/internal/proxy/orchestrator_test.go
@@ -457,10 +457,10 @@ func TestPrepareRequestForCredential_ChatCompletionsNormalizesDeveloperRole(t *t
 }
 
 // TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForRealOpenAI
-// verifies the normalization is skipped for a genuine OpenAI credential
-// (api.openai.com): "developer" exists specifically for OpenAI's own
-// reasoning models, so a client that deliberately sent it must not have it
-// silently rewritten to "system" for that destination.
+// verifies the normalization is skipped for a genuine OpenAI model
+// (gpt-5.6-sol, not DeepSeek): "developer" exists specifically for OpenAI's
+// own reasoning models, so a client that deliberately sent it must not have
+// it silently rewritten to "system".
 func TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForRealOpenAI(t *testing.T) {
 	prx := NewTestProxyBuilder().Build()
 	cred := config.CredentialConfig{Name: "openai-real", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "https://api.openai.com/v1", RPM: 100}
@@ -494,6 +494,39 @@ func TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForRea
 	require.NoError(t, json.Unmarshal(prepared.proxyBody, &forwarded))
 	forwardedMessages := forwarded["messages"].([]interface{})
 	require.Equal(t, "developer", forwardedMessages[0].(map[string]interface{})["role"])
+}
+
+// TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForNonDeepSeekModel
+// verifies the fix is scoped to DeepSeek specifically, not to "anything
+// that isn't real OpenAI": another model (glm-5.3) reached through the very
+// same OpenAI-compatible OpenRouter credential must keep "developer"
+// untouched too, since this rejection has only been confirmed for DeepSeek.
+func TestPrepareRequestForCredential_ChatCompletionsPreservesDeveloperRoleForNonDeepSeekModel(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	cred := config.CredentialConfig{Name: "openrouter", Type: config.ProviderTypeOpenAI, APIKey: "key", BaseURL: "https://openrouter.ai/api/v1", RPM: 100}
+	req := httptest.NewRequest("POST", "/v1/chat/completions", nil)
+	body := []byte(`{"model":"glm-5.3","messages":[{"role":"developer","content":"You are a pirate."},{"role":"user","content":"Hello"}]}`)
+
+	prepared, err := prx.prepareRequestForCredential(
+		req,
+		body,
+		body,
+		"z-ai/glm-5.3",
+		"z-ai/glm-5.3",
+		"/v1/chat/completions",
+		false,
+		&cred,
+		false,
+		false,
+		false,
+	)
+
+	require.NoError(t, err)
+
+	var direct map[string]interface{}
+	require.NoError(t, json.Unmarshal(prepared.body, &direct))
+	directMessages := direct["messages"].([]interface{})
+	require.Equal(t, "developer", directMessages[0].(map[string]interface{})["role"])
 }
 
 func TestPrepareRequestForCredential_MessagesKeepsOriginalProxyRequest(t *testing.T) {

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -69,6 +69,17 @@ func isCometAPICredential(cred *config.CredentialConfig) bool {
 		strings.Contains(name, "comet-api")
 }
 
+// isRealOpenAICredential reports whether cred talks to OpenAI's own API
+// (api.openai.com), as opposed to a third-party backend merely using
+// ProviderTypeOpenAI's wire-compatible protocol (DeepSeek via OpenRouter/
+// Requesty/DeepInfra, Alibaba DashScope's compatible-mode endpoint, etc.).
+func isRealOpenAICredential(cred *config.CredentialConfig) bool {
+	if cred == nil || cred.Type != config.ProviderTypeOpenAI {
+		return false
+	}
+	return isProviderHost(cred.BaseURL, "openai.com")
+}
+
 func isProviderHost(rawBaseURL, domain string) bool {
 	baseURL := strings.TrimSpace(rawBaseURL)
 	domain = strings.TrimSuffix(strings.ToLower(strings.TrimSpace(domain)), ".")

--- a/internal/proxy/proxy_log.go
+++ b/internal/proxy/proxy_log.go
@@ -69,15 +69,17 @@ func isCometAPICredential(cred *config.CredentialConfig) bool {
 		strings.Contains(name, "comet-api")
 }
 
-// isRealOpenAICredential reports whether cred talks to OpenAI's own API
-// (api.openai.com), as opposed to a third-party backend merely using
-// ProviderTypeOpenAI's wire-compatible protocol (DeepSeek via OpenRouter/
-// Requesty/DeepInfra, Alibaba DashScope's compatible-mode endpoint, etc.).
-func isRealOpenAICredential(cred *config.CredentialConfig) bool {
-	if cred == nil || cred.Type != config.ProviderTypeOpenAI {
-		return false
-	}
-	return isProviderHost(cred.BaseURL, "openai.com")
+// isDeepSeekModel reports whether modelID identifies a DeepSeek model,
+// regardless of which OpenAI-compatible backend it's reached through —
+// vendor-prefixed ("deepseek/deepseek-v4-flash-0731" on OpenRouter),
+// policy-aliased ("policy/deepseek-v4-flash-0731-ateam" on Requesty),
+// differently-cased ("deepseek-ai/DeepSeek-V4-Flash-0731" on DeepInfra), or
+// a plain client-facing alias ("deepseek-v4-flash-0731"). The "developer"
+// role rejection this gates has only been confirmed reproduced for
+// DeepSeek; other models reached through the same generic OpenAI-compatible
+// credentials are left untouched until confirmed to need it too.
+func isDeepSeekModel(modelID string) bool {
+	return strings.Contains(strings.ToLower(modelID), "deepseek")
 }
 
 func isProviderHost(rawBaseURL, domain string) bool {


### PR DESCRIPTION
## Summary
- PR #175 fixed the "developer" role rejection (most Chat-Completions-only backends, e.g. DeepSeek, reject it outright) — but only inside the Responses API → Chat Completions converter (`RequestToChat`).
- A client sending an already Chat-Completions-shaped body straight to `/v1/chat/completions` never goes through that converter at all, so `role: "developer"` reaches these providers unmodified and fails every time.
- Reproduced live: 18/20 requests with `role: "developer"` via `/v1/chat/completions` on `deepseek-v4-flash-0731` failed with 400; the other 2 were unrelated rate limits. 0 successes.

## Fix
- Added `openai.NormalizeDeveloperRole(body []byte) []byte` — walks a Chat Completions `messages` array and downgrades any `role: "developer"` to `role: "system"`, mirroring the exact rename already applied in `converter/responses.convertMessage`.
- Applied it to both `body` and `proxyBody` in the native (non-Responses-API) branch of `prepareRequestForCredential` — `proxyBody` must stay in sync since `TryFallbackProxy` forwards `proxyBody`, not `body`, to fallback credentials (same class of bug fixed in PR #178).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite)
- [x] `TestNormalizeDeveloperRole_DowngradesToSystem` / `_LeavesOtherRolesUntouched` / `_NoMessagesArray` (converter unit tests)
- [x] `TestPrepareRequestForCredential_ChatCompletionsNormalizesDeveloperRole` — end-to-end, proves both `body` and `proxyBody` get normalized