### PR TITLE
fix: preserve 400 error classification in litellm compatibility mode

### DIFF
--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -1,13 +1,12 @@
 package proxy
 
 import (
-	"bytes"
 	"encoding/json"
 	"net/http"
-	"strings"
 
 	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/requestid"
+	"github.com/mixaill76/auto_ai_router/internal/upstreamerror"
 )
 
 // APIErrorResponse represents an OpenAI-compatible error response.
@@ -108,266 +107,21 @@ func maskedUpstreamErrorBody(statusCode int, requestID string, rawBodies ...[]by
 	return append(body, '\n')
 }
 
+// classifiedBadRequestError delegates to the shared upstreamerror classifier
+// (also used by litellm compatibility mode's normalizeError) so both modes
+// surface the same classification instead of one discarding it.
 func classifiedBadRequestError(rawBodies ...[]byte) APIError {
-	errorCode := "invalid_request"
-	result := APIError{
-		Message: "Invalid request",
+	var raw []byte
+	if len(rawBodies) > 0 {
+		raw = rawBodies[0]
+	}
+	classified := upstreamerror.ClassifyBadRequest(raw)
+	code := classified.Code
+	return APIError{
+		Message: classified.Message,
 		Type:    errorTypeForStatus(http.StatusBadRequest),
-		Param:   nil,
-		Code:    &errorCode,
-	}
-	if len(rawBodies) == 0 || len(rawBodies[0]) == 0 {
-		return result
-	}
-
-	signals, providerParam := providerErrorSignalsFromBody(rawBodies[0])
-	joined := strings.ToLower(strings.Join(signals, " "))
-
-	switch {
-	case hasSignal(joined, "tool_choice", "tool choice", "toolchoice"):
-		param := "tool_choice"
-		code := "invalid_tool_choice"
-		result.Message = "Invalid tool_choice"
-		result.Param = &param
-		result.Code = &code
-	case hasSignal(joined, "max_completion_tokens", "max_output_tokens", "max_tokens", "max tokens", "maximum tokens", "output tokens"):
-		param := inferBadRequestParam(joined, providerParam)
-		if param == nil || !strings.Contains(*param, "token") {
-			v := inferMaxTokensParam(joined)
-			param = &v
-		}
-		code := "invalid_max_tokens"
-		result.Message = "Invalid " + *param
-		result.Param = param
-		result.Code = &code
-	case hasSignal(joined, "context length", "context window", "context limit", "too many tokens", "input too long", "prompt too long", "token limit"):
-		code := "context_length_exceeded"
-		result.Message = "Context length exceeded"
-		result.Param = inferBadRequestParam(joined, providerParam)
-		result.Code = &code
-	case hasSignal(joined, "model group", "model not found", "model does not exist", "unsupported model", "invalid model", "model not supported"):
-		param := "model"
-		code := "invalid_model"
-		result.Message = "Invalid model"
-		result.Param = &param
-		result.Code = &code
-	case hasSignal(joined, "invalid argument", "invalid parameter", "invalidparameter", "invalid value", "unsupported parameter", "unknown parameter", "unrecognized parameter", "missing required", "required field", "must be", "should be", "does not support", "is not supported"):
-		code := "invalid_parameter"
-		result.Message = "Invalid request parameter"
-		// Precedence: an explicit "param" from the provider's own JSON is
-		// authoritative; next, a field path quoted directly in the message
-		// ("Invalid 'output[1].type': 'input_file'. Supported values are:
-		// ...") is precise even for dynamic/nested paths a fixed list can't
-		// cover; only fall back to the generic keyword list last — it does
-		// broad substring matching (e.g. "input") that a quoted path like
-		// "input_file" would otherwise shadow.
-		param := providerParam
-		if param == nil {
-			param = extractQuotedInvalidField(signals)
-		}
-		if param == nil {
-			param = inferBadRequestParam(joined, nil)
-		}
-		result.Param = param
-		result.Code = &code
-	default:
-		result.Param = providerParam
-	}
-
-	return result
-}
-
-const maxProviderErrorSignalBytes = 8 * 1024
-
-func providerErrorSignalsFromBody(body []byte) ([]string, *string) {
-	if len(body) > maxProviderErrorSignalBytes {
-		body = body[:maxProviderErrorSignalBytes]
-	}
-	trimmed := bytes.TrimSpace(body)
-	if len(trimmed) == 0 {
-		return nil, nil
-	}
-
-	signals := make([]string, 0, 8)
-	var param *string
-	var value any
-	if err := json.Unmarshal(trimmed, &value); err == nil {
-		collectProviderErrorSignals(value, 0, &signals, &param)
-	} else {
-		signals = append(signals, string(trimmed))
-	}
-	return signals, param
-}
-
-func collectProviderErrorSignals(value any, depth int, signals *[]string, param **string) {
-	if depth > 5 || len(*signals) >= 32 {
-		return
-	}
-	switch v := value.(type) {
-	case map[string]any:
-		for _, key := range []string{"message", "type", "code", "status", "reason", "error"} {
-			raw, exists := mapValueFold(v, key)
-			if !exists {
-				continue
-			}
-			text, ok := raw.(string)
-			if ok {
-				if s := cleanProviderErrorSignal(text); s != "" {
-					*signals = append(*signals, s)
-				}
-			}
-		}
-		if *param == nil {
-			for _, key := range []string{"param", "parameter", "field"} {
-				raw, exists := mapValueFold(v, key)
-				if !exists {
-					continue
-				}
-				if text, ok := raw.(string); ok {
-					if p := cleanProviderErrorParam(text); p != "" {
-						*param = &p
-						break
-					}
-				}
-			}
-		}
-		for _, key := range []string{"error", "response", "details", "detail", "violations"} {
-			raw, exists := mapValueFold(v, key)
-			if exists {
-				collectProviderErrorSignals(raw, depth+1, signals, param)
-			}
-		}
-	case []any:
-		for _, item := range v {
-			collectProviderErrorSignals(item, depth+1, signals, param)
-		}
-	case string:
-		if s := cleanProviderErrorSignal(v); s != "" {
-			*signals = append(*signals, s)
-		}
-	}
-}
-
-func mapValueFold(values map[string]any, key string) (any, bool) {
-	if raw, exists := values[key]; exists {
-		return raw, true
-	}
-	for k, raw := range values {
-		if strings.EqualFold(k, key) {
-			return raw, true
-		}
-	}
-	return nil, false
-}
-
-func cleanProviderErrorSignal(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" {
-		return ""
-	}
-	if len(s) > 512 {
-		s = s[:512]
-	}
-	return s
-}
-
-func cleanProviderErrorParam(s string) string {
-	s = strings.TrimSpace(s)
-	if s == "" || len(s) > 80 {
-		return ""
-	}
-	for _, r := range s {
-		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
-			continue
-		}
-		switch r {
-		case '_', '.', '-', '[', ']':
-			continue
-		default:
-			return ""
-		}
-	}
-	return s
-}
-
-func hasSignal(value string, needles ...string) bool {
-	for _, needle := range needles {
-		if strings.Contains(value, needle) {
-			return true
-		}
-	}
-	return false
-}
-
-func inferBadRequestParam(joined string, providerParam *string) *string {
-	if providerParam != nil {
-		return providerParam
-	}
-	for _, param := range []string{
-		"max_completion_tokens",
-		"max_output_tokens",
-		"max_tokens",
-		"tool_choice",
-		"parallel_tool_calls",
-		"response_format",
-		"reasoning_effort",
-		"service_tier",
-		"stream_options",
-		"temperature",
-		"top_p",
-		"logprobs",
-		"messages",
-		"input",
-		"tools",
-		"model",
-		"stop",
-		"metadata",
-		"audio",
-		"image",
-		"prompt",
-		"n",
-	} {
-		if strings.Contains(joined, param) {
-			p := param
-			return &p
-		}
-	}
-	return nil
-}
-
-// extractQuotedInvalidField pulls the field path out of a provider message
-// shaped like `Invalid 'output[1].type': 'input_file'. Supported values
-// are: ...` — the quoted token right after "Invalid " is the offending
-// field/parameter path. Fixed param-name lists can't cover these because
-// the path is dynamic (array index, nested field), so this is checked as a
-// fallback once the static list in inferBadRequestParam comes up empty.
-// Tries each raw (pre-lowercased) signal in turn and returns the first hit.
-func extractQuotedInvalidField(signals []string) *string {
-	const marker = "invalid '"
-	for _, s := range signals {
-		idx := strings.Index(strings.ToLower(s), marker)
-		if idx == -1 {
-			continue
-		}
-		rest := s[idx+len(marker):]
-		end := strings.IndexByte(rest, '\'')
-		if end <= 0 {
-			continue
-		}
-		field := rest[:end]
-		return &field
-	}
-	return nil
-}
-
-func inferMaxTokensParam(joined string) string {
-	switch {
-	case strings.Contains(joined, "max_completion_tokens"):
-		return "max_completion_tokens"
-	case strings.Contains(joined, "max_output_tokens"):
-		return "max_output_tokens"
-	default:
-		return "max_tokens"
+		Param:   classified.Param,
+		Code:    &code,
 	}
 }
 

--- a/internal/proxy/errors_test.go
+++ b/internal/proxy/errors_test.go
@@ -221,54 +221,6 @@ func TestMaskedUpstreamErrorBodyKeepsGenericNonBadRequest(t *testing.T) {
 	}
 }
 
-func TestExtractQuotedInvalidField(t *testing.T) {
-	tests := []struct {
-		name    string
-		signals []string
-		want    *string
-	}{
-		{
-			name:    "dynamic nested path",
-			signals: []string{"Invalid 'output[1].type': 'input_file'. Supported values are: 'input_text', 'input_image'."},
-			want:    stringPtr("output[1].type"),
-		},
-		{
-			name:    "case-insensitive marker",
-			signals: []string{"invalid 'tool_choice.type': unsupported value"},
-			want:    stringPtr("tool_choice.type"),
-		},
-		{
-			name:    "picks first matching signal",
-			signals: []string{"generic failure", "Invalid 'foo': bar"},
-			want:    stringPtr("foo"),
-		},
-		{
-			name:    "no marker present",
-			signals: []string{"something else went wrong"},
-			want:    nil,
-		},
-		{
-			name:    "marker with no closing quote",
-			signals: []string{"Invalid 'unterminated"},
-			want:    nil,
-		},
-		{
-			name:    "empty quoted field",
-			signals: []string{"Invalid '': something"},
-			want:    nil,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := extractQuotedInvalidField(tt.signals)
-			if !equalStringPtr(got, tt.want) {
-				t.Fatalf("got %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 // TestWriteValidationError_HonorsArbitraryStatusCode guards against
 // writeValidationError silently collapsing a future non-413 StatusCode (e.g.
 // 415) to 400 while statusForValidationError — what callers log as

--- a/internal/proxy/response_compat_test.go
+++ b/internal/proxy/response_compat_test.go
@@ -33,7 +33,15 @@ func TestResponseCompatibilityWriterTransformsInternalError(t *testing.T) {
 	assert.Empty(t, recorder.Header().Get("x-litellm-call-id"))
 	var body map[string]any
 	require.NoError(t, json.Unmarshal(recorder.Body.Bytes(), &body))
-	assert.Equal(t, "400", body["error"].(map[string]any)["code"])
+	// A 400 now goes through the same signal-based classifier as native mode
+	// (see upstreamerror.ClassifyBadRequest); this body's text doesn't match
+	// any known pattern, so it lands on the same generic default native mode
+	// would also produce for it — "invalid_request", not the old hardcoded
+	// "400" — and the raw "bad request" text must never leak into the
+	// client-facing message either way.
+	assert.Equal(t, "invalid_request", body["error"].(map[string]any)["code"])
+	assert.Equal(t, "Invalid request", body["error"].(map[string]any)["message"])
+	assert.NotContains(t, recorder.Body.String(), "bad request")
 }
 
 func TestResponseCompatibilityWriterTransformsStream(t *testing.T) {

--- a/internal/responsecompat/litellm/transform.go
+++ b/internal/responsecompat/litellm/transform.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/mixaill76/auto_ai_router/internal/upstreamerror"
 )
 
 var rateLimitHeaders = map[string]struct{}{
@@ -296,9 +297,26 @@ func errorStatus(value any) int {
 	return http.StatusUnprocessableEntity
 }
 
-func normalizeError(status int, _ []byte) []byte {
+// normalizeError builds the litellm-compatible error body for a non-2xx
+// response. Status 400 is run through the same signal-based classifier as
+// native mode's maskedUpstreamErrorBody (see upstreamerror.ClassifyBadRequest)
+// to surface which parameter was rejected — this only ever extracts a short,
+// pre-vetted message from a small fixed set plus a narrow field/param name,
+// never the raw provider message text, so it's safe to run on a body that
+// hasn't been trusted yet (see TestTransformError: raw provider bodies with
+// embedded credential names or internal URLs must never reach the client
+// verbatim, for 429 or otherwise). Other statuses keep their fixed generic
+// message, matching native mode exactly.
+func normalizeError(status int, body []byte) []byte {
 	message := "Request failed"
+	code := fmt.Sprintf("%d", status)
+	var param *string
 	switch status {
+	case http.StatusBadRequest:
+		classified := upstreamerror.ClassifyBadRequest(body)
+		message = classified.Message
+		code = classified.Code
+		param = classified.Param
 	case http.StatusTooManyRequests:
 		message = "Rate limit exceeded"
 	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
@@ -309,8 +327,8 @@ func normalizeError(status int, _ []byte) []byte {
 		"error": map[string]any{
 			"message": message,
 			"type":    errorTypeForStatus(status),
-			"param":   nil,
-			"code":    fmt.Sprintf("%d", status),
+			"param":   param,
+			"code":    code,
 		},
 	})
 	return result

--- a/internal/responsecompat/litellm/transform_test.go
+++ b/internal/responsecompat/litellm/transform_test.go
@@ -162,6 +162,45 @@ func TestTransformError(t *testing.T) {
 	assert.NotContains(t, string(result.Body), "provider.internal")
 }
 
+// TestTransformError_BadRequestPreservesRouterClassification reproduces the
+// real production gap: the router's own already-classified 400 body (what
+// maskedUpstreamErrorBody produces natively, e.g. for a rejected "logprobs"
+// parameter) must survive this compatibility layer with its message/code/
+// param intact, instead of being discarded for the old hardcoded generic
+// "Request failed" / param:null / code:"400".
+func TestTransformError_BadRequestPreservesRouterClassification(t *testing.T) {
+	result := New().Transform(Context{}, Response{
+		StatusCode: http.StatusBadRequest,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"error":{"message":"Invalid request parameter","type":"invalid_request_error","param":"logprobs","code":"invalid_parameter"}}`),
+	})
+
+	assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(result.Body, &body))
+	errorBody := body["error"].(map[string]any)
+	assert.Equal(t, "Invalid request parameter", errorBody["message"])
+	assert.Equal(t, "invalid_parameter", errorBody["code"])
+	assert.Equal(t, "logprobs", errorBody["param"])
+}
+
+// TestTransformError_BadRequestNeverLeaksRawUpstreamText guards the security
+// property TestTransformError already checks for 429: a raw, untrusted
+// upstream 400 body must never reach the client verbatim either, even
+// though 400 is now classified instead of always-generic.
+func TestTransformError_BadRequestNeverLeaksRawUpstreamText(t *testing.T) {
+	result := New().Transform(Context{}, Response{
+		StatusCode: http.StatusBadRequest,
+		Headers:    http.Header{"Content-Type": {"application/json"}},
+		Body:       []byte(`{"error":{"message":"Alibaba credential prod-qwen misconfigured; see https://provider.internal/setup","type":"provider_error"}}`),
+	})
+
+	assert.Equal(t, http.StatusBadRequest, result.StatusCode)
+	assert.NotContains(t, string(result.Body), "Alibaba")
+	assert.NotContains(t, string(result.Body), "prod-qwen")
+	assert.NotContains(t, string(result.Body), "provider.internal")
+}
+
 func TestTransformDropsRoutingMetadata(t *testing.T) {
 	result := New().Transform(Context{
 		Endpoint:       "/v1/chat/completions",

--- a/internal/upstreamerror/classify.go
+++ b/internal/upstreamerror/classify.go
@@ -1,0 +1,285 @@
+// Package upstreamerror classifies a raw 400 Bad Request body from an
+// upstream LLM provider into a short, pre-vetted message plus (when
+// available) the specific parameter/field name that was rejected — without
+// ever echoing the provider's own free-text message back to the client.
+// Shared by native mode (proxy.maskedUpstreamErrorBody) and litellm
+// compatibility mode (responsecompat/litellm.normalizeError), so both
+// surface the same classification instead of one of them discarding it.
+package upstreamerror
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// BadRequest is the result of classifying a raw 400 body: always one of a
+// small fixed set of messages/codes, plus an optional narrowly-scoped
+// parameter/field name — never the provider's own message text.
+type BadRequest struct {
+	Message string
+	Code    string
+	Param   *string
+}
+
+// ClassifyBadRequest inspects rawBody for known signal phrases and returns a
+// classified message/code/param. Returns the generic "Invalid request" /
+// "invalid_request" (Param nil) when nothing recognizable is found.
+func ClassifyBadRequest(rawBody []byte) BadRequest {
+	result := BadRequest{Message: "Invalid request", Code: "invalid_request"}
+	if len(rawBody) == 0 {
+		return result
+	}
+
+	signals, providerParam := providerErrorSignalsFromBody(rawBody)
+	joined := strings.ToLower(strings.Join(signals, " "))
+
+	switch {
+	case hasSignal(joined, "tool_choice", "tool choice", "toolchoice"):
+		param := "tool_choice"
+		result.Message = "Invalid tool_choice"
+		result.Code = "invalid_tool_choice"
+		result.Param = &param
+	case hasSignal(joined, "max_completion_tokens", "max_output_tokens", "max_tokens", "max tokens", "maximum tokens", "output tokens"):
+		param := inferBadRequestParam(joined, providerParam)
+		if param == nil || !strings.Contains(*param, "token") {
+			v := inferMaxTokensParam(joined)
+			param = &v
+		}
+		result.Message = "Invalid " + *param
+		result.Code = "invalid_max_tokens"
+		result.Param = param
+	case hasSignal(joined, "context length", "context window", "context limit", "too many tokens", "input too long", "prompt too long", "token limit"):
+		result.Message = "Context length exceeded"
+		result.Code = "context_length_exceeded"
+		result.Param = inferBadRequestParam(joined, providerParam)
+	case hasSignal(joined, "model group", "model not found", "model does not exist", "unsupported model", "invalid model", "model not supported"):
+		param := "model"
+		result.Message = "Invalid model"
+		result.Code = "invalid_model"
+		result.Param = &param
+	// "invalid_parameter" (underscore) is this branch's own Code value below —
+	// needed so re-classifying this package's own already-classified output
+	// (e.g. litellm-compat mode's normalizeError running ClassifyBadRequest
+	// on the router's own body: message "Invalid request parameter" doesn't
+	// itself contain "invalid parameter"/"invalidparameter" as a substring,
+	// "request" sits in between) still lands back in this same bucket
+	// instead of falling through to the generic default.
+	case hasSignal(joined, "invalid argument", "invalid parameter", "invalidparameter", "invalid_parameter", "invalid value", "unsupported parameter", "unknown parameter", "unrecognized parameter", "missing required", "required field", "must be", "should be", "does not support", "is not supported"):
+		result.Message = "Invalid request parameter"
+		result.Code = "invalid_parameter"
+		// Precedence: an explicit "param" from the provider's own JSON is
+		// authoritative; next, a field path quoted directly in the message
+		// ("Invalid 'output[1].type': 'input_file'. Supported values are:
+		// ...") is precise even for dynamic/nested paths a fixed list can't
+		// cover; only fall back to the generic keyword list last — it does
+		// broad substring matching (e.g. "input") that a quoted path like
+		// "input_file" would otherwise shadow.
+		param := providerParam
+		if param == nil {
+			param = extractQuotedInvalidField(signals)
+		}
+		if param == nil {
+			param = inferBadRequestParam(joined, nil)
+		}
+		result.Param = param
+	default:
+		result.Param = providerParam
+	}
+
+	return result
+}
+
+const maxProviderErrorSignalBytes = 8 * 1024
+
+func providerErrorSignalsFromBody(body []byte) ([]string, *string) {
+	if len(body) > maxProviderErrorSignalBytes {
+		body = body[:maxProviderErrorSignalBytes]
+	}
+	trimmed := bytes.TrimSpace(body)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+
+	signals := make([]string, 0, 8)
+	var param *string
+	var value any
+	if err := json.Unmarshal(trimmed, &value); err == nil {
+		collectProviderErrorSignals(value, 0, &signals, &param)
+	} else {
+		signals = append(signals, string(trimmed))
+	}
+	return signals, param
+}
+
+func collectProviderErrorSignals(value any, depth int, signals *[]string, param **string) {
+	if depth > 5 || len(*signals) >= 32 {
+		return
+	}
+	switch v := value.(type) {
+	case map[string]any:
+		for _, key := range []string{"message", "type", "code", "status", "reason", "error"} {
+			raw, exists := mapValueFold(v, key)
+			if !exists {
+				continue
+			}
+			text, ok := raw.(string)
+			if ok {
+				if s := cleanProviderErrorSignal(text); s != "" {
+					*signals = append(*signals, s)
+				}
+			}
+		}
+		if *param == nil {
+			for _, key := range []string{"param", "parameter", "field"} {
+				raw, exists := mapValueFold(v, key)
+				if !exists {
+					continue
+				}
+				if text, ok := raw.(string); ok {
+					if p := cleanProviderErrorParam(text); p != "" {
+						*param = &p
+						break
+					}
+				}
+			}
+		}
+		for _, key := range []string{"error", "response", "details", "detail", "violations"} {
+			raw, exists := mapValueFold(v, key)
+			if exists {
+				collectProviderErrorSignals(raw, depth+1, signals, param)
+			}
+		}
+	case []any:
+		for _, item := range v {
+			collectProviderErrorSignals(item, depth+1, signals, param)
+		}
+	case string:
+		if s := cleanProviderErrorSignal(v); s != "" {
+			*signals = append(*signals, s)
+		}
+	}
+}
+
+func mapValueFold(values map[string]any, key string) (any, bool) {
+	if raw, exists := values[key]; exists {
+		return raw, true
+	}
+	for k, raw := range values {
+		if strings.EqualFold(k, key) {
+			return raw, true
+		}
+	}
+	return nil, false
+}
+
+func cleanProviderErrorSignal(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if len(s) > 512 {
+		s = s[:512]
+	}
+	return s
+}
+
+func cleanProviderErrorParam(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" || len(s) > 80 {
+		return ""
+	}
+	for _, r := range s {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' {
+			continue
+		}
+		switch r {
+		case '_', '.', '-', '[', ']':
+			continue
+		default:
+			return ""
+		}
+	}
+	return s
+}
+
+func hasSignal(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}
+
+func inferBadRequestParam(joined string, providerParam *string) *string {
+	if providerParam != nil {
+		return providerParam
+	}
+	for _, param := range []string{
+		"max_completion_tokens",
+		"max_output_tokens",
+		"max_tokens",
+		"tool_choice",
+		"parallel_tool_calls",
+		"response_format",
+		"reasoning_effort",
+		"service_tier",
+		"stream_options",
+		"temperature",
+		"top_p",
+		"logprobs",
+		"messages",
+		"input",
+		"tools",
+		"model",
+		"stop",
+		"metadata",
+		"audio",
+		"image",
+		"prompt",
+		"n",
+	} {
+		if strings.Contains(joined, param) {
+			p := param
+			return &p
+		}
+	}
+	return nil
+}
+
+// extractQuotedInvalidField pulls the field path out of a provider message
+// shaped like `Invalid 'output[1].type': 'input_file'. Supported values
+// are: ...` — the quoted token right after "Invalid " is the offending
+// field/parameter path. Fixed param-name lists can't cover these because
+// the path is dynamic (array index, nested field), so this is checked as a
+// fallback once the static list in inferBadRequestParam comes up empty.
+// Tries each raw (pre-lowercased) signal in turn and returns the first hit.
+func extractQuotedInvalidField(signals []string) *string {
+	const marker = "invalid '"
+	for _, s := range signals {
+		idx := strings.Index(strings.ToLower(s), marker)
+		if idx == -1 {
+			continue
+		}
+		rest := s[idx+len(marker):]
+		end := strings.IndexByte(rest, '\'')
+		if end <= 0 {
+			continue
+		}
+		field := rest[:end]
+		return &field
+	}
+	return nil
+}
+
+func inferMaxTokensParam(joined string) string {
+	switch {
+	case strings.Contains(joined, "max_completion_tokens"):
+		return "max_completion_tokens"
+	case strings.Contains(joined, "max_output_tokens"):
+		return "max_output_tokens"
+	default:
+		return "max_tokens"
+	}
+}

--- a/internal/upstreamerror/classify_test.go
+++ b/internal/upstreamerror/classify_test.go
@@ -1,0 +1,192 @@
+package upstreamerror
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func equalStringPtr(a, b *string) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
+}
+
+func TestClassifyBadRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		body        string
+		wantMessage string
+		wantCode    string
+		wantParam   *string
+		notContains []string
+	}{
+		{
+			name:        "invalid tool choice",
+			body:        `{"error":{"message":"Provider rejected tool_choice. Debug trace abc123","type":"invalid_request_error","param":"tool_choice","code":"bad_request"}}`,
+			wantMessage: "Invalid tool_choice",
+			wantCode:    "invalid_tool_choice",
+			wantParam:   stringPtr("tool_choice"),
+			notContains: []string{"Provider rejected", "Debug trace"},
+		},
+		{
+			name:        "max tokens",
+			body:        `{"error":{"message":"max_completion_tokens must be less than 8192","param":"max_completion_tokens","code":"invalid_request_error"}}`,
+			wantMessage: "Invalid max_completion_tokens",
+			wantCode:    "invalid_max_tokens",
+			wantParam:   stringPtr("max_completion_tokens"),
+			notContains: []string{"8192"},
+		},
+		{
+			name:        "context length",
+			body:        `{"error":{"message":"Input is too long for the context window","code":"context_length_exceeded"}}`,
+			wantMessage: "Context length exceeded",
+			wantCode:    "context_length_exceeded",
+			wantParam:   stringPtr("input"),
+		},
+		{
+			name:        "invalid model",
+			body:        `{"error":{"message":"litellm.BadRequestError: Received Model Group=secret/internal Available Model Group Fallbacks=None"}}`,
+			wantMessage: "Invalid model",
+			wantCode:    "invalid_model",
+			wantParam:   stringPtr("model"),
+			notContains: []string{"litellm", "secret/internal", "Fallbacks"},
+		},
+		{
+			name:        "invalid parameter",
+			body:        `{"error":{"message":"unsupported parameter response_format for this model","param":"response_format"}}`,
+			wantMessage: "Invalid request parameter",
+			wantCode:    "invalid_parameter",
+			wantParam:   stringPtr("response_format"),
+			notContains: []string{"unsupported parameter", "this model"},
+		},
+		{
+			// Reproduces a real production body: DeepInfra-style
+			// "is not supported" phrasing (not "does not support") with an
+			// underscore-style error code ("invalid_parameter_error", not a
+			// literal "invalid parameter" substring) — both must still land
+			// in the invalid_parameter bucket instead of the generic fallback.
+			name:        "is not supported phrasing with underscore error code",
+			body:        "{\"error\":{\"code\":\"invalid_parameter_error\",\"message\":\"The parameters `logprobs` is not supported.\",\"param\":null,\"type\":\"invalid_request_error\"},\"id\":\"chatcmpl-c851a2c6-8a54-9ca4-9561-b3ff6163be27\"}",
+			wantMessage: "Invalid request parameter",
+			wantCode:    "invalid_parameter",
+			wantParam:   stringPtr("logprobs"),
+			notContains: []string{"chatcmpl", "c851a2c6"},
+		},
+		{
+			// Reproduces another real production body: a PascalCase
+			// "InvalidParameter" type (lowercases to "invalidparameter",
+			// no space — doesn't match the "invalid parameter" needle) with
+			// no "param" field of its own, and a dynamic/nested offending
+			// field path ("output[1].type") that a fixed param-name list can
+			// never enumerate in advance. Must extract the path quoted right
+			// after "Invalid " in the message instead of leaving param null.
+			name:        "PascalCase InvalidParameter with quoted dynamic field path",
+			body:        `{"error":{"message":"Invalid 'output[1].type': 'input_file'. Supported values are: 'input_text', 'input_image'.","type":"InvalidParameter"}}`,
+			wantMessage: "Invalid request parameter",
+			wantCode:    "invalid_parameter",
+			wantParam:   stringPtr("output[1].type"),
+			notContains: []string{"Supported values are"},
+		},
+		{
+			name:        "plain text fallback",
+			body:        `vendor stack id 012345`,
+			wantMessage: "Invalid request",
+			wantCode:    "invalid_request",
+			notContains: []string{"vendor stack"},
+		},
+		{
+			name:        "empty body",
+			body:        "",
+			wantMessage: "Invalid request",
+			wantCode:    "invalid_request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ClassifyBadRequest([]byte(tt.body))
+
+			assert.Equal(t, tt.wantMessage, got.Message)
+			assert.Equal(t, tt.wantCode, got.Code)
+			assert.True(t, equalStringPtr(got.Param, tt.wantParam), "param = %v, want %v", got.Param, tt.wantParam)
+
+			serialized, err := json.Marshal(got)
+			require.NoError(t, err)
+			for _, s := range tt.notContains {
+				assert.NotContains(t, string(serialized), s)
+			}
+		})
+	}
+}
+
+func TestExtractQuotedInvalidField(t *testing.T) {
+	tests := []struct {
+		name    string
+		signals []string
+		want    *string
+	}{
+		{
+			name:    "dynamic nested path",
+			signals: []string{"Invalid 'output[1].type': 'input_file'. Supported values are: 'input_text', 'input_image'."},
+			want:    stringPtr("output[1].type"),
+		},
+		{
+			name:    "case-insensitive marker",
+			signals: []string{"invalid 'tool_choice.type': unsupported value"},
+			want:    stringPtr("tool_choice.type"),
+		},
+		{
+			name:    "picks first matching signal",
+			signals: []string{"generic failure", "Invalid 'foo': bar"},
+			want:    stringPtr("foo"),
+		},
+		{
+			name:    "no marker present",
+			signals: []string{"something else went wrong"},
+			want:    nil,
+		},
+		{
+			name:    "marker with no closing quote",
+			signals: []string{"Invalid 'unterminated"},
+			want:    nil,
+		},
+		{
+			name:    "empty quoted field",
+			signals: []string{"Invalid '': something"},
+			want:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractQuotedInvalidField(tt.signals)
+			if !equalStringPtr(got, tt.want) {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyBadRequest_NeverEchoesRawSensitiveText guards the whole point
+// of this package: even when a raw, untrusted provider body contains
+// sensitive detail (credential names, internal URLs), ClassifyBadRequest
+// must never let it reach the output — every branch either returns a fixed
+// message or a narrow, character-restricted param/field name.
+func TestClassifyBadRequest_NeverEchoesRawSensitiveText(t *testing.T) {
+	body := `{"error":{"message":"Alibaba credential prod-qwen throttled; see https://provider.internal/quota","type":"provider_error","code":"quota"}}`
+	got := ClassifyBadRequest([]byte(body))
+
+	serialized, err := json.Marshal(got)
+	require.NoError(t, err)
+	for _, s := range []string{"Alibaba", "prod-qwen", "provider.internal"} {
+		assert.NotContains(t, string(serialized), s)
+	}
+}

--- a/internal/upstreamerror/classify_test.go
+++ b/internal/upstreamerror/classify_test.go
@@ -190,3 +190,49 @@ func TestClassifyBadRequest_NeverEchoesRawSensitiveText(t *testing.T) {
 		assert.NotContains(t, string(serialized), s)
 	}
 }
+
+// TestClassifyBadRequest_IsIdempotent guards the property litellm
+// compatibility mode's normalizeError depends on: Transform only ever sees
+// the router's own already-classified body (see
+// responseCompatibilityWriter.Close), so it re-runs ClassifyBadRequest on
+// that body rather than trusting it blindly. Every branch's own canonical
+// output must re-classify back into itself — message and code identical,
+// param preserved — or a fix like PR #187 silently regresses back to the
+// generic default despite having classified correctly the first time (this
+// is exactly what happened before "invalid_parameter" was added as a
+// needle: the "invalid_parameter" code round-tripped to the generic
+// default because "Invalid request parameter" doesn't itself contain
+// "invalid parameter" as a substring — "request" sits in between).
+func TestClassifyBadRequest_IsIdempotent(t *testing.T) {
+	rawBodies := []string{
+		`{"error":{"message":"Provider rejected tool_choice.","param":"tool_choice"}}`,
+		`{"error":{"message":"max_completion_tokens must be less than 8192","param":"max_completion_tokens"}}`,
+		`{"error":{"message":"Input is too long for the context window"}}`,
+		`{"error":{"message":"litellm.BadRequestError: Received Model Group=x"}}`,
+		`{"error":{"message":"The parameters logprobs is not supported.","code":"invalid_parameter_error"}}`,
+		`{"error":{"message":"Invalid 'output[1].type': 'input_file'.","type":"InvalidParameter"}}`,
+		`vendor stack id 012345`,
+	}
+
+	for _, raw := range rawBodies {
+		t.Run(raw, func(t *testing.T) {
+			first := ClassifyBadRequest([]byte(raw))
+
+			routerBody, err := json.Marshal(map[string]any{
+				"error": map[string]any{
+					"message": first.Message,
+					"type":    "invalid_request_error",
+					"param":   first.Param,
+					"code":    first.Code,
+				},
+			})
+			require.NoError(t, err)
+
+			second := ClassifyBadRequest(routerBody)
+
+			assert.Equal(t, first.Message, second.Message, "message must survive a second classification pass")
+			assert.Equal(t, first.Code, second.Code, "code must survive a second classification pass")
+			assert.True(t, equalStringPtr(first.Param, second.Param), "param must survive a second classification pass: first=%v second=%v", first.Param, second.Param)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Native mode's \`maskedUpstreamErrorBody\` classifies a 400 into a short, pre-vetted message plus (when available) the specific parameter that was rejected — e.g. a rejected \`logprobs\` param surfaces as \`param:"logprobs"\` instead of a generic \`"Invalid request"\`.
- Gateways running \`response_compatibility: litellm\` never saw any of this: \`normalizeError\` unconditionally discarded the body (the parameter was literally named \`_ []byte\`) and replaced it with a hardcoded \`"Request failed"\` / \`param:null\` / \`code:"<status>"\`, regardless of what the router had already computed.
- Confirmed live on \`api.vsellm.ru\` (\`response_compatibility: litellm\`): a real \`logprobs\`-rejection 400 came back as \`{"error":{"code":"400","message":"Request failed","param":null,...}}\` instead of the classified body native mode produces.

## Fix
- Extracted the classification logic (previously private to \`proxy/errors.go\`) into a new shared \`internal/upstreamerror\` package, so both native mode and litellm-compat mode run the *identical* classifier instead of one discarding it.
- The classifier only ever returns a message from a small fixed set plus a narrowly-restricted field/param name — **never** the provider's own free-text message — so it's safe to run on a body that hasn't been trusted yet. This is deliberately tested: \`TestTransformError\` / new \`TestClassifyBadRequest_NeverEchoesRawSensitiveText\` assert that a raw provider body with an embedded credential name and internal URL never reaches the client verbatim, classified or not.
- Re-classifying the router's own already-classified 400 output (which is what litellm-compat mode's \`Transform\` actually receives — see \`responseCompatibilityWriter.Close\`) needed one more fix to stay idempotent: the \`"invalid_parameter"\` code (underscore) didn't match any existing needle (\`"invalid parameter"\` has a space, \`"invalidparameter"\` has none), so re-running the classifier on the router's own body fell through to the generic default despite the original classification already being correct. Added \`"invalid_parameter"\` as an explicit needle.
- Updated \`TestResponseCompatibilityWriterTransformsInternalError\`, which asserted the old hardcoded generic shape for an unclassifiable body — now expects the same \`"invalid_request"\` default native mode already produces for the same input, instead of the old status-code-as-string \`"400"\`.

## Before → after (litellm-compat mode, logprobs example)
\`\`\`json
{"error":{"code":"400","message":"Request failed","param":null,"type":"invalid_request_error"}}
\`\`\`
\`\`\`json
{"error":{"code":"invalid_parameter","message":"Invalid request parameter","param":"logprobs","type":"invalid_request_error"}}
\`\`\`

## Test plan
- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` (full suite)
- [x] New \`internal/upstreamerror\` package tests (moved/adapted from \`proxy/errors_test.go\`, plus a new security-focused test)
- [x] New \`TestTransformError_BadRequestPreservesRouterClassification\` / \`TestTransformError_BadRequestNeverLeaksRawUpstreamText\` in the litellm package
- [x] Manually verified both real production repro bodies (logprobs rejection, \`output[1].type\` invalid input type) produce identical output in native mode and litellm-compat mode