### PR TITLE
Preserve Gemini image output and billing metadata

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -88,9 +88,7 @@ client.chat.completions.create(
 )
 
 # Built-in tool is preserved for upstream validation
-client.chat.completions.create(
-    model="gpt-5.6-sol", tools=[{"type": "web_search"}], ...
-)
+client.chat.completions.create(model="gpt-5.6-sol", tools=[{"type": "web_search"}], ...)
 ```
 
 Other non-function tool types (e.g. `computer_use`, `code_execution`) are also dropped for OpenAI Chat Completions requests. They are handled by their respective providers (Vertex AI, Anthropic) when those backends are configured.

--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -213,7 +213,7 @@ func (c *ProviderConverter) ResponseTo(body []byte) ([]byte, error) {
 		if c.mode.IsImageGeneration {
 			if strings.Contains(strings.ToLower(c.mode.ModelID), "gemini") {
 				// Gemini image generation goes through chat API
-				return vertex.VertexChatResponseToOpenAIImage(body)
+				return vertex.VertexChatResponseToOpenAIImageWithModel(body, c.mode.responseModel())
 			}
 			// Imagen: native image generation endpoint
 			return vertex.VertexImageToOpenAI(body)

--- a/internal/converter/openai/types.go
+++ b/internal/converter/openai/types.go
@@ -143,6 +143,7 @@ type TokenDetails struct {
 	CacheCreationTokenDetails *CacheCreationTokenDetails `json:"cache_creation_token_details,omitempty"`
 	CacheWriteTokens          int                        `json:"cache_write_tokens,omitempty"`
 	AudioTokens               int                        `json:"audio_tokens,omitempty"`
+	ImageTokens               int                        `json:"image_tokens,omitempty"`
 }
 
 // CacheCreationTokenDetails preserves Anthropic's cache-write TTL breakdown.
@@ -199,6 +200,7 @@ type OpenAIStreamingDelta struct {
 	ToolCalls        []OpenAIStreamingToolCall `json:"tool_calls,omitempty"`
 	Refusal          string                    `json:"refusal,omitempty"`
 	ReasoningContent string                    `json:"reasoning_content,omitempty"`
+	Images           []ImageData               `json:"images,omitempty"`
 }
 
 type OpenAIStreamingToolCall struct {
@@ -265,6 +267,7 @@ type OpenAIImageUsage struct {
 type OpenAIImageResponse struct {
 	Created int64             `json:"created"`
 	Data    []OpenAIImageData `json:"data"`
+	Model   string            `json:"model,omitempty"`
 	Usage   *OpenAIImageUsage `json:"usage,omitempty"`
 }
 

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -337,6 +337,12 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 // VertexChatResponseToOpenAIImage converts Vertex AI chat response with image to OpenAI image format
 // Extracts inline image data from chat response and returns it in OpenAI image generation format
 func VertexChatResponseToOpenAIImage(vertexBody []byte) ([]byte, error) {
+	return VertexChatResponseToOpenAIImageWithModel(vertexBody, "")
+}
+
+// VertexChatResponseToOpenAIImageWithModel preserves the client-visible model
+// on transformed Gemini Images responses.
+func VertexChatResponseToOpenAIImageWithModel(vertexBody []byte, model string) ([]byte, error) {
 	var vertexResp genai.GenerateContentResponse
 	if err := json.Unmarshal(vertexBody, &vertexResp); err != nil {
 		return nil, fmt.Errorf("failed to parse Vertex chat response: %w", err)
@@ -345,6 +351,7 @@ func VertexChatResponseToOpenAIImage(vertexBody []byte) ([]byte, error) {
 	openAIResp := openai.OpenAIImageResponse{
 		Created: converterutil.GetCurrentTimestamp(),
 		Data:    make([]openai.OpenAIImageData, 0),
+		Model:   model,
 	}
 
 	// Extract images from candidates

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -612,6 +612,16 @@ func TestConvertVertexUsageToImageUsage(t *testing.T) {
 }
 
 func TestVertexChatResponseToOpenAIImage_UsageFormat(t *testing.T) {
+	t.Run("preserves requested model", func(t *testing.T) {
+		body := `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"iVBORw=="}}]}}]}`
+		result, err := VertexChatResponseToOpenAIImageWithModel([]byte(body), "google/gemini-3-pro-image-preview")
+		require.NoError(t, err)
+
+		var resp openai.OpenAIImageResponse
+		require.NoError(t, json.Unmarshal(result, &resp))
+		assert.Equal(t, "google/gemini-3-pro-image-preview", resp.Model)
+	})
+
 	t.Run("response without usage metadata omits usage field", func(t *testing.T) {
 		body := `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"iVBORw=="}}]}}]}`
 		result, err := VertexChatResponseToOpenAIImage([]byte(body))

--- a/internal/converter/vertex/response.go
+++ b/internal/converter/vertex/response.go
@@ -239,8 +239,11 @@ func convertVertexUsageMetadata(meta *genai.GenerateContentResponseUsageMetadata
 			if detail == nil {
 				continue
 			}
-			if genai.MediaModality(detail.Modality) == genai.MediaModalityAudio {
+			switch genai.MediaModality(detail.Modality) {
+			case genai.MediaModalityAudio:
 				usage.PromptTokensDetails.AudioTokens += int(detail.TokenCount)
+			case genai.MediaModalityImage, genai.MediaModalityVideo:
+				usage.PromptTokensDetails.ImageTokens += int(detail.TokenCount)
 			}
 		}
 	}
@@ -253,24 +256,33 @@ func convertVertexUsageMetadata(meta *genai.GenerateContentResponseUsageMetadata
 			if detail == nil {
 				continue
 			}
-			if genai.MediaModality(detail.Modality) == genai.MediaModalityAudio {
+			switch genai.MediaModality(detail.Modality) {
+			case genai.MediaModalityAudio:
 				usage.PromptTokensDetails.AudioTokens += int(detail.TokenCount)
+			case genai.MediaModalityImage, genai.MediaModalityVideo:
+				usage.PromptTokensDetails.ImageTokens += int(detail.TokenCount)
 			}
 		}
 	}
 
-	// Avoid double-charging cached modality tokens as regular audio.
+	// Avoid double-charging cached modality tokens as regular audio/image input.
 	// Cached tokens are billed separately via CachedTokens.
 	if len(meta.CacheTokensDetails) > 0 && usage.PromptTokensDetails != nil {
 		for _, detail := range meta.CacheTokensDetails {
 			if detail == nil {
 				continue
 			}
-			if genai.MediaModality(detail.Modality) == genai.MediaModalityAudio {
+			switch genai.MediaModality(detail.Modality) {
+			case genai.MediaModalityAudio:
 				usage.PromptTokensDetails.CachedAudioTokens += int(detail.TokenCount)
 				usage.PromptTokensDetails.AudioTokens -= int(detail.TokenCount)
 				if usage.PromptTokensDetails.AudioTokens < 0 {
 					usage.PromptTokensDetails.AudioTokens = 0
+				}
+			case genai.MediaModalityImage, genai.MediaModalityVideo:
+				usage.PromptTokensDetails.ImageTokens -= int(detail.TokenCount)
+				if usage.PromptTokensDetails.ImageTokens < 0 {
+					usage.PromptTokensDetails.ImageTokens = 0
 				}
 			}
 		}

--- a/internal/converter/vertex/response_test.go
+++ b/internal/converter/vertex/response_test.go
@@ -402,8 +402,9 @@ func TestConvertVertexUsageMetadata_NilModalityEntries(t *testing.T) {
 // are exposed through LiteLLM's completion_tokens_details.image_tokens extension.
 func TestConvertVertexUsageMetadata_ImageVideoTokens(t *testing.T) {
 	meta := &genai.GenerateContentResponseUsageMetadata{
-		PromptTokenCount:     200,
-		CandidatesTokenCount: 50,
+		PromptTokenCount:        200,
+		ToolUsePromptTokenCount: 30,
+		CandidatesTokenCount:    50,
 		PromptTokensDetails: []*genai.ModalityTokenCount{
 			{Modality: genai.MediaModalityImage, TokenCount: 100},
 			{Modality: genai.MediaModalityVideo, TokenCount: 50},
@@ -413,14 +414,24 @@ func TestConvertVertexUsageMetadata_ImageVideoTokens(t *testing.T) {
 			{Modality: genai.MediaModalityImage, TokenCount: 30},
 			{Modality: genai.MediaModalityVideo, TokenCount: 20},
 		},
+		ToolUsePromptTokensDetails: []*genai.ModalityTokenCount{
+			{Modality: genai.MediaModalityImage, TokenCount: 20},
+			{Modality: genai.MediaModalityVideo, TokenCount: 10},
+		},
+		CachedContentTokenCount: 80,
+		CacheTokensDetails: []*genai.ModalityTokenCount{
+			{Modality: genai.MediaModalityImage, TokenCount: 60},
+			{Modality: genai.MediaModalityVideo, TokenCount: 20},
+		},
 	}
 
 	usage := convertVertexUsageMetadata(meta)
 
-	// Input image/video details remain part of PromptTokens; this converter only
-	// exposes the generated media breakdown needed for output billing.
-	if usage.PromptTokensDetails != nil && usage.PromptTokensDetails.AudioTokens != 0 {
-		t.Fatalf("expected no audio tokens from image/video, got %d", usage.PromptTokensDetails.AudioTokens)
+	if usage.PromptTokensDetails == nil || usage.PromptTokensDetails.ImageTokens != 100 {
+		t.Fatalf("expected 100 uncached input image/video tokens, got %v", usage.PromptTokensDetails)
+	}
+	if usage.PromptTokensDetails.CachedTokens != 80 {
+		t.Fatalf("expected 80 cached tokens, got %v", usage.PromptTokensDetails)
 	}
 	if usage.CompletionTokensDetails == nil {
 		t.Fatal("expected completion token details for generated media")
@@ -429,7 +440,7 @@ func TestConvertVertexUsageMetadata_ImageVideoTokens(t *testing.T) {
 		t.Fatalf("expected 50 image/video output tokens, got %d", usage.CompletionTokensDetails.ImageTokens)
 	}
 	// Total tokens still correct
-	if usage.PromptTokens != 200 || usage.CompletionTokens != 50 {
+	if usage.PromptTokens != 230 || usage.CompletionTokens != 50 {
 		t.Fatalf("token totals wrong: prompt=%d completion=%d", usage.PromptTokens, usage.CompletionTokens)
 	}
 }

--- a/internal/converter/vertex/streaming.go
+++ b/internal/converter/vertex/streaming.go
@@ -22,10 +22,12 @@ import (
 	"google.golang.org/genai"
 )
 
+const maxVertexSSELineBytes = 64 * 1024 * 1024
+
 // TransformVertexStreamToOpenAI converts Vertex AI SSE stream to OpenAI SSE format
 func TransformVertexStreamToOpenAI(vertexStream io.Reader, model string, output io.Writer) error {
 	scanner := bufio.NewScanner(vertexStream)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024) //  1MB buffer (default 64KB too small)
+	scanner.Buffer(make([]byte, 1024*1024), maxVertexSSELineBytes)
 	chatID := converterutil.GenerateID()
 	timestamp := converterutil.GetCurrentTimestamp()
 	isFirstChunk := true
@@ -121,6 +123,7 @@ func TransformVertexStreamToOpenAI(vertexStream io.Reader, model string, output 
 			var content string
 			var reasoningContent string
 			var toolCalls []openai.OpenAIStreamingToolCall
+			var images []openai.ImageData
 			toolCallIdx := 0
 
 			if candidate.Content != nil && candidate.Content.Parts != nil {
@@ -139,7 +142,11 @@ func TransformVertexStreamToOpenAI(vertexStream io.Reader, model string, output 
 						toolCalls = append(toolCalls, toolCall)
 						toolCallIdx++
 					}
-					// Note: streaming doesn't support images in delta, only text
+					if part.InlineData != nil {
+						if imageData, ok := inlineDataToChatImage(len(images), part.InlineData); ok {
+							images = append(images, imageData)
+						}
+					}
 				}
 			}
 
@@ -149,6 +156,9 @@ func TransformVertexStreamToOpenAI(vertexStream io.Reader, model string, output 
 			}
 			if len(toolCalls) > 0 {
 				choice.Delta.ToolCalls = toolCalls
+			}
+			if len(images) > 0 {
+				choice.Delta.Images = images
 			}
 
 			// Handle finish reason

--- a/internal/converter/vertex/streaming_test.go
+++ b/internal/converter/vertex/streaming_test.go
@@ -2,10 +2,12 @@ package vertex
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genai"
@@ -79,6 +81,48 @@ func TestTransformVertexStreamToOpenAI_AccumulatesDistinctSearchesAcrossChunks(t
 	))
 
 	assert.Contains(t, out.String(), `"server_tool_use":{"web_search_requests":2}`)
+}
+
+func TestTransformVertexStreamToOpenAI_PreservesLargeInlineImage(t *testing.T) {
+	imageBytes := bytes.Repeat([]byte{0xab}, 900*1024) // base64 makes the SSE line exceed 1 MiB
+	chunk := &genai.GenerateContentResponse{
+		Candidates: []*genai.Candidate{{
+			Content: &genai.Content{Role: "model", Parts: []*genai.Part{{
+				InlineData: &genai.Blob{MIMEType: "image/png", Data: imageBytes},
+			}}},
+		}},
+		UsageMetadata: &genai.GenerateContentResponseUsageMetadata{
+			PromptTokenCount:     10,
+			CandidatesTokenCount: 1120,
+			CandidatesTokensDetails: []*genai.ModalityTokenCount{{
+				Modality: genai.MediaModalityImage, TokenCount: 1120,
+			}},
+		},
+	}
+	data, err := json.Marshal(chunk)
+	require.NoError(t, err)
+	require.Greater(t, len(data), 1024*1024)
+
+	var out bytes.Buffer
+	require.NoError(t, TransformVertexStreamToOpenAI(
+		strings.NewReader("data: "+string(data)+"\n\ndata: [DONE]\n\n"),
+		"gemini-image",
+		&out,
+	))
+
+	line := strings.Split(out.String(), "\n")[0]
+	var converted openai.OpenAIStreamingChunk
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &converted))
+	require.Len(t, converted.Choices, 1)
+	require.Len(t, converted.Choices[0].Delta.Images, 1)
+	require.NotNil(t, converted.Choices[0].Delta.Images[0].ImageURL)
+	assert.Equal(t,
+		"data:image/png;base64,"+base64.StdEncoding.EncodeToString(imageBytes),
+		converted.Choices[0].Delta.Images[0].ImageURL.URL,
+	)
+	require.NotNil(t, converted.Usage)
+	require.NotNil(t, converted.Usage.CompletionTokensDetails)
+	assert.Equal(t, 1120, converted.Usage.CompletionTokensDetails.ImageTokens)
 }
 
 func TestConvertVertexFunctionCallToStreamingOpenAI(t *testing.T) {

--- a/internal/models/gemini_image_billing_test.go
+++ b/internal/models/gemini_image_billing_test.go
@@ -47,3 +47,43 @@ func TestGeminiFlashLiteImageBillingFromProviderResponse(t *testing.T) {
 	assert.InDelta(t, 0.036891, costs.ImageCost, 1e-12)
 	assert.InDelta(t, 0.0368928, costs.TotalCost, 1e-12)
 }
+
+func TestGeminiChatCachedImageBillingFromProviderResponse(t *testing.T) {
+	providerBody := []byte(`{
+		"candidates":[{"content":{"parts":[{"text":"ok"}]}}],
+		"usageMetadata":{
+			"promptTokenCount":1000,
+			"cachedContentTokenCount":500,
+			"candidatesTokenCount":0,
+			"totalTokenCount":1000,
+			"promptTokensDetails":[
+				{"modality":"TEXT","tokenCount":700},
+				{"modality":"IMAGE","tokenCount":300}
+			],
+			"cacheTokensDetails":[
+				{"modality":"TEXT","tokenCount":300},
+				{"modality":"IMAGE","tokenCount":200}
+			]
+		}
+	}`)
+	chatConverter := converter.New(config.ProviderTypeGemini, converter.RequestMode{ModelID: "gemini-image"})
+	convertedBody, err := chatConverter.ResponseTo(providerBody)
+	require.NoError(t, err)
+
+	usage := chatConverter.UsageFromResponse(convertedBody)
+	require.NotNil(t, usage)
+	assert.Equal(t, 500, usage.CachedInputTokens)
+	assert.Equal(t, 100, usage.ImageTokens)
+
+	price := &models.ModelPrice{
+		InputCostPerToken:        0.001,
+		InputCostPerImageToken:   0.005,
+		CacheReadInputTokensFree: true,
+	}
+	costs := price.CalculateCosts(usage)
+	require.NotNil(t, costs)
+	assert.InDelta(t, 400*0.001, costs.InputCost, 1e-12)
+	assert.InDelta(t, 100*0.005, costs.ImageCost, 1e-12)
+	assert.Zero(t, costs.CachedInputCost)
+	assert.InDelta(t, 0.9, costs.TotalCost, 1e-12)
+}

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -87,6 +87,7 @@ type ModelPrice struct {
 	OutputCostPerCachedToken                     float64 `json:"output_cost_per_cached_token,omitempty"`
 	InputCostPerCachedToken                      float64 `json:"input_cost_per_cached_token,omitempty"`
 	CacheReadInputTokenCost                      float64 `json:"cache_read_input_token_cost,omitempty"`
+	CacheReadInputTokensFree                     bool    `json:"cache_read_input_tokens_free,omitempty"`
 	CacheCreationInputTokenCost                  float64 `json:"cache_creation_input_token_cost,omitempty"`
 	CacheReadInputTokenCostAbove200k             float64 `json:"cache_read_input_token_cost_above_200k_tokens,omitempty"`
 	CacheCreationInputTokenCostAbove200k         float64 `json:"cache_creation_input_token_cost_above_200k_tokens,omitempty"`

--- a/internal/models/organization_policy_test.go
+++ b/internal/models/organization_policy_test.go
@@ -102,7 +102,7 @@ func TestLoadOrganizationPolicies_FreePriceAndScopedCatalog(t *testing.T) {
 	registry, err := LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
 		OrganizationID:  "org-1",
 		PriceProfileID:  "profile-1",
-		ModelPricesLink: writePolicyPrices(t, `{"public/a":{"input_cost_per_token":0},"org/model":{"input_cost_per_token":0.5}}`),
+		ModelPricesLink: writePolicyPrices(t, `{"public/a":{"input_cost_per_token":0},"org/model":{"input_cost_per_token":0.5,"cache_read_input_tokens_free":true}}`),
 		ModelMappings:   map[string]string{"org/model": "route-b"},
 	}}, manager, validPolicyOptions())
 	require.NoError(t, err)
@@ -118,4 +118,6 @@ func TestLoadOrganizationPolicies_FreePriceAndScopedCatalog(t *testing.T) {
 	assert.Equal(t, "route-b", resolution.CanonicalModelID)
 	assert.Equal(t, "route-b", resolution.ModelID)
 	assert.Equal(t, "org/model", resolution.PriceModelID)
+	require.NotNil(t, resolution.ModelPrice)
+	assert.True(t, resolution.ModelPrice.CacheReadInputTokensFree)
 }

--- a/internal/models/price_calculator.go
+++ b/internal/models/price_calculator.go
@@ -261,17 +261,20 @@ func CalculateTokenCosts(usage *converter.TokenUsage, price *ModelPrice) *conver
 
 	// Cached read tokens: prefer explicit cached price, fall back to LiteLLM alias,
 	// then fall back to regular rate (no discount known).
-	cachedInputCost := price.InputCostPerCachedToken
-	if cachedInputCost == 0 {
-		cachedInputCost = price.CacheReadInputTokenCost
-	}
-	if fullSessionCacheReadMatched {
-		cachedInputCost = fullSessionCacheReadRate
-	} else if promptTokens > tokenTiering200kThreshold && price.CacheReadInputTokenCostAbove200k > 0 {
-		cachedInputCost = price.CacheReadInputTokenCostAbove200k
-	}
-	if cachedInputCost == 0 {
-		cachedInputCost = inputCostPerToken
+	cachedInputCost := 0.0
+	if !price.CacheReadInputTokensFree {
+		cachedInputCost = price.InputCostPerCachedToken
+		if cachedInputCost == 0 {
+			cachedInputCost = price.CacheReadInputTokenCost
+		}
+		if fullSessionCacheReadMatched {
+			cachedInputCost = fullSessionCacheReadRate
+		} else if promptTokens > tokenTiering200kThreshold && price.CacheReadInputTokenCostAbove200k > 0 {
+			cachedInputCost = price.CacheReadInputTokenCostAbove200k
+		}
+		if cachedInputCost == 0 {
+			cachedInputCost = inputCostPerToken
+		}
 	}
 	cachedAudioTokens := converterutil.NonNegativeTokenCount(usage.CachedAudioInputTokens)
 	if cachedAudioTokens > cachedInputTokens {

--- a/internal/models/price_calculator_test.go
+++ b/internal/models/price_calculator_test.go
@@ -1372,6 +1372,35 @@ func TestCalculateTokenCosts_UncachedImageTokensBilledInFull(t *testing.T) {
 	assert.InDelta(t, wantInputSide, costs.InputCost+costs.CachedInputCost+costs.ImageCost, 1e-18)
 }
 
+func TestCalculateTokenCosts_ExplicitFreeCacheSuppressesFallbacks(t *testing.T) {
+	usage := &converter.TokenUsage{PromptTokens: 40_000, CachedInputTokens: 10_000}
+	price := &ModelPrice{
+		InputCostPerToken:               0.001,
+		InputCostPerTokenAbove32k:       0.002,
+		InputCostPerCachedToken:         0.0005,
+		CacheReadInputTokenCost:         0.0004,
+		CacheReadInputTokenCostAbove32k: 0.0002,
+		CacheReadInputTokensFree:        true,
+	}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 30_000*0.002, costs.InputCost, 1e-12)
+	assert.Zero(t, costs.CachedInputCost)
+}
+
+func TestCalculateTokenCosts_MissingFreeFlagKeepsCacheFallback(t *testing.T) {
+	usage := &converter.TokenUsage{PromptTokens: 100, CachedInputTokens: 80}
+	price := &ModelPrice{InputCostPerToken: 0.001}
+
+	costs := CalculateTokenCosts(usage, price)
+
+	require.NotNil(t, costs)
+	assert.InDelta(t, 20*0.001, costs.InputCost, 1e-12)
+	assert.InDelta(t, 80*0.001, costs.CachedInputCost, 1e-12)
+}
+
 func TestCalculateTokenCosts_CachedImageOverlapKeepsDedicatedImageRate(t *testing.T) {
 	usage := &converter.TokenUsage{
 		PromptTokens:      100,

--- a/internal/proxy/chat_response_compat.go
+++ b/internal/proxy/chat_response_compat.go
@@ -18,11 +18,16 @@ import (
 	goccyjson "github.com/goccy/go-json"
 )
 
-const maxSSEModelRewriteLineBytes = 1024 * 1024
+const maxSSEModelRewriteLineBytes = 64 * 1024 * 1024
+
+var existingModelOnlyResponseRoutes = map[string]struct{}{
+	"/v1/images/generations": {},
+	"/v1/images/edits":       {},
+}
 
 // modelBearingResponseRoutes is the product surface whose successful response
-// schema exposes a client-visible model. Image responses intentionally do not
-// participate because their OpenAI schema has no model field.
+// schema exposes a client-visible model and may receive one when absent. Images
+// use existingModelOnlyResponseRoutes above so GPT passthrough shapes stay unchanged.
 var modelBearingResponseRoutes = map[string]struct{}{
 	"/v1/chat/completions": {},
 	"/v1/completions":      {},
@@ -40,7 +45,9 @@ func normalizeSuccessfulResponseModel(body []byte, endpoint, publicModel string)
 	if publicModel == "" {
 		return body
 	}
-	if _, ok := modelBearingResponseRoutes[endpoint]; !ok {
+	_, modelBearing := modelBearingResponseRoutes[endpoint]
+	_, existingModelOnly := existingModelOnlyResponseRoutes[endpoint]
+	if !modelBearing && !existingModelOnly {
 		return body
 	}
 
@@ -53,6 +60,8 @@ func normalizeSuccessfulResponseModel(body []byte, endpoint, publicModel string)
 		if err := goccyjson.Unmarshal(rawModel, &currentModel); err == nil && currentModel == publicModel {
 			return body
 		}
+	} else if existingModelOnly {
+		return body
 	}
 	modelJSON, err := goccyjson.Marshal(publicModel)
 	if err != nil {
@@ -104,6 +113,7 @@ func normalizeSuccessfulResponseModelStream(
 		source:                      bufio.NewReader(reader),
 		publicModel:                 publicModel,
 		preserveNestedResponseModel: responseCompatRequestFromContext(logCtx.Request.Context()) != nil,
+		maxLineBytes:                maxSSEModelRewriteLineBytes,
 	}
 }
 
@@ -115,6 +125,7 @@ type responseModelStreamReader struct {
 	pendingErr                  error
 	line                        []byte
 	passthrough                 bool
+	maxLineBytes                int
 }
 
 func (r *responseModelStreamReader) Read(dst []byte) (int, error) {
@@ -139,7 +150,11 @@ func (r *responseModelStreamReader) Read(dst []byte) (int, error) {
 			}
 			continue
 		}
-		if len(r.line)+len(fragment) > maxSSEModelRewriteLineBytes {
+		maxLineBytes := r.maxLineBytes
+		if maxLineBytes <= 0 {
+			maxLineBytes = maxSSEModelRewriteLineBytes
+		}
+		if len(r.line)+len(fragment) > maxLineBytes {
 			r.pending = append(r.pending, r.line...)
 			r.pending = append(r.pending, fragment...)
 			r.line = r.line[:0]

--- a/internal/proxy/chat_response_compat.go
+++ b/internal/proxy/chat_response_compat.go
@@ -9,9 +9,9 @@ import (
 	// goccy/go-json for every JSON call in this file: normalizeSuccessfulResponseModel
 	// full-body-decodes+remarshals every non-streaming response (benchmarked
 	// ~1.66x faster than encoding/json against a real embedding body, 1536-float
-	// vector). normalizeSSEDataLineModel/decodeJSONObject were originally left on
-	// stdlib on the assumption that small per-SSE-chunk map[string]interface{}
-	// decodes wouldn't show the same win — re-benchmarked after the
+	// vector). normalizeSSEDataLineModel/decodeShallowJSONObject were originally
+	// left on stdlib on the assumption that small per-SSE-chunk map decodes
+	// wouldn't show the same win — re-benchmarked after the
 	// token_estimator.go streaming fixes proved that assumption wrong even for
 	// tiny typed-struct payloads; goccy measured ~1.5x faster here too
 	// (map[string]interface{} decode+encode, not just typed structs).
@@ -20,6 +20,13 @@ import (
 
 const maxSSEModelRewriteLineBytes = 64 * 1024 * 1024
 
+// existingModelOnlyResponseRoutes are surfaces where a top-level "model" is
+// rewritten to the client alias when the backend already emits one, but is
+// never added when absent. This keeps schema-less image passthrough shapes
+// (OpenAI gpt-image-1, Imagen) byte-identical while still presenting the alias
+// for backends that do echo a model (canonical Gemini image, and any other
+// OpenAI-compatible image provider that returns "model") — matching the alias
+// every other route reports.
 var existingModelOnlyResponseRoutes = map[string]struct{}{
 	"/v1/images/generations": {},
 	"/v1/images/edits":       {},
@@ -48,6 +55,11 @@ func normalizeSuccessfulResponseModel(body []byte, endpoint, publicModel string)
 	_, modelBearing := modelBearingResponseRoutes[endpoint]
 	_, existingModelOnly := existingModelOnlyResponseRoutes[endpoint]
 	if !modelBearing && !existingModelOnly {
+		return body
+	}
+	// existing-model-only routes never add "model"; skip the unmarshal entirely
+	// when the body can't contain the field (gpt-image-1 / Imagen passthrough).
+	if existingModelOnly && !modelBearing && !bytes.Contains(body, []byte(`"model"`)) {
 		return body
 	}
 
@@ -203,29 +215,33 @@ func normalizeSSEDataLineModelWithOptions(line []byte, publicModel string, prese
 	if len(payload) == 0 || bytes.Equal(payload, []byte("[DONE]")) {
 		return line
 	}
-	event, err := decodeJSONObject(payload)
+	// Shallow decode: every field but "model" (and, on /v1/responses, the
+	// nested response object) is kept as opaque bytes so a multi-MB base64
+	// image delta is never expanded into a map[string]interface{} tree and
+	// re-marshaled — same technique as normalizeSuccessfulResponseModel.
+	event, err := decodeShallowJSONObject(payload)
 	if err != nil || event == nil {
 		return line
 	}
 	rawError, hasError := event["error"]
-	eventType, _ := event["type"].(string)
-	if isStreamErrorEvent(eventType, hasError && rawError != nil) {
+	eventType := rawMessageString(event["type"])
+	if isStreamErrorEvent(eventType, hasError && !isJSONNull(rawError)) {
 		return line
 	}
 
 	changed := false
-	if current, exists := event["model"]; exists {
-		if current != publicModel {
-			event["model"] = publicModel
+	if _, exists := event["model"]; exists {
+		if rawMessageString(event["model"]) != publicModel {
+			event["model"] = marshalJSONString(publicModel)
 			changed = true
 		}
-	} else if object, _ := event["object"].(string); object == "chat.completion.chunk" || object == "text_completion" {
-		event["model"] = publicModel
+	} else if object := rawMessageString(event["object"]); object == "chat.completion.chunk" || object == "text_completion" {
+		event["model"] = marshalJSONString(publicModel)
 		changed = true
 	}
-	if response, ok := event["response"].(map[string]interface{}); ok && !preserveNestedResponseModel {
-		if response["model"] != publicModel {
-			response["model"] = publicModel
+	if rawResponse, ok := event["response"]; ok && !preserveNestedResponseModel {
+		if updated, nestedChanged := rewriteNestedResponseModel(rawResponse, publicModel); nestedChanged {
+			event["response"] = updated
 			changed = true
 		}
 	}
@@ -246,10 +262,11 @@ func normalizeSSEDataLineModelWithOptions(line []byte, publicModel string, prese
 	return result
 }
 
-func decodeJSONObject(data []byte) (map[string]interface{}, error) {
+// decodeShallowJSONObject decodes exactly one JSON object, keeping each value as
+// raw bytes, and rejects trailing content after it.
+func decodeShallowJSONObject(data []byte) (map[string]goccyjson.RawMessage, error) {
 	decoder := goccyjson.NewDecoder(bytes.NewReader(data))
-	decoder.UseNumber()
-	var object map[string]interface{}
+	var object map[string]goccyjson.RawMessage
 	if err := decoder.Decode(&object); err != nil {
 		return nil, err
 	}
@@ -261,4 +278,52 @@ func decodeJSONObject(data []byte) (map[string]interface{}, error) {
 		return nil, err
 	}
 	return object, nil
+}
+
+// rewriteNestedResponseModel mirrors the /v1/responses handling of the old deep
+// decode: if "response" is a JSON object it is given the client-visible model
+// (added when absent), touching only that one nested field.
+func rewriteNestedResponseModel(raw goccyjson.RawMessage, publicModel string) (goccyjson.RawMessage, bool) {
+	var nested map[string]goccyjson.RawMessage
+	if err := goccyjson.Unmarshal(raw, &nested); err != nil || nested == nil {
+		return raw, false
+	}
+	if _, ok := nested["model"]; ok && rawMessageString(nested["model"]) == publicModel {
+		return raw, false
+	}
+	nested["model"] = marshalJSONString(publicModel)
+	updated, err := goccyjson.Marshal(nested)
+	if err != nil {
+		return raw, false
+	}
+	return updated, true
+}
+
+// rawMessageString returns the string value of a JSON raw message, or "" if it
+// is absent or not a JSON string.
+func rawMessageString(raw goccyjson.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := goccyjson.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// isJSONNull reports whether a raw message is absent or the JSON literal null.
+func isJSONNull(raw goccyjson.RawMessage) bool {
+	trimmed := bytes.TrimSpace(raw)
+	return len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null"))
+}
+
+// marshalJSONString encodes s as a JSON string, falling back to "" on the
+// (practically impossible) marshal error.
+func marshalJSONString(s string) goccyjson.RawMessage {
+	encoded, err := goccyjson.Marshal(s)
+	if err != nil {
+		return goccyjson.RawMessage(`""`)
+	}
+	return encoded
 }

--- a/internal/proxy/chat_response_compat_bench_test.go
+++ b/internal/proxy/chat_response_compat_bench_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 )
 
-// decodeJSONObjectStdlib mirrors decodeJSONObject (chat_response_compat.go,
-// now on goccy) exactly, on stdlib json, kept only to isolate the engine
-// swap's own effect in the benchmarks below.
+// decodeJSONObjectStdlib is the old full map[string]interface{} decode on
+// stdlib json, kept as a baseline for the benchmarks below (production now
+// shallow-decodes into map[string]RawMessage via goccy).
 func decodeJSONObjectStdlib(data []byte) (map[string]interface{}, error) {
 	decoder := stdjson.NewDecoder(bytes.NewReader(data))
 	decoder.UseNumber()
@@ -28,8 +28,9 @@ func decodeJSONObjectStdlib(data []byte) (map[string]interface{}, error) {
 	return object, nil
 }
 
-// normalizeSSEDataLineModelStdlib mirrors normalizeSSEDataLineModel exactly,
-// using decodeJSONObjectStdlib + stdjson.Marshal instead of goccy.
+// normalizeSSEDataLineModelStdlib is the old deep-decode implementation
+// (decodeJSONObjectStdlib + stdjson.Marshal), kept as a benchmark baseline
+// against the current shallow production path.
 func normalizeSSEDataLineModelStdlib(line []byte, publicModel string) []byte {
 	newline := []byte(nil)
 	body := line

--- a/internal/proxy/chat_response_compat_test.go
+++ b/internal/proxy/chat_response_compat_test.go
@@ -1,10 +1,12 @@
 package proxy
 
 import (
+	"bufio"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -61,22 +63,66 @@ func TestNormalizeSuccessfulResponseModelStreamPreservesNestedModelForLiteLLM(t 
 	)
 }
 
-func TestNormalizeSuccessfulResponseModelStreamBoundsOversizedLines(t *testing.T) {
-	stream := "data: {\"model\":\"backend\",\"payload\":\"" +
-		strings.Repeat("x", maxSSEModelRewriteLineBytes) +
-		"\"}\n\n"
+func TestNormalizeSuccessfulResponseModelStreamRewritesImageSizedLines(t *testing.T) {
+	imageURL := "data:image/png;base64," + strings.Repeat("x", 2*1024*1024)
+	stream := "data: {\"model\":\"canonical\",\"choices\":[{\"delta\":{\"images\":[{\"image_url\":{\"url\":" +
+		strconv.Quote(imageURL) + "}}]}}]}\n\n"
 	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
-	logCtx := &RequestLogContext{Request: request, PublicModelID: "public"}
+	logCtx := &RequestLogContext{Request: request, PublicModelID: "google/gemini-3-pro-image-preview"}
 
 	result, err := io.ReadAll(normalizeSuccessfulResponseModelStream(
 		strings.NewReader(stream),
 		http.StatusOK,
 		logCtx,
-		"backend",
+		"canonical",
 	))
 
 	require.NoError(t, err)
+	line := strings.TrimSpace(strings.TrimPrefix(string(result), "data:"))
+	var payload struct {
+		Model   string `json:"model"`
+		Choices []struct {
+			Delta struct {
+				Images []struct {
+					ImageURL struct {
+						URL string `json:"url"`
+					} `json:"image_url"`
+				} `json:"images"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(line), &payload))
+	assert.Equal(t, "google/gemini-3-pro-image-preview", payload.Model)
+	require.Len(t, payload.Choices, 1)
+	require.Len(t, payload.Choices[0].Delta.Images, 1)
+	assert.Equal(t, imageURL, payload.Choices[0].Delta.Images[0].ImageURL.URL)
+}
+
+func TestResponseModelStreamReaderBoundsOversizedLines(t *testing.T) {
+	stream := "data: {\"model\":\"backend\",\"payload\":\"" + strings.Repeat("x", 2048) + "\"}\n\n"
+	reader := &responseModelStreamReader{
+		source:       bufio.NewReader(strings.NewReader(stream)),
+		publicModel:  "public",
+		maxLineBytes: 1024,
+	}
+
+	result, err := io.ReadAll(reader)
+
+	require.NoError(t, err)
 	assert.Equal(t, stream, string(result))
+}
+
+func TestNormalizeSuccessfulResponseModel_RewritesExistingImageModelOnly(t *testing.T) {
+	withModel := []byte(`{"created":1,"data":[],"model":"canonical"}`)
+	withoutModel := []byte(`{"created":1,"data":[]}`)
+
+	assert.JSONEq(t,
+		`{"created":1,"data":[],"model":"google/gemini-3-pro-image-preview"}`,
+		string(normalizeSuccessfulResponseModel(withModel, "/v1/images/generations", "google/gemini-3-pro-image-preview")),
+	)
+	assert.Equal(t, withoutModel,
+		normalizeSuccessfulResponseModel(withoutModel, "/v1/images/generations", "openai/gpt-image-1"),
+	)
 }
 
 func TestNormalizeSuccessfulResponseModelStreamPreservesErrorEventsAndFraming(t *testing.T) {

--- a/internal/proxy/chat_response_compat_test.go
+++ b/internal/proxy/chat_response_compat_test.go
@@ -63,6 +63,63 @@ func TestNormalizeSuccessfulResponseModelStreamPreservesNestedModelForLiteLLM(t 
 	)
 }
 
+func TestNormalizeSuccessfulResponseModelStreamRewritesNestedResponseModel(t *testing.T) {
+	// Without the response-compat marker the nested response.model is aliased
+	// too, and is added when absent — parity with the old deep-decode path.
+	stream := "data: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_1\",\"model\":\"backend\"}}\n\n" +
+		"data: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_2\"}}\n\n"
+	request := httptest.NewRequest(http.MethodPost, "/v1/responses", nil)
+	logCtx := &RequestLogContext{Request: request, PublicModelID: "public"}
+
+	result, err := io.ReadAll(normalizeSuccessfulResponseModelStream(
+		strings.NewReader(stream),
+		http.StatusOK,
+		logCtx,
+		"backend",
+	))
+
+	require.NoError(t, err)
+	lines := strings.Split(string(result), "\n")
+	assert.JSONEq(t,
+		`{"type":"response.completed","response":{"id":"resp_1","model":"public"}}`,
+		strings.TrimSpace(strings.TrimPrefix(lines[0], "data:")),
+	)
+	assert.JSONEq(t,
+		`{"type":"response.created","response":{"id":"resp_2","model":"public"}}`,
+		strings.TrimSpace(strings.TrimPrefix(lines[2], "data:")),
+	)
+}
+
+func TestNormalizeSuccessfulResponseModelStreamKeepsOpaqueFieldsVerbatim(t *testing.T) {
+	// The shallow rewrite must not disturb sibling fields — big ints, floats,
+	// unicode escapes and nested structures all survive byte-for-byte.
+	stream := `data: {"model":"backend","object":"chat.completion.chunk",` +
+		`"created":1730000000123456789,"score":0.30000000000000004,` +
+		`"choices":[{"delta":{"content":"café 🚀"}}]}` + "\n\n"
+	request := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", nil)
+	logCtx := &RequestLogContext{Request: request, PublicModelID: "public"}
+
+	result, err := io.ReadAll(normalizeSuccessfulResponseModelStream(
+		strings.NewReader(stream), http.StatusOK, logCtx, "backend",
+	))
+
+	require.NoError(t, err)
+	out := strings.TrimSpace(strings.TrimPrefix(string(result), "data:"))
+	assert.Contains(t, out, `"model":"public"`)
+	assert.Contains(t, out, `"created":1730000000123456789`)
+	assert.Contains(t, out, `"score":0.30000000000000004`)
+	var payload struct {
+		Choices []struct {
+			Delta struct {
+				Content string `json:"content"`
+			} `json:"delta"`
+		} `json:"choices"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &payload))
+	require.Len(t, payload.Choices, 1)
+	assert.Equal(t, "café 🚀", payload.Choices[0].Delta.Content)
+}
+
 func TestNormalizeSuccessfulResponseModelStreamRewritesImageSizedLines(t *testing.T) {
 	imageURL := "data:image/png;base64," + strings.Repeat("x", 2*1024*1024)
 	stream := "data: {\"model\":\"canonical\",\"choices\":[{\"delta\":{\"images\":[{\"image_url\":{\"url\":" +
@@ -113,16 +170,42 @@ func TestResponseModelStreamReaderBoundsOversizedLines(t *testing.T) {
 }
 
 func TestNormalizeSuccessfulResponseModel_RewritesExistingImageModelOnly(t *testing.T) {
-	withModel := []byte(`{"created":1,"data":[],"model":"canonical"}`)
-	withoutModel := []byte(`{"created":1,"data":[]}`)
+	for _, route := range []string{"/v1/images/generations", "/v1/images/edits"} {
+		t.Run(route+" canonical backend model is aliased", func(t *testing.T) {
+			withModel := []byte(`{"created":1,"data":[],"model":"canonical"}`)
+			assert.JSONEq(t,
+				`{"created":1,"data":[],"model":"google/gemini-3-pro-image-preview"}`,
+				string(normalizeSuccessfulResponseModel(withModel, route, "google/gemini-3-pro-image-preview")),
+			)
+		})
 
-	assert.JSONEq(t,
-		`{"created":1,"data":[],"model":"google/gemini-3-pro-image-preview"}`,
-		string(normalizeSuccessfulResponseModel(withModel, "/v1/images/generations", "google/gemini-3-pro-image-preview")),
-	)
-	assert.Equal(t, withoutModel,
-		normalizeSuccessfulResponseModel(withoutModel, "/v1/images/generations", "openai/gpt-image-1"),
-	)
+		t.Run(route+" third-party echoed model is aliased", func(t *testing.T) {
+			// An OpenAI-compatible image backend that passes through raw and
+			// echoes its own "model" is presented under the client alias,
+			// exactly like every non-image route.
+			thirdParty := []byte(`{"created":1,"data":[{"b64_json":"aGk="}],"model":"vendor/their-image-model"}`)
+			out := normalizeSuccessfulResponseModel(thirdParty, route, "alias/img")
+			var payload struct {
+				Model string `json:"model"`
+				Data  []struct {
+					B64JSON string `json:"b64_json"`
+				} `json:"data"`
+			}
+			require.NoError(t, json.Unmarshal(out, &payload))
+			assert.Equal(t, "alias/img", payload.Model)
+			require.Len(t, payload.Data, 1)
+			assert.Equal(t, "aGk=", payload.Data[0].B64JSON)
+		})
+
+		t.Run(route+" schema-less passthrough is untouched (no re-marshal)", func(t *testing.T) {
+			withoutModel := []byte(`{"created":1,"data":[{"b64_json":"aGk="}]}`)
+			out := normalizeSuccessfulResponseModel(withoutModel, route, "openai/gpt-image-1")
+			assert.Equal(t, withoutModel, out)
+			// The no-"model" fast path returns the caller's slice verbatim,
+			// never routing it through unmarshal/re-marshal.
+			assert.Same(t, &withoutModel[0], &out[0])
+		})
+	}
 }
 
 func TestNormalizeSuccessfulResponseModelStreamPreservesErrorEventsAndFraming(t *testing.T) {


### PR DESCRIPTION
## Changes

- Preserve Gemini inline images in chat completion streaming deltas
- Support image-sized Vertex SSE events up to 64 MiB
- Preserve input image and video token details from Vertex usage metadata
- Exclude cached image and video tokens from billable image input tokens
- Add explicit free cache read pricing without changing existing fallback behavior
- Preserve requested model IDs in converted Gemini image responses
- Restore requested model aliases in large streaming image events
- Keep GPT image response shapes unchanged when no model field is present

## Verification

- `go test -count=1 ./...`
- `go test -race -count=1 ./internal/converter/vertex ./internal/models ./internal/proxy`
- `go vet ./...`

## Limit

- Vertex SSE events remain bounded to 64 MiB