### PR TITLE
Add GPT-6 and native Responses WebSockets

### DIFF
--- a/docs/advanced/responses.md
+++ b/docs/advanced/responses.md
@@ -11,6 +11,34 @@ Auto AI Router implements the [OpenAI Responses API](../refs/openai_responses_ap
 | `GET`  | `/v1/responses/{id}`    | Retrieve a stored response by ID               |
 | `POST` | `/v1/responses/compact` | Compact a conversation into a summary item     |
 
+## GPT-6 Astra over HTTP
+
+Configure `gpt-6-astra` on an existing OpenAI-compatible credential. OpenAI credentials
+forward Responses requests directly to `/v1/responses`. For example, with an existing
+credential named `openai_main`:
+
+```yaml
+models:
+  - name: gpt-6-astra
+    credential: openai_main
+```
+
+For GPT-6 requests, the router removes `temperature`, `top_p`, and `top_logprobs`.
+Responses requests also drop `message.output_text.logprobs` from `include`, preserving
+other include values. Chat Completions requests drop `logprobs` and use the existing
+`max_tokens` to `max_completion_tokens` conversion. `max_output_tokens` is preserved.
+See the [OpenAI migration guide](https://developers.openai.com/api/docs/guides/latest-model).
+
+Use Responses for tool calling. Native HTTP forwarding preserves `async` tool flags,
+`additional_tools` with required or named `tool_choice`, `configuration_update` input
+items, `prompt_cache_breakpoint`, and `prompt_cache_options`. Reasoning values such as
+`max` and `pro` are forwarded for the upstream to interpret; the router does not add
+provider-specific reasoning aliases. Cache options do not guarantee a cache hit.
+
+Prices still come from `server.model_prices_link` or the LiteLLM database. Add the
+model's applicable rates there before using budget enforcement. Input, output, cache
+read/write, and reasoning usage use the existing billing pipeline.
+
 ## Request Parameters
 
 All standard Responses API parameters are supported. The table below lists the full set recognized by the router:

--- a/docs/advanced/responses.md
+++ b/docs/advanced/responses.md
@@ -11,7 +11,7 @@ Auto AI Router implements the [OpenAI Responses API](../refs/openai_responses_ap
 | `GET`  | `/v1/responses/{id}`    | Retrieve a stored response by ID               |
 | `POST` | `/v1/responses/compact` | Compact a conversation into a summary item     |
 
-## GPT-6 Astra over HTTP
+## GPT-6 Astra
 
 Configure `gpt-6-astra` on an existing OpenAI-compatible credential. OpenAI credentials
 forward Responses requests directly to `/v1/responses`. For example, with an existing
@@ -177,7 +177,52 @@ for event in stream:
 
 ## WebSocket Protocol
 
-The router accepts WebSocket connections on `GET /v1/responses` (with `Upgrade: websocket` header). This allows multiple request-response turns on a single persistent connection.
+The router accepts WebSocket connections on `GET /v1/responses` (with `Upgrade: websocket` header). By default, each turn uses the existing HTTP/SSE provider path. Enable native upstream WebSockets for models whose providers support them:
+
+```yaml
+models:
+  - name: gpt-6-astra
+    credential: openai_main
+    websocket_responses: true
+```
+
+### Native Upstream Mode
+
+Native mode connects directly to the configured provider's WebSocket Responses endpoint.
+It supports OpenAI and existing `proxy`/`air` credentials with native Responses passthrough.
+All credentials serving an opted-in model must support WebSockets. For a custom deployment
+name, also set `passthrough_responses: true` if native Responses is not auto-detected.
+
+Send `response.create` to begin. Once `response.created` arrives, GPT-6 Astra accepts
+`response.steer` during generation:
+
+```json
+{"type":"response.steer","previous_response_id":"resp_1","input":"Keep the answer shorter."}
+```
+
+Steering accepts user input, and the upstream creates its successor response automatically.
+The router tracks and bills each response separately. If `response.steer.pending` requests
+a tool result, send another `response.create` with the original `previous_response_id`
+and the required `function_call_output`. Async tool flags, cache options, and
+`configuration_update` items in `response.create.input` follow the HTTP passthrough rules.
+Support for these features still depends on the provider; Azure WebSocket transport does
+not imply Azure supports steering. See [OpenAI steering](https://developers.openai.com/api/docs/guides/steering).
+
+Native sessions use one model and credential, one active response, and at most one queued
+steer. Authentication, model access, credential scope, rate limits, and budget checks run
+for each create/steer request. Provider usage, including cache usage, feeds the existing
+billing pipeline; continuation reservations include an estimate of prior context.
+
+`stream` and `background` are removed and `store` is forced to `false`. Responses remain
+on the upstream connection: router HTTP retrieval and cross-connection continuation are
+unavailable. Reconnect with full input history after an upstream disconnect, credential
+change, one hour, or 128 admitted responses. There is no automatic provider fallback
+inside an established session. By default, disconnecting closes the upstream and uses estimated usage for unfinished
+responses. With `drain_upstream_on_abort: true`, the router keeps reading for the existing
+drain grace period to collect final provider usage.
+
+The remaining examples also apply to the default HTTP/SSE bridge; its local and persistent
+response-store behavior is described separately below.
 
 ### Connection
 
@@ -200,7 +245,7 @@ Send a JSON message with `"type": "response.create"` and any standard Responses 
 }
 ```
 
-The `type` field is stripped before forwarding to the provider.
+In the default bridge, `type` is stripped before forwarding HTTP. Native mode sends `response.create` over the upstream WebSocket.
 
 ### Receiving Events
 
@@ -236,7 +281,7 @@ HTTP errors are converted to structured WebSocket error events:
 }
 ```
 
-### Connection-Local Cache
+### Connection-Local Cache (HTTP/SSE Bridge)
 
 When `store: false` is explicitly set, completed responses are cached in connection-local memory for the duration of the WebSocket connection. This allows `previous_response_id` continuations within the same session without a persistent store. The cache is cleared on reconnect.
 

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -28,10 +28,26 @@ credentials:
   - name: "azure_openai"
     type: "openai"
     api_key: "os.environ/AZURE_OPENAI_KEY"
-    base_url: "https://your-resource.openai.azure.com"
+    base_url: "https://your-resource.openai.azure.com/openai/v1"
     rpm: 100
     tpm: 50000
 ```
+
+For native Responses WebSockets, configure the deployment name and enable the transport:
+
+```yaml
+models:
+  - name: gpt-6-astra
+    model: your-astra-deployment
+    credential: azure_openai
+    passthrough_responses: true
+    websocket_responses: true
+```
+
+The router connects to `wss://your-resource.openai.azure.com/openai/v1/responses`
+with the credential's API key as a Bearer token. See the
+[Azure WebSocket guide](https://learn.microsoft.com/en-us/azure/foundry/openai/how-to/websockets)
+and [router session limits](../advanced/responses.md#native-upstream-mode).
 
 ## Per-Model Configuration
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -121,6 +121,7 @@ type ModelRPMConfig struct {
 	// nil (omitted in config) = auto-detect: true for codex models, false otherwise.
 	// Explicit true/false overrides the auto-detection.
 	PassthroughResponses *bool `yaml:"passthrough_responses,omitempty"`
+	WebSocketResponses   bool  `yaml:"websocket_responses,omitempty"`
 
 	// PassthroughMessages controls whether /v1/messages requests for this model are
 	// forwarded as-is to an Anthropic-wire-compatible provider's native /v1/messages
@@ -142,6 +143,7 @@ func (m *ModelRPMConfig) UnmarshalYAML(value *yaml.Node) error {
 		Weight               string `yaml:"weight"`
 		Credential           string `yaml:"credential,omitempty"`
 		PassthroughResponses string `yaml:"passthrough_responses,omitempty"`
+		WebSocketResponses   string `yaml:"websocket_responses,omitempty"`
 		PassthroughMessages  string `yaml:"passthrough_messages,omitempty"`
 	}
 
@@ -157,6 +159,9 @@ func (m *ModelRPMConfig) UnmarshalYAML(value *yaml.Node) error {
 	m.PassthroughMessages = nil
 
 	var err error
+	if m.WebSocketResponses, err = parseField(temp.WebSocketResponses, false, strconv.ParseBool, "websocket_responses"); err != nil {
+		return err
+	}
 	if m.RPM, err = parseField(temp.RPM, 0, strconv.Atoi, "rpm for model '"+m.Name+"'"); err != nil {
 		return err
 	}

--- a/internal/config/websocket_test.go
+++ b/internal/config/websocket_test.go
@@ -1,0 +1,27 @@
+package config
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+	"testing"
+)
+
+func TestModelWebSocketResponsesConfig(t *testing.T) {
+	t.Setenv("TEST_NATIVE_WS", "true")
+	for _, tt := range []struct {
+		yaml string
+		want bool
+	}{
+		{"name: gpt-6-astra", false},
+		{"name: gpt-6-astra\nwebsocket_responses: false", false},
+		{"name: gpt-6-astra\nwebsocket_responses: true", true},
+		{"name: gpt-6-astra\nwebsocket_responses: os.environ/TEST_NATIVE_WS", true},
+	} {
+		var cfg ModelRPMConfig
+		require.NoError(t, yaml.Unmarshal([]byte(tt.yaml), &cfg))
+		assert.Equal(t, tt.want, cfg.WebSocketResponses)
+	}
+	var cfg ModelRPMConfig
+	require.Error(t, yaml.Unmarshal([]byte("name: gpt-6-astra\nwebsocket_responses: invalid"), &cfg))
+}

--- a/internal/converter/openai/gpt6_test.go
+++ b/internal/converter/openai/gpt6_test.go
@@ -1,0 +1,53 @@
+package openai
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReplaceBodyParamGPT6(t *testing.T) {
+	for _, model := range []string{"gpt-6", "gpt-6-astra", "openai/gpt-6-astra", "OpenAI:GPT-6-ASTRA"} {
+		t.Run(model, func(t *testing.T) {
+			body := []byte(`{"max_tokens":100,"max_completion_tokens":200,"max_output_tokens":300,"temperature":0.5,"top_p":0.9,"logprobs":true,"top_logprobs":3,"reasoning_effort":"max","frequency_penalty":0.1}`)
+			got := bodyToMap(t, ReplaceBodyParam(model, body))
+			for _, key := range []string{"max_tokens", "temperature", "top_p", "logprobs", "top_logprobs"} {
+				assert.NotContains(t, got, key)
+			}
+			assert.Equal(t, float64(200), got["max_completion_tokens"])
+			assert.Equal(t, float64(300), got["max_output_tokens"])
+			assert.Equal(t, "max", got["reasoning_effort"])
+			assert.Equal(t, 0.1, got["frequency_penalty"])
+			assert.Equal(t, float64(100), bodyToMap(t, ReplaceBodyParam(model, []byte(`{"max_tokens":100}`)))["max_completion_tokens"])
+		})
+	}
+}
+
+func TestReplaceResponsesBodyParamGPT6(t *testing.T) {
+	for _, model := range []string{"gpt-6-astra", "openai/gpt-6-astra"} {
+		t.Run(model, func(t *testing.T) {
+			body := []byte(`{"temperature":0.5,"top_p":0.9,"top_logprobs":3,"max_output_tokens":300,"reasoning":{"effort":"max","mode":"pro"},"include":["message.output_text.logprobs","reasoning.encrypted_content"],"prompt_cache_options":{"ttl":"30m","mode":"explicit"},"seed":9223372036854775807}`)
+			result := ReplaceResponsesBodyParam(model, body)
+			got := bodyToMap(t, result)
+			for _, key := range []string{"temperature", "top_p", "top_logprobs"} {
+				assert.NotContains(t, got, key)
+			}
+			assert.Equal(t, float64(300), got["max_output_tokens"])
+			assert.Equal(t, []any{"reasoning.encrypted_content"}, got["include"])
+			assert.Equal(t, map[string]any{"effort": "max", "mode": "pro"}, got["reasoning"])
+			assert.Equal(t, map[string]any{"ttl": "30m", "mode": "explicit"}, got["prompt_cache_options"])
+			assert.Contains(t, string(result), `9223372036854775807`)
+			assert.NotContains(t, bodyToMap(t, ReplaceResponsesBodyParam(model, []byte(`{"include":["message.output_text.logprobs"]}`))), "include")
+			assert.Equal(t, []byte(`invalid`), ReplaceResponsesBodyParam(model, []byte(`invalid`)))
+		})
+	}
+}
+
+func TestGPT6RulesLeaveOtherModelsUnchanged(t *testing.T) {
+	body := []byte(`{"temperature":0.5,"include":["message.output_text.logprobs"]}`)
+	for _, model := range []string{"gpt-5.6-sol", "gpt-4o", "gpt-60", "my-gpt-6-astra"} {
+		assert.Equal(t, body, ReplaceResponsesBodyParam(model, body), model)
+	}
+	for _, model := range []string{"gpt-60", "my-gpt-6-astra"} {
+		assert.Equal(t, body, ReplaceBodyParam(model, body), model)
+	}
+}

--- a/internal/converter/openai/gpt6_test.go
+++ b/internal/converter/openai/gpt6_test.go
@@ -51,3 +51,16 @@ func TestGPT6RulesLeaveOtherModelsUnchanged(t *testing.T) {
 		assert.Equal(t, body, ReplaceBodyParam(model, body), model)
 	}
 }
+
+func TestGPT6ResponsesPreservesUnchangedBody(t *testing.T) {
+	for _, raw := range []string{
+		`{ "model": "gpt-6-astra", "input": "hi" }`,
+		`{ "model": "gpt-6-astra", "include": ["reasoning.encrypted_content"], "input": "hi" }`,
+		`{ "model": "gpt-6-astra", "include": [], "input": "hi" }`,
+	} {
+		body := []byte(raw)
+		got := ReplaceResponsesBodyParam("gpt-6-astra", body)
+		assert.Equal(t, raw, string(got))
+		assert.Same(t, &body[0], &got[0])
+	}
+}

--- a/internal/converter/openai/openai_rules.go
+++ b/internal/converter/openai/openai_rules.go
@@ -142,6 +142,11 @@ var gpt5Mapping = ModelParamsMapping{
 	},
 }
 
+var gpt6Mapping = ModelParamsMapping{
+	KeysToReplace: map[string]string{"max_tokens": "max_completion_tokens"},
+	KeysToRemove:  []string{"temperature", "top_p", "logprobs", "top_logprobs"},
+}
+
 // modelMappings maps model family prefixes to their parameter transformations.
 // Order matters: longer prefixes are checked first via matchModelFamily.
 var modelMappings = []struct {
@@ -152,6 +157,7 @@ var modelMappings = []struct {
 	{"o3", o3Mapping},
 	{"o4", o4Mapping},
 	{"gpt-5", gpt5Mapping},
+	{"gpt-6", gpt6Mapping},
 }
 
 // extractBaseModelName strips provider prefixes and known suffixes from a model ID.
@@ -382,4 +388,42 @@ func StripResponseFormat(body []byte) []byte {
 	return UpdateJSONField(body, ModelParamsMapping{
 		KeysToRemove: []string{"response_format"},
 	})
+}
+
+func ReplaceResponsesBodyParam(modelID string, body []byte) []byte {
+	if !matchModelFamily(modelID, "gpt-6") {
+		return body
+	}
+	var data map[string]json.RawMessage
+	if json.Unmarshal(body, &data) != nil {
+		return body
+	}
+	for _, key := range []string{"temperature", "top_p", "top_logprobs"} {
+		delete(data, key)
+	}
+	var include []string
+	if json.Unmarshal(data["include"], &include) == nil {
+		filtered := make([]string, 0, len(include))
+		for _, item := range include {
+			if item != "message.output_text.logprobs" {
+				filtered = append(filtered, item)
+			}
+		}
+		if len(filtered) != len(include) {
+			if len(filtered) == 0 {
+				delete(data, "include")
+			} else {
+				encoded, err := json.Marshal(filtered)
+				if err != nil {
+					return body
+				}
+				data["include"] = encoded
+			}
+		}
+	}
+	updated, err := json.Marshal(data)
+	if err != nil {
+		return body
+	}
+	return updated
 }

--- a/internal/converter/openai/openai_rules.go
+++ b/internal/converter/openai/openai_rules.go
@@ -398,8 +398,12 @@ func ReplaceResponsesBodyParam(modelID string, body []byte) []byte {
 	if json.Unmarshal(body, &data) != nil {
 		return body
 	}
+	changed := false
 	for _, key := range []string{"temperature", "top_p", "top_logprobs"} {
-		delete(data, key)
+		if _, exists := data[key]; exists {
+			delete(data, key)
+			changed = true
+		}
 	}
 	var include []string
 	if json.Unmarshal(data["include"], &include) == nil {
@@ -410,6 +414,7 @@ func ReplaceResponsesBodyParam(modelID string, body []byte) []byte {
 			}
 		}
 		if len(filtered) != len(include) {
+			changed = true
 			if len(filtered) == 0 {
 				delete(data, "include")
 			} else {
@@ -420,6 +425,9 @@ func ReplaceResponsesBodyParam(modelID string, body []byte) []byte {
 				data["include"] = encoded
 			}
 		}
+	}
+	if !changed {
+		return body
 	}
 	updated, err := json.Marshal(data)
 	if err != nil {

--- a/internal/converter/responses/async_tools_test.go
+++ b/internal/converter/responses/async_tools_test.go
@@ -1,0 +1,34 @@
+package responses
+
+import (
+	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestPrepareCodexPassthroughPreservesAsyncFunctionFields(t *testing.T) {
+	body := []byte(`{"tools":[{"type":"function","async":true,"defer_loading":true,"function":{"name":"lookup","strict":true,"parameters":{"type":"object"}}}]}`)
+	var got map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(PrepareCodexPassthrough(body, false), &got))
+	assert.JSONEq(t, `[{"type":"function","async":true,"defer_loading":true,"name":"lookup","strict":true,"parameters":{"type":"object"}}]`, string(got["tools"]))
+}
+
+func TestPrepareCodexPassthroughAdditionalToolsChoice(t *testing.T) {
+	for _, choice := range []string{`"required"`, `{"type":"function","name":"lookup"}`} {
+		for _, additional := range []string{`[]`, `[{"type":"function","name":"lookup","async":true}]`} {
+			t.Run(choice+additional, func(t *testing.T) {
+				var got map[string]json.RawMessage
+				body := []byte(`{"tools":[],"additional_tools":` + additional + `,"tool_choice":` + choice + `}`)
+				require.NoError(t, json.Unmarshal(PrepareCodexPassthrough(body, false), &got))
+				assert.NotContains(t, got, "tools")
+				assert.JSONEq(t, additional, string(got["additional_tools"]))
+				if additional == `[]` {
+					assert.NotContains(t, got, "tool_choice")
+				} else {
+					assert.JSONEq(t, choice, string(got["tool_choice"]))
+				}
+			})
+		}
+	}
+}

--- a/internal/converter/responses/request.go
+++ b/internal/converter/responses/request.go
@@ -440,7 +440,10 @@ func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 		if toolsArr, ok := toolsVal.([]interface{}); ok {
 			if len(toolsArr) == 0 {
 				delete(raw, "tools")
-				delete(raw, "tool_choice")
+				additionalTools, _ := raw["additional_tools"].([]interface{})
+				if len(additionalTools) == 0 {
+					delete(raw, "tool_choice")
+				}
 			} else {
 				normalized := make([]interface{}, len(toolsArr))
 				for i, t := range toolsArr {
@@ -451,7 +454,12 @@ func PrepareCodexPassthrough(body []byte, prevEntryHandled bool) []byte {
 					}
 					if toolMap["type"] == "function" {
 						if funcDef, ok := toolMap["function"].(map[string]interface{}); ok {
-							flat := map[string]interface{}{"type": "function"}
+							flat := make(map[string]interface{}, len(toolMap)+len(funcDef))
+							for k, v := range toolMap {
+								if k != "function" {
+									flat[k] = v
+								}
+							}
 							for k, v := range funcDef {
 								flat[k] = v
 							}

--- a/internal/models/gpt6_test.go
+++ b/internal/models/gpt6_test.go
@@ -1,0 +1,17 @@
+package models
+
+import (
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/stretchr/testify/assert"
+	"log/slog"
+	"testing"
+)
+
+func TestGPT6ResponsesDetection(t *testing.T) {
+	manager := New(slog.Default(), 100, nil)
+	for _, model := range []string{"gpt-6-astra", "openai/gpt-6-astra", "GPT-6-ASTRA"} {
+		assert.True(t, manager.IsPassthroughResponses(model), model)
+		assert.True(t, manager.IsPassthroughResponsesForProvider(model, config.ProviderTypeOpenAI), model)
+		assert.False(t, manager.IsPassthroughResponsesForProvider(model, config.ProviderTypeAnthropic), model)
+	}
+}

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -529,6 +529,7 @@ var responsesAPIModelPrefixes = []string{
 	"gpt-4o",
 	"gpt-4.1",
 	"gpt-5",
+	"gpt-6",
 	"o1",
 	"o3",
 	"o4",

--- a/internal/models/manager.go
+++ b/internal/models/manager.go
@@ -292,13 +292,14 @@ const (
 // Manager handles model discovery and mapping
 type Manager struct {
 	mu                           sync.RWMutex
-	credentialModels             map[string][]string                                // credential name -> list of model IDs
-	allModels                    []Model                                            // deduplicated list of all models
-	modelToCredentials           map[string][]string                                // model ID -> list of credential names
-	modelLimits                  map[string][]ModelLimits                           // model ID -> limits (may have multiple entries for different credentials)
-	staticModelLimits            map[string][]ModelLimits                           // immutable snapshot of limits from config.yaml (never modified after New())
-	staticModelRealNames         map[string]string                                  // immutable snapshot of global real names from config.yaml
-	staticModelRealNamesPerCred  map[string]map[string]string                       // immutable snapshot of per-credential real names: credential -> alias -> real name
+	credentialModels             map[string][]string          // credential name -> list of model IDs
+	allModels                    []Model                      // deduplicated list of all models
+	modelToCredentials           map[string][]string          // model ID -> list of credential names
+	modelLimits                  map[string][]ModelLimits     // model ID -> limits (may have multiple entries for different credentials)
+	staticModelLimits            map[string][]ModelLimits     // immutable snapshot of limits from config.yaml (never modified after New())
+	staticModelRealNames         map[string]string            // immutable snapshot of global real names from config.yaml
+	staticModelRealNamesPerCred  map[string]map[string]string // immutable snapshot of per-credential real names: credential -> alias -> real name
+	modelWebSocketResponses      map[string]bool
 	modelPassthroughResponses    map[string]*bool                                   // model name -> explicit passthrough_responses override (nil = auto)
 	modelPassthroughMessages     map[string]*bool                                   // model name -> explicit passthrough_messages override (nil = provider default)
 	dynamicModelWeights          map[string]map[string]int                          // model ID -> credential -> weight learned from upstream /health
@@ -342,6 +343,7 @@ func New(logger *slog.Logger, defaultModelsRPM int, staticModels []config.ModelR
 		acceptedModelAliases:        make(map[string]string),
 		modelRealNames:              make(map[string]string),
 		modelRealNamesPerCred:       make(map[string]map[string]string),
+		modelWebSocketResponses:     make(map[string]bool),
 		modelPassthroughResponses:   make(map[string]*bool),
 		modelPassthroughMessages:    make(map[string]*bool),
 		dynamicModelWeights:         make(map[string]map[string]int),
@@ -361,6 +363,9 @@ func New(logger *slog.Logger, defaultModelsRPM int, staticModels []config.ModelR
 	if len(staticModels) > 0 {
 		logger.Info("Loading static models from config.yaml", "models_count", len(staticModels))
 		for _, staticModel := range staticModels {
+			if staticModel.WebSocketResponses {
+				m.modelWebSocketResponses[staticModel.Name] = true
+			}
 			m.modelLimits[staticModel.Name] = append(m.modelLimits[staticModel.Name], ModelLimits{
 				RPM:        staticModel.RPM,
 				TPM:        staticModel.TPM,
@@ -560,6 +565,18 @@ var providerPassthroughDefaults = map[config.ProviderType]bool{
 	config.ProviderTypeCometAPI:  false,
 	config.ProviderTypeProMan:    false,
 	config.ProviderTypeBedrock:   false,
+}
+
+func (m *Manager) IsWebSocketResponses(modelID string) bool {
+	if canonical, alias, err := m.ResolvePublicModelAlias(modelID); err == nil && alias {
+		modelID = canonical
+	}
+	if resolved, alias := m.ResolveAlias(modelID); alias {
+		modelID = resolved
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.modelWebSocketResponses[modelID]
 }
 
 // IsPassthroughResponses reports whether Responses API requests for modelID

--- a/internal/models/websocket_test.go
+++ b/internal/models/websocket_test.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestWebSocketResponsesAliases(t *testing.T) {
+	manager := New(testhelpers.NewTestLogger(), 100, []config.ModelRPMConfig{{Name: "astra", Model: "gpt-6-astra", WebSocketResponses: true}, {Name: "gpt-5.6-sol"}})
+	manager.LoadModelsFromConfig([]config.CredentialConfig{{Name: "upstream", Type: config.ProviderTypeOpenAI, BaseURL: "http://example.invalid", APIKey: "test"}})
+	manager.SetModelAliases(map[string]string{"fast": "astra"})
+	manager.SetPublicModelAliases(map[string]string{"public": "astra"})
+	manager.SetAcceptedModelAliases(map[string]string{"hidden": "astra"})
+	for _, name := range []string{"astra", "fast", "public", "hidden"} {
+		assert.True(t, manager.IsWebSocketResponses(name), name)
+	}
+	for _, name := range []string{"gpt-5.6-sol", "unknown"} {
+		assert.False(t, manager.IsWebSocketResponses(name), name)
+	}
+}

--- a/internal/proxy/budget_enforcement.go
+++ b/internal/proxy/budget_enforcement.go
@@ -146,6 +146,9 @@ func (p *Proxy) estimateRequestCost(logCtx *RequestLogContext, publicModelID, mo
 	var promptTokens int
 	if p.tiktokenEnabled {
 		promptTokens = estimatePromptTokensForModel(body, realModelID)
+		if routing := nativeWSRoutingFromContext(logCtx.Context()); routing != nil {
+			promptTokens += routing.historyTokens
+		}
 	}
 	usage := &converter.TokenUsage{
 		PromptTokens:     promptTokens,

--- a/internal/proxy/budget_enforcement.go
+++ b/internal/proxy/budget_enforcement.go
@@ -146,9 +146,7 @@ func (p *Proxy) estimateRequestCost(logCtx *RequestLogContext, publicModelID, mo
 	var promptTokens int
 	if p.tiktokenEnabled {
 		promptTokens = estimatePromptTokensForModel(body, realModelID)
-		if routing := nativeWSRoutingFromContext(logCtx.Context()); routing != nil {
-			promptTokens += routing.historyTokens
-		}
+		promptTokens = addNativeWSHistoryTokens(logCtx.Context(), promptTokens)
 	}
 	usage := &converter.TokenUsage{
 		PromptTokens:     promptTokens,

--- a/internal/proxy/gpt6_http_test.go
+++ b/internal/proxy/gpt6_http_test.go
@@ -1,0 +1,138 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGPT6ResponsesHTTP(t *testing.T) {
+	for _, streaming := range []bool{false, true} {
+		for _, effort := range []string{"max", "pro"} {
+			for _, toolFields := range []string{
+				`"tools":[{"type":"function","async":true,"function":{"name":"lookup","parameters":{"type":"object"}}}],"tool_choice":"required"`,
+				`"tools":[],"additional_tools":[{"type":"function","name":"lookup","async":true}],"tool_choice":{"type":"function","name":"lookup"}`,
+			} {
+				t.Run(fmt.Sprintf("stream=%t/effort=%s/%s", streaming, effort, toolFields), func(t *testing.T) {
+					upstreamBody := make(chan map[string]json.RawMessage, 1)
+					upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						assert.Equal(t, "/v1/responses", r.URL.Path)
+						var body map[string]json.RawMessage
+						if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+							t.Error(err)
+							w.WriteHeader(400)
+							return
+						}
+						upstreamBody <- body
+						response := `{"id":"resp_gpt6","object":"response","model":"gpt-6-astra","status":"completed","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"GPT6_OK"}]}],"usage":{"input_tokens":100,"output_tokens":20,"total_tokens":120,"input_tokens_details":{"cached_tokens":40,"cache_write_tokens":10},"output_tokens_details":{"reasoning_tokens":5}}}`
+						if streaming {
+							w.Header().Set("Content-Type", "text/event-stream")
+							_, _ = fmt.Fprintf(w, "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":%s}\n\ndata: [DONE]\n\n", response)
+						} else {
+							w.Header().Set("Content-Type", "application/json")
+							_, _ = io.WriteString(w, response)
+						}
+					}))
+					defer upstream.Close()
+					prx := NewTestProxyBuilder().WithSingleCredential("upstream", config.ProviderTypeOpenAI, upstream.URL, "upstream-key").WithMasterKey("master-key").Build()
+					dbStub := &stubLiteLLMManager{}
+					prx.LiteLLMDB = dbStub
+					prx.priceRegistry = models.NewModelPriceRegistry()
+					prx.priceRegistry.Update(map[string]*models.ModelPrice{"gpt-6-astra": {
+						InputCostPerToken: 1, OutputCostPerToken: 2, CacheReadInputTokenCost: 0.1, CacheCreationInputTokenCost: 1.25,
+					}})
+					input := `[{"role":"user","content":"test"},{"type":"configuration_update","reasoning":{"effort":"high"}},{"type":"prompt_cache_breakpoint"}]`
+					body := fmt.Sprintf(`{"model":"gpt-6-astra","input":%s,"stream":%t,"max_output_tokens":256,"reasoning":{"effort":%q},"temperature":0.5,"top_p":0.9,"top_logprobs":2,"include":["message.output_text.logprobs","reasoning.encrypted_content"],"prompt_cache_options":{"ttl":"30m","mode":"explicit"},%s}`, input, streaming, effort, toolFields)
+					req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(body))
+					req.Header.Set("Authorization", "Bearer master-key")
+					req.Header.Set("Content-Type", "application/json")
+					recorder := httptest.NewRecorder()
+					prx.ProxyRequest(recorder, req)
+					require.Equal(t, 200, recorder.Code, recorder.Body.String())
+					require.NotEmpty(t, upstreamBody)
+					got := <-upstreamBody
+					assert.JSONEq(t, input, string(got["input"]))
+					assert.JSONEq(t, `{"effort":`+fmt.Sprintf("%q", effort)+`}`, string(got["reasoning"]))
+					assert.JSONEq(t, `{"ttl":"30m","mode":"explicit"}`, string(got["prompt_cache_options"]))
+					assert.Equal(t, "256", string(got["max_output_tokens"]))
+					for _, key := range []string{"temperature", "top_p", "top_logprobs"} {
+						assert.NotContains(t, got, key)
+					}
+					assert.JSONEq(t, `["reasoning.encrypted_content"]`, string(got["include"]))
+					assert.Contains(t, got, "tool_choice")
+					if tools, ok := got["tools"]; ok {
+						assert.JSONEq(t, `[{"type":"function","name":"lookup","async":true,"parameters":{"type":"object"}}]`, string(tools))
+					} else {
+						assert.JSONEq(t, `[{"type":"function","name":"lookup","async":true}]`, string(got["additional_tools"]))
+					}
+					assert.Contains(t, recorder.Body.String(), "GPT6_OK")
+					require.Len(t, dbStub.loggedEntries, 1)
+					entry := dbStub.loggedEntries[0]
+					assert.Equal(t, 100, entry.PromptTokens)
+					assert.Equal(t, 20, entry.CompletionTokens)
+					assert.InDelta(t, 106.5, entry.Spend, 1e-9)
+				})
+			}
+		}
+	}
+}
+
+func TestGPT6HTTPAliasUsesUpstreamModelRules(t *testing.T) {
+	for _, path := range []string{"/v1/responses", "/v1/chat/completions"} {
+		t.Run(path, func(t *testing.T) {
+			upstreamBody := make(chan map[string]json.RawMessage, 1)
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, path, r.URL.Path)
+				var body map[string]json.RawMessage
+				if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+					t.Error(err)
+					w.WriteHeader(400)
+					return
+				}
+				upstreamBody <- body
+				w.Header().Set("Content-Type", "application/json")
+				if path == "/v1/responses" {
+					_, _ = io.WriteString(w, `{"id":"resp_alias","object":"response","model":"gpt-6-astra","status":"completed","output":[],"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}}`)
+				} else {
+					_, _ = io.WriteString(w, `{"id":"chat_alias","object":"chat.completion","model":"gpt-6-astra","choices":[{"index":0,"message":{"role":"assistant","content":"OK"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}`)
+				}
+			}))
+			defer upstream.Close()
+			credential := config.CredentialConfig{Name: "upstream", Type: config.ProviderTypeOpenAI, BaseURL: upstream.URL, APIKey: "upstream-key", RPM: 100, TPM: 10000}
+			prx := NewTestProxyBuilder().WithCredentials(credential).WithMasterKey("master-key").Build()
+			prx.modelManager = models.New(prx.logger, 50, []config.ModelRPMConfig{{Name: "astra", Model: "gpt-6-astra", Credential: "upstream"}})
+			prx.modelManager.LoadModelsFromConfig([]config.CredentialConfig{credential})
+			body := `{"model":"astra","input":"test","max_output_tokens":300,"temperature":0.5,"top_p":0.9,"top_logprobs":2}`
+			if path == "/v1/chat/completions" {
+				body = `{"model":"astra","messages":[{"role":"user","content":"test"}],"max_tokens":200,"reasoning_effort":"max","temperature":0.5,"top_p":0.9,"top_logprobs":2,"logprobs":true}`
+			}
+			req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+			req.Header.Set("Authorization", "Bearer master-key")
+			req.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			prx.ProxyRequest(recorder, req)
+			require.Equal(t, 200, recorder.Code, recorder.Body.String())
+			require.NotEmpty(t, upstreamBody)
+			got := <-upstreamBody
+			assert.JSONEq(t, `"gpt-6-astra"`, string(got["model"]))
+			for _, key := range []string{"temperature", "top_p", "top_logprobs", "logprobs", "max_tokens"} {
+				assert.NotContains(t, got, key)
+			}
+			if path == "/v1/chat/completions" {
+				assert.Equal(t, "200", string(got["max_completion_tokens"]))
+				assert.JSONEq(t, `"max"`, string(got["reasoning_effort"]))
+			} else {
+				assert.Equal(t, "300", string(got["max_output_tokens"]))
+			}
+		})
+	}
+}

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -154,7 +154,7 @@ func (p *Proxy) orchestrateRequest(
 		meta := responses.ExtractResponsesMetadata(body)
 		responsesMetadata = &meta
 
-		if meta.PreviousResponseID != "" && p.responseStore != nil {
+		if meta.PreviousResponseID != "" && p.responseStore != nil && nativeWSRoutingFromContext(r.Context()) == nil {
 			apiKeyHash := litellmdb.HashToken(logCtx.Token)
 			entry, loadErr := p.responseStore.GetEntry(r.Context(), meta.PreviousResponseID, apiKeyHash)
 			if loadErr != nil {
@@ -820,6 +820,19 @@ func (p *Proxy) selectCredentialForModel(
 		logCtx.Logged = true
 
 		WriteErrorNotFound(w, errorMsg)
+		return nil, false
+	}
+
+	if routing := nativeWSRoutingFromContext(logCtx.Context()); routing != nil && routing.credential != "" {
+		if !exclude[routing.credential] {
+			if cred, err := p.balancer.NextSpecificScoped(routing.credential, modelID, logCtx.Scope); err == nil {
+				return cred, true
+			}
+		}
+		logCtx.Status = "failure"
+		logCtx.HTTPStatus = http.StatusTooManyRequests
+		logCtx.ErrorMsg = "WebSocket credential unavailable; reconnect to select another credential"
+		WriteErrorRateLimit(w, logCtx.ErrorMsg)
 		return nil, false
 	}
 

--- a/internal/proxy/orchestrator.go
+++ b/internal/proxy/orchestrator.go
@@ -390,8 +390,8 @@ func (p *Proxy) prepareRequestForCredential(
 
 	switch {
 	case p.modelManager != nil && p.modelManager.IsPassthroughResponsesForProvider(modelID, cred.Type):
-		req.body = responses.PrepareCodexPassthrough(body, prevEntryHandled)
-		req.proxyBody = responses.PrepareCodexPassthrough(proxyBody, prevEntryHandled)
+		req.body = openai.ReplaceResponsesBodyParam(realModelID, responses.PrepareCodexPassthrough(body, prevEntryHandled))
+		req.proxyBody = openai.ReplaceResponsesBodyParam(realModelID, responses.PrepareCodexPassthrough(proxyBody, prevEntryHandled))
 		req.passthroughResponses = true
 		p.logger.DebugContext(r.Context(), "Native Responses API passthrough",
 			"model", modelID, "provider", cred.Type, "streaming", streaming)

--- a/internal/proxy/proxy_websocket.go
+++ b/internal/proxy/proxy_websocket.go
@@ -271,6 +271,11 @@ outerLoop:
 			continue
 		}
 
+		if model, _ := reqMap["model"].(string); p.modelManager != nil && p.modelManager.IsWebSocketResponses(model) {
+			p.handleNativeResponsesWebSocket(conn, r, msg)
+			return
+		}
+
 		// Remove the protocol-level "type" field before forwarding.
 		delete(reqMap, "type")
 

--- a/internal/proxy/proxy_websocket.go
+++ b/internal/proxy/proxy_websocket.go
@@ -228,11 +228,7 @@ func (p *Proxy) HandleWebSocketResponses(w http.ResponseWriter, r *http.Request)
 		p.logger.DebugContext(r.Context(), "ws: upgrade failed", "error", err)
 		return
 	}
-	readLimit := int64(p.maxBodySizeMB) * 1024 * 1024
-	if readLimit <= 0 {
-		readLimit = 1024 * 1024
-	}
-	conn.SetReadLimit(readLimit)
+	conn.SetReadLimit(p.websocketReadLimit())
 	defer func() {
 		if closeErr := conn.Close(); closeErr != nil && p.logger != nil {
 			p.logger.DebugContext(r.Context(), "ws: close failed", "error", closeErr)
@@ -436,4 +432,12 @@ func waitForWSTurn(turnDone, streamDone, requestDone <-chan struct{}) bool {
 	}
 	<-turnDone
 	return true
+}
+
+func (p *Proxy) websocketReadLimit() int64 {
+	limit := int64(p.maxBodySizeMB) * 1024 * 1024
+	if limit <= 0 {
+		return 1024 * 1024
+	}
+	return limit
 }

--- a/internal/proxy/token_estimator.go
+++ b/internal/proxy/token_estimator.go
@@ -335,7 +335,8 @@ func tokenizerForModel(model string) tokenizer.Codec {
 	}
 
 	switch {
-	case strings.HasPrefix(normalized, "gpt-5"),
+	case strings.HasPrefix(normalized, "gpt-6"),
+		strings.HasPrefix(normalized, "gpt-5"),
 		strings.HasPrefix(normalized, "gpt-4.1"),
 		strings.HasPrefix(normalized, "gpt-4.5"),
 		strings.HasPrefix(normalized, "gpt-4o"),

--- a/internal/proxy/token_estimator.go
+++ b/internal/proxy/token_estimator.go
@@ -410,7 +410,11 @@ func (p *Proxy) setPromptTokensEstimate(logCtx *RequestLogContext, body []byte, 
 		return
 	}
 	logCtx.promptTokensEstimateFn = func() int {
-		return estimatePromptTokensForModel(body, model)
+		tokens := estimatePromptTokensForModel(body, model)
+		if routing := nativeWSRoutingFromContext(logCtx.Context()); routing != nil {
+			tokens += routing.historyTokens
+		}
+		return tokens
 	}
 }
 

--- a/internal/proxy/token_estimator.go
+++ b/internal/proxy/token_estimator.go
@@ -411,9 +411,7 @@ func (p *Proxy) setPromptTokensEstimate(logCtx *RequestLogContext, body []byte, 
 	}
 	logCtx.promptTokensEstimateFn = func() int {
 		tokens := estimatePromptTokensForModel(body, model)
-		if routing := nativeWSRoutingFromContext(logCtx.Context()); routing != nil {
-			tokens += routing.historyTokens
-		}
+		tokens = addNativeWSHistoryTokens(logCtx.Context(), tokens)
 		return tokens
 	}
 }

--- a/internal/proxy/token_estimator_test.go
+++ b/internal/proxy/token_estimator_test.go
@@ -19,10 +19,10 @@ func TestEstimatePromptTokensForModel_OpenAIChatUsesTokenizer(t *testing.T) {
 	assert.Equal(t, 8, got)
 }
 
-func TestEstimatePromptTokensForModel_GPT5FamilyUsesTokenizer(t *testing.T) {
+func TestEstimatePromptTokensForModel_GPTReasoningFamiliesUseTokenizer(t *testing.T) {
 	body := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
 
-	for _, model := range []string{"gpt-5", "gpt-5-mini", "gpt-5.5"} {
+	for _, model := range []string{"gpt-5", "gpt-5-mini", "gpt-5.5", "gpt-6-astra", "openai/gpt-6-astra"} {
 		t.Run(model, func(t *testing.T) {
 			got := estimatePromptTokensForModel(body, model)
 
@@ -97,8 +97,8 @@ func TestCountTextTokens_IsNotAdditiveAcrossSubstrings(t *testing.T) {
 	assert.NotEqual(t, full, parts)
 }
 
-func TestCompletionTokenAccumulator_GPT5FamilyUsesTokenizer(t *testing.T) {
-	for _, model := range []string{"gpt-5", "gpt-5-mini", "gpt-5.5"} {
+func TestCompletionTokenAccumulator_GPTReasoningFamiliesUseTokenizer(t *testing.T) {
+	for _, model := range []string{"gpt-5", "gpt-5-mini", "gpt-5.5", "gpt-6-astra", "openai/gpt-6-astra"} {
 		t.Run(model, func(t *testing.T) {
 			acc := newCompletionTokenAccumulator(model)
 			acc.AddChunk([]byte(`data: {"choices":[{"delta":{"content":"hello"}}]}` + "\n\n"))

--- a/internal/proxy/websocket_native.go
+++ b/internal/proxy/websocket_native.go
@@ -1,0 +1,562 @@
+package proxy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/url"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
+	promanutils "github.com/mixaill76/auto_ai_router/internal/converter/proman/utils"
+	"github.com/mixaill76/auto_ai_router/internal/requestid"
+)
+
+const nativeWSMaxResponses = 128
+const nativeWSWriteTimeout = 10 * time.Second
+
+type nativeWSRoutingKey struct{}
+type nativeWSRouting struct {
+	credential    string
+	historyTokens int
+}
+
+func nativeWSRoutingFromContext(ctx context.Context) *nativeWSRouting {
+	routing, _ := ctx.Value(nativeWSRoutingKey{}).(*nativeWSRouting)
+	return routing
+}
+
+type nativeWSMessage struct {
+	body []byte
+	err  error
+}
+type nativeWSTurn struct {
+	log         *RequestLogContext
+	id          string
+	body        []byte
+	accumulator *completionTokenAccumulator
+}
+
+type nativeWSSession struct {
+	proxy            *Proxy
+	client, upstream *websocket.Conn
+	request          *http.Request
+	credential       *config.CredentialConfig
+	model            string
+	targetURL        string
+	actualCredential string
+	denylist         []string
+	realModel        string
+	active, pending  *nativeWSTurn
+	waitingForTools  bool
+	clientAborted    bool
+	template         map[string]json.RawMessage
+	completed        map[string]int
+	turns            int
+}
+
+func readNativeWS(ctx context.Context, conn *websocket.Conn, messages chan<- nativeWSMessage) {
+	for {
+		kind, body, err := conn.ReadMessage()
+		if err == nil && kind != websocket.TextMessage {
+			err = errors.New("expected a text frame")
+		}
+		select {
+		case messages <- nativeWSMessage{body, err}:
+		case <-ctx.Done():
+			return
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+func writeNativeWS(conn *websocket.Conn, body []byte) error {
+	if err := conn.SetWriteDeadline(time.Now().Add(nativeWSWriteTimeout)); err != nil {
+		return err
+	}
+	return conn.WriteMessage(websocket.TextMessage, body)
+}
+
+func (p *Proxy) handleNativeResponsesWebSocket(client *websocket.Conn, r *http.Request, first []byte) {
+	ctx, cancel := context.WithTimeout(r.Context(), time.Hour)
+	defer cancel()
+	s := &nativeWSSession{proxy: p, client: client, request: r.WithContext(ctx), completed: make(map[string]int)}
+	defer s.close()
+	if !s.clientEvent(first) {
+		return
+	}
+	if s.upstream == nil {
+		return
+	}
+	clientMessages := make(chan nativeWSMessage, 1)
+	upstreamMessages := make(chan nativeWSMessage, 1)
+	go readNativeWS(ctx, client, clientMessages)
+	go readNativeWS(ctx, s.upstream, upstreamMessages)
+	var drainTimer *time.Timer
+	var drainDone <-chan time.Time
+	defer func() {
+		if drainTimer != nil {
+			drainTimer.Stop()
+		}
+	}()
+	startDrain := func() {
+		s.clientAborted = true
+		clientMessages = nil
+		if drainTimer == nil {
+			drainTimer = time.NewTimer(streamDrainTimeout)
+			drainDone = drainTimer.C
+		}
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-drainDone:
+			return
+		case msg := <-clientMessages:
+			if msg.err != nil {
+				s.clientAborted = true
+				if p.drainUpstreamOnAbort && (s.active != nil || s.pending != nil) {
+					startDrain()
+					continue
+				}
+				return
+			}
+			if !s.clientEvent(msg.body) {
+				return
+			}
+		case msg := <-upstreamMessages:
+			if msg.err != nil {
+				s.sendError("upstream_disconnected", "Upstream connection closed; reconnect with full input history")
+				return
+			}
+			if !s.upstreamEvent(msg.body) {
+				return
+			}
+			if s.clientAborted {
+				if !p.drainUpstreamOnAbort || (s.active == nil && s.pending == nil) {
+					return
+				}
+				startDrain()
+			}
+		}
+	}
+}
+
+func (s *nativeWSSession) sendError(code, message string) {
+	_ = s.client.SetWriteDeadline(time.Now().Add(nativeWSWriteTimeout))
+	sendWSError(s.client, code, message)
+}
+
+func (s *nativeWSSession) close() {
+	if s.upstream != nil {
+		_ = s.upstream.Close()
+	}
+	_ = s.client.Close()
+	if s.active != nil {
+		outcome := "stream_error"
+		if s.clientAborted {
+			outcome = "client_aborted"
+		}
+		s.finish(s.active, nil, outcome)
+		s.active = nil
+	}
+	s.releasePending()
+}
+
+func (s *nativeWSSession) releasePending() {
+	if s.pending != nil {
+		s.proxy.reconcileBudgetAndRateLimits(s.pending.log, 0)
+		s.pending = nil
+	}
+	s.waitingForTools = false
+}
+
+func (s *nativeWSSession) clientEvent(body []byte) bool {
+	var event map[string]json.RawMessage
+	if json.Unmarshal(body, &event) != nil || event == nil {
+		s.sendError("invalid_request", "Invalid JSON object")
+		return true
+	}
+	var eventType string
+	_ = json.Unmarshal(event["type"], &eventType)
+	switch eventType {
+	case "response.create":
+		return s.create(event)
+	case "response.steer":
+		return s.steer(event)
+	default:
+		s.sendError("invalid_request", "Unsupported WebSocket event")
+		return true
+	}
+}
+
+func (s *nativeWSSession) create(event map[string]json.RawMessage) bool {
+	if s.active != nil || (s.pending != nil && !s.waitingForTools) {
+		s.sendError("response_in_progress", "Wait for the current response or send response.steer")
+		return true
+	}
+	var model, previous string
+	_ = json.Unmarshal(event["model"], &model)
+	_ = json.Unmarshal(event["previous_response_id"], &previous)
+	if model == "" && s.model != "" {
+		model = s.model
+		event["model"], _ = json.Marshal(model)
+	}
+	if s.model != "" && model != s.model {
+		s.sendError("invalid_request", "Reconnect to change models")
+		return true
+	}
+	if previous != "" && !s.hasCompleted(previous) {
+		s.sendError("previous_response_not_found", "Send full input history on a new connection")
+		return true
+	}
+	historyTokens := s.completed[previous]
+	resuming := s.pending != nil
+	if resuming {
+		if previous != s.pending.id {
+			s.sendError("invalid_request", "Return tool results for the steered response")
+			return true
+		}
+		historyTokens = max(historyTokens, s.pending.log.promptTokensEstimate())
+		s.releasePending()
+	}
+	turn, wire, ok := s.prepare(event, historyTokens)
+	if !ok {
+		return s.upstream != nil && !resuming
+	}
+	if s.upstream == nil {
+		if err := s.connect(turn.log); err != nil {
+			turn.log.ErrorMsg = "Upstream WebSocket handshake failed"
+			turn.log.promptTokensEstimateFn = nil
+			s.finish(turn, nil, "stream_error")
+			s.sendError("upstream_websocket_unavailable", "Upstream WebSocket handshake failed")
+			return false
+		}
+	}
+	s.model = model
+	s.realModel = turn.log.RealModelID
+	s.template = event
+	s.active = turn
+	wire["type"] = json.RawMessage(`"response.create"`)
+	encoded, err := json.Marshal(wire)
+	if err != nil {
+		return false
+	}
+	return writeNativeWS(s.upstream, encoded) == nil
+}
+
+func (s *nativeWSSession) steer(event map[string]json.RawMessage) bool {
+	if s.active == nil || s.active.id == "" || s.pending != nil {
+		s.sendError("invalid_request", "Steering requires an active response and no queued steer")
+		return true
+	}
+	var previous string
+	_ = json.Unmarshal(event["previous_response_id"], &previous)
+	if previous != s.active.id {
+		s.sendError("invalid_request", "previous_response_id must identify the active response")
+		return true
+	}
+	for key := range event {
+		if key != "type" && key != "previous_response_id" && key != "input" {
+			s.sendError("invalid_request", "Steering accepts only type, previous_response_id, and input")
+			return true
+		}
+	}
+	if len(event["input"]) == 0 {
+		s.sendError("invalid_request", "Steering input is required")
+		return true
+	}
+	request := make(map[string]json.RawMessage, len(s.template))
+	for key, value := range s.template {
+		request[key] = value
+	}
+	request["input"] = event["input"]
+	delete(request, "previous_response_id")
+	historyTokens := s.active.log.promptTokensEstimate() + s.proxy.estimateCompletionTokens(s.active.body)
+	pending, _, ok := s.prepare(request, historyTokens)
+	if !ok {
+		return true
+	}
+	pending.id = previous
+	s.pending = pending
+	wire, err := json.Marshal(event)
+	if err != nil {
+		return false
+	}
+	return writeNativeWS(s.upstream, wire) == nil
+}
+
+func (s *nativeWSSession) prepare(event map[string]json.RawMessage, historyTokens int) (*nativeWSTurn, map[string]json.RawMessage, bool) {
+	if s.turns >= nativeWSMaxResponses {
+		s.sendError("websocket_limit", "Reconnect after 128 responses")
+		return nil, nil, false
+	}
+	requestBody := make(map[string]json.RawMessage, len(event))
+	for key, value := range event {
+		requestBody[key] = value
+	}
+	delete(requestBody, "type")
+	requestBody["stream"] = json.RawMessage(`true`)
+	body, err := json.Marshal(requestBody)
+	if err != nil {
+		return nil, nil, false
+	}
+	routing := &nativeWSRouting{historyTokens: historyTokens}
+	if s.credential != nil {
+		routing.credential = s.credential.Name
+	}
+	ctx := context.WithValue(s.request.Context(), nativeWSRoutingKey{}, routing)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/v1/responses", bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, false
+	}
+	req.Header = s.request.Header.Clone()
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = s.request.RemoteAddr
+	marker := req.Header.Get(HeaderAIRProxyClient) == "1" || req.Header.Get(HeaderLegacyAIRProxyClient) == "1"
+	req.Header.Del(HeaderAIRProxyClient)
+	req.Header.Del(HeaderLegacyAIRProxyClient)
+	req = captureCredentialDenylist(req, marker)
+	logCtx := &RequestLogContext{RequestID: requestid.New(), EventID: requestid.New(), StartTime: time.Now(), Request: req, Status: "unknown", IsResponsesAPI: true}
+	recorder := newCaptureResponseWriter()
+	prepared, ok := s.proxy.orchestrateRequest(recorder, req, logCtx)
+	if ok {
+		logCtx.Request = prepared.request
+		logCtx.RealModelID = prepared.realModelID
+		if !prepared.passthroughResponses || (prepared.cred.Type != config.ProviderTypeOpenAI && !prepared.cred.IsProxyLike()) {
+			WriteErrorBadRequest(recorder, "Native WebSocket requires an OpenAI-compatible Responses provider")
+			ok = false
+		} else if s.credential != nil && (prepared.cred.Name != s.credential.Name || prepared.cred.APIKey != s.credential.APIKey || prepared.cred.BaseURL != s.credential.BaseURL || prepared.cred.Type != s.credential.Type || prepared.realModelID != s.realModel || !slices.Equal(effectiveCredentialDenylist(prepared.request.Context()), s.denylist)) {
+			WriteErrorBadRequest(recorder, "Routing policy changed; reconnect")
+			ok = false
+		} else {
+			ok = s.proxy.enforceBudgetAndRateLimits(recorder, prepared.request, logCtx, prepared.modelID, prepared.realModelID, prepared.body)
+		}
+	}
+	if !ok {
+		s.proxy.reconcileBudgetAndRateLimits(logCtx, 0)
+		_ = s.client.SetWriteDeadline(time.Now().Add(nativeWSWriteTimeout))
+		sendWSHTTPError(s.client, recorder.body.Bytes(), recorder.statusCode)
+		return nil, nil, false
+	}
+	wireBody := prepared.body
+	if prepared.cred.IsProxyLike() {
+		wireBody = prepared.proxyBody
+	}
+	var wire map[string]json.RawMessage
+	if json.Unmarshal(wireBody, &wire) != nil {
+		s.proxy.reconcileBudgetAndRateLimits(logCtx, 0)
+		return nil, nil, false
+	}
+	delete(wire, "stream")
+	delete(wire, "background")
+	wire["store"] = json.RawMessage(`false`)
+	logCtx.TargetURL = s.targetURL
+	logCtx.WebSearchRequested, logCtx.WebSearchContextSize = extractWebSearchRequestUsage(prepared.body, "application/json")
+	s.proxy.setPromptTokensEstimate(logCtx, prepared.body, prepared.realModelID)
+	logCtx.ActualCredentialName = s.actualCredential
+	s.turns++
+	return &nativeWSTurn{log: logCtx, body: prepared.body, accumulator: s.proxy.newCompletionTokenAccumulator(prepared.realModelID)}, wire, true
+}
+
+func nativeWebSocketURL(baseURL string) (string, error) {
+	target, err := url.Parse(baseURL)
+	if err != nil {
+		return "", err
+	}
+	switch target.Scheme {
+	case "https":
+		target.Scheme = "wss"
+	case "http":
+		target.Scheme = "ws"
+	default:
+		return "", errors.New("expected http or https upstream URL")
+	}
+	if target.Host == "" || target.User != nil {
+		return "", errors.New("invalid upstream URL")
+	}
+	basePath := strings.TrimRight(target.Path, "/")
+	if extractVersionSuffix(basePath) != "" {
+		target.Path = basePath + "/responses"
+	} else {
+		target.Path = basePath + "/v1/responses"
+	}
+	return target.String(), nil
+}
+
+func (s *nativeWSSession) connect(logCtx *RequestLogContext) error {
+	cred := logCtx.Credential
+	target, err := nativeWebSocketURL(cred.BaseURL)
+	if err != nil {
+		return err
+	}
+	headers := make(http.Header)
+	// Handshake headers are rebuilt: client authentication and WebSocket keys never reach the provider.
+	for _, key := range []string{"OpenAI-Beta", "OpenAI-Organization", "OpenAI-Project"} {
+		if value := s.request.Header.Get(key); value != "" {
+			headers.Set(key, value)
+		}
+	}
+	headers.Set("Authorization", "Bearer "+cred.APIKey)
+	if cred.IsProxyLike() {
+		headers.Set(HeaderAIRProxyClient, "1")
+		headers.Set(HeaderLegacyAIRProxyClient, "1")
+		if carriesCredentialDenylist(cred) {
+			if err := setCredentialDenylistHeader(headers, effectiveCredentialDenylist(logCtx.Request.Context())); err != nil {
+				return err
+			}
+		}
+	}
+	dialer := websocket.Dialer{HandshakeTimeout: 30 * time.Second, Proxy: http.ProxyFromEnvironment}
+	conn, response, err := dialer.DialContext(s.request.Context(), target, headers)
+	if response != nil && response.Body != nil {
+		_ = response.Body.Close()
+	}
+	if err != nil {
+		return err
+	}
+	limit := int64(s.proxy.maxBodySizeMB) * 1024 * 1024
+	if limit <= 0 {
+		limit = 1024 * 1024
+	}
+	conn.SetReadLimit(limit)
+	s.upstream = conn
+	snapshot := *cred
+	s.credential = &snapshot
+	s.denylist = slices.Clone(effectiveCredentialDenylist(logCtx.Request.Context()))
+	if cred.IsProxyLike() && response != nil {
+		s.actualCredential = response.Header.Get("X-Credential-Name")
+		logCtx.ActualCredentialName = s.actualCredential
+	}
+	s.targetURL = target
+	return nil
+}
+
+func (s *nativeWSSession) upstreamEvent(body []byte) bool {
+	var event struct {
+		Type       string `json:"type"`
+		ResponseID string `json:"response_id"`
+		Response   struct {
+			ID     string          `json:"id"`
+			Model  string          `json:"model"`
+			Output json.RawMessage `json:"output"`
+		} `json:"response"`
+	}
+	if json.Unmarshal(body, &event) != nil {
+		s.sendError("upstream_protocol_error", "Invalid upstream event")
+		return false
+	}
+	id := event.Response.ID
+	if id == "" {
+		id = event.ResponseID
+	}
+	if id != "" && s.hasCompleted(id) {
+		return true
+	}
+	if event.Type == "response.created" {
+		if s.active == nil && s.pending != nil {
+			s.active = s.pending
+			s.active.id = ""
+			s.pending = nil
+			s.waitingForTools = false
+		}
+		if s.active == nil || s.active.id != "" || id == "" {
+			s.sendError("upstream_protocol_error", "Unexpected response.created")
+			return false
+		}
+		s.active.id = id
+		s.active.log.ClientResponseID = id
+	}
+	if event.Type == "response.steer.pending" {
+		s.waitingForTools = true
+	}
+	if event.Type == "response.steer.failed" {
+		s.releasePending()
+	}
+	if s.active != nil {
+		if id != "" && s.active.id != "" && id != s.active.id {
+			s.sendError("upstream_protocol_error", "Unexpected response ID")
+			return false
+		}
+		chunk := append(append([]byte("data: "), body...), '\n', '\n')
+		s.active.accumulator.AddChunk(chunk)
+		if strings.HasSuffix(event.Type, ".delta") && s.active.log.CompletionStartTime.IsZero() {
+			s.active.log.CompletionStartTime = time.Now()
+		}
+		if event.Response.Model != "" {
+			body = openai.ReplaceModelInBody(body, event.Response.Model, s.active.log.PublicModelID)
+		}
+	}
+	original := body
+	body, _ = promanutils.SanitizeUpstreamJSONBody(body, s.model)
+	delivered := !s.clientAborted && writeNativeWS(s.client, body) == nil
+	if !delivered {
+		s.clientAborted = true
+	}
+	switch event.Type {
+	case "response.completed", "response.done", "response.incomplete", "response.failed":
+		if s.active == nil || id == "" {
+			return false
+		}
+		s.active.log.RequestCompleted = delivered
+		s.finish(s.active, original, "completed")
+		s.completed[id] = s.active.log.TokenUsage.PromptTokens + s.active.log.TokenUsage.CompletionTokens
+		if s.pending != nil {
+			var output []struct {
+				Type  string `json:"type"`
+				Async bool   `json:"async"`
+			}
+			_ = json.Unmarshal(event.Response.Output, &output)
+			for _, item := range output {
+				if !item.Async && (item.Type == "function_call" || item.Type == "custom_tool_call" || item.Type == "mcp_approval_request") {
+					s.waitingForTools = true
+				}
+			}
+		}
+		s.active = nil
+	case "error", "response.error":
+		if s.active != nil {
+			s.finish(s.active, original, "stream_error")
+			s.active = nil
+		}
+		return false
+	}
+	return delivered || (s.clientAborted && s.proxy.drainUpstreamOnAbort)
+}
+
+func (s *nativeWSSession) finish(turn *nativeWSTurn, event []byte, outcome string) {
+	if turn.log.Logged {
+		return
+	}
+	if s.clientAborted && outcome == "completed" {
+		outcome = "client_aborted"
+	}
+	turn.log.StreamOutcome = outcome
+	turn.log.TargetURL = s.targetURL
+	status := http.StatusOK
+	if outcome == "stream_error" {
+		status = http.StatusBadGateway
+	}
+	chunk := append(append([]byte("data: "), event...), '\n', '\n')
+	s.proxy.finalizeStreamingLog(turn.log, turn.accumulator.TokenCount(), chunk, "openai", status, false)
+	if turn.log.Credential != nil && turn.log.TokenUsage != nil {
+		tokens := turn.log.TokenUsage.PromptTokens + turn.log.TokenUsage.CompletionTokens
+		s.proxy.rateLimiter.ConsumeTokens(turn.log.Credential.Name, tokens)
+		s.proxy.rateLimiter.ConsumeModelTokens(turn.log.Credential.Name, turn.log.ModelID, tokens)
+	}
+	s.proxy.reconcileBudgetAndRateLimits(turn.log, 0)
+}
+
+func (s *nativeWSSession) hasCompleted(id string) bool {
+	_, ok := s.completed[id]
+	return ok
+}

--- a/internal/proxy/websocket_native.go
+++ b/internal/proxy/websocket_native.go
@@ -54,6 +54,7 @@ type nativeWSSession struct {
 	denylist         []string
 	realModel        string
 	active, pending  *nativeWSTurn
+	retiring         map[string]*nativeWSTurn
 	waitingForTools  bool
 	clientAborted    bool
 	template         map[string]json.RawMessage
@@ -124,7 +125,7 @@ func (p *Proxy) handleNativeResponsesWebSocket(client *websocket.Conn, r *http.R
 		case msg := <-clientMessages:
 			if msg.err != nil {
 				s.clientAborted = true
-				if p.drainUpstreamOnAbort && (s.active != nil || s.pending != nil) {
+				if p.drainUpstreamOnAbort && (s.active != nil || s.pending != nil || len(s.retiring) != 0) {
 					startDrain()
 					continue
 				}
@@ -142,7 +143,7 @@ func (p *Proxy) handleNativeResponsesWebSocket(client *websocket.Conn, r *http.R
 				return
 			}
 			if s.clientAborted {
-				if !p.drainUpstreamOnAbort || (s.active == nil && s.pending == nil) {
+				if !p.drainUpstreamOnAbort || (s.active == nil && s.pending == nil && len(s.retiring) == 0) {
 					return
 				}
 				startDrain()
@@ -156,18 +157,27 @@ func (s *nativeWSSession) sendError(code, message string) {
 	sendWSError(s.client, code, message)
 }
 
+func (s *nativeWSSession) sendHTTPError(recorder *captureResponseWriter) {
+	_ = s.client.SetWriteDeadline(time.Now().Add(nativeWSWriteTimeout))
+	sendWSHTTPError(s.client, recorder.body.Bytes(), recorder.statusCode)
+}
+
 func (s *nativeWSSession) close() {
 	if s.upstream != nil {
 		_ = s.upstream.Close()
 	}
 	_ = s.client.Close()
+	outcome := "stream_error"
+	if s.clientAborted {
+		outcome = "client_aborted"
+	}
 	if s.active != nil {
-		outcome := "stream_error"
-		if s.clientAborted {
-			outcome = "client_aborted"
-		}
 		s.finish(s.active, nil, outcome)
 		s.active = nil
+	}
+	for id, turn := range s.retiring {
+		s.finish(turn, nil, outcome)
+		delete(s.retiring, id)
 	}
 	s.releasePending()
 }
@@ -227,11 +237,14 @@ func (s *nativeWSSession) create(event map[string]json.RawMessage) bool {
 			return true
 		}
 		historyTokens = max(historyTokens, s.pending.log.promptTokensEstimate())
-		s.releasePending()
+		s.proxy.reconcileBudgetAndRateLimits(s.pending.log, 0)
 	}
 	turn, wire, ok := s.prepare(event, historyTokens)
 	if !ok {
-		return s.upstream != nil && !resuming
+		return s.upstream != nil
+	}
+	if resuming {
+		s.releasePending()
 	}
 	if s.upstream == nil {
 		if err := s.connect(turn.log); err != nil {
@@ -320,6 +333,19 @@ func (s *nativeWSSession) prepare(event map[string]json.RawMessage, historyToken
 		return nil, nil, false
 	}
 	req.Header = s.request.Header.Clone()
+	for _, value := range req.Header.Values("Connection") {
+		for _, key := range strings.Split(value, ",") {
+			req.Header.Del(strings.TrimSpace(key))
+		}
+	}
+	for key := range req.Header {
+		if strings.HasPrefix(strings.ToLower(key), "sec-websocket-") {
+			req.Header.Del(key)
+		}
+	}
+	for _, key := range []string{"Connection", "Upgrade", "Keep-Alive", "Proxy-Connection", "Transfer-Encoding", "TE", "Trailer"} {
+		req.Header.Del(key)
+	}
 	req.Header.Set("Content-Type", "application/json")
 	req.RemoteAddr = s.request.RemoteAddr
 	marker := req.Header.Get(HeaderAIRProxyClient) == "1" || req.Header.Get(HeaderLegacyAIRProxyClient) == "1"
@@ -344,27 +370,21 @@ func (s *nativeWSSession) prepare(event map[string]json.RawMessage, historyToken
 	}
 	if !ok {
 		s.proxy.reconcileBudgetAndRateLimits(logCtx, 0)
-		_ = s.client.SetWriteDeadline(time.Now().Add(nativeWSWriteTimeout))
-		sendWSHTTPError(s.client, recorder.body.Bytes(), recorder.statusCode)
+		s.sendHTTPError(recorder)
 		return nil, nil, false
 	}
 	wireBody := prepared.body
 	if prepared.cred.IsProxyLike() {
 		wireBody = prepared.proxyBody
 	}
-	var wire map[string]json.RawMessage
-	if json.Unmarshal(wireBody, &wire) != nil {
-		s.proxy.reconcileBudgetAndRateLimits(logCtx, 0)
+	wire, ok := s.prepareWireBody(logCtx, wireBody)
+	if !ok {
 		return nil, nil, false
 	}
-	delete(wire, "stream")
-	delete(wire, "background")
-	wire["store"] = json.RawMessage(`false`)
 	logCtx.TargetURL = s.targetURL
 	logCtx.WebSearchRequested, logCtx.WebSearchContextSize = extractWebSearchRequestUsage(prepared.body, "application/json")
 	s.proxy.setPromptTokensEstimate(logCtx, prepared.body, prepared.realModelID)
 	logCtx.ActualCredentialName = s.actualCredential
-	s.turns++
 	return &nativeWSTurn{log: logCtx, body: prepared.body, accumulator: s.proxy.newCompletionTokenAccumulator(prepared.realModelID)}, wire, true
 }
 
@@ -424,11 +444,7 @@ func (s *nativeWSSession) connect(logCtx *RequestLogContext) error {
 	if err != nil {
 		return err
 	}
-	limit := int64(s.proxy.maxBodySizeMB) * 1024 * 1024
-	if limit <= 0 {
-		limit = 1024 * 1024
-	}
-	conn.SetReadLimit(limit)
+	conn.SetReadLimit(s.proxy.websocketReadLimit())
 	s.upstream = conn
 	snapshot := *cred
 	s.credential = &snapshot
@@ -463,7 +479,17 @@ func (s *nativeWSSession) upstreamEvent(body []byte) bool {
 		return true
 	}
 	if event.Type == "response.created" {
-		if s.active == nil && s.pending != nil {
+		if s.retiring[id] != nil {
+			s.sendError("upstream_protocol_error", "Unexpected response.created")
+			return false
+		}
+		if s.pending != nil && id != "" && (s.active == nil || (s.active.id != "" && s.active.id != id)) {
+			if s.active != nil {
+				if s.retiring == nil {
+					s.retiring = make(map[string]*nativeWSTurn)
+				}
+				s.retiring[s.active.id] = s.active
+			}
 			s.active = s.pending
 			s.active.id = ""
 			s.pending = nil
@@ -473,6 +499,7 @@ func (s *nativeWSSession) upstreamEvent(body []byte) bool {
 			s.sendError("upstream_protocol_error", "Unexpected response.created")
 			return false
 		}
+		s.turns++
 		s.active.id = id
 		s.active.log.ClientResponseID = id
 	}
@@ -482,18 +509,22 @@ func (s *nativeWSSession) upstreamEvent(body []byte) bool {
 	if event.Type == "response.steer.failed" {
 		s.releasePending()
 	}
-	if s.active != nil {
-		if id != "" && s.active.id != "" && id != s.active.id {
+	turn := s.active
+	if retiring := s.retiring[id]; retiring != nil {
+		turn = retiring
+	}
+	if turn != nil {
+		if id != "" && turn.id != "" && id != turn.id {
 			s.sendError("upstream_protocol_error", "Unexpected response ID")
 			return false
 		}
-		chunk := append(append([]byte("data: "), body...), '\n', '\n')
-		s.active.accumulator.AddChunk(chunk)
-		if strings.HasSuffix(event.Type, ".delta") && s.active.log.CompletionStartTime.IsZero() {
-			s.active.log.CompletionStartTime = time.Now()
+		chunk := sseDataFrame(body)
+		turn.accumulator.AddChunk(chunk)
+		if strings.HasSuffix(event.Type, ".delta") && turn.log.CompletionStartTime.IsZero() {
+			turn.log.CompletionStartTime = time.Now()
 		}
 		if event.Response.Model != "" {
-			body = openai.ReplaceModelInBody(body, event.Response.Model, s.active.log.PublicModelID)
+			body = openai.ReplaceModelInBody(body, event.Response.Model, turn.log.PublicModelID)
 		}
 	}
 	original := body
@@ -504,13 +535,13 @@ func (s *nativeWSSession) upstreamEvent(body []byte) bool {
 	}
 	switch event.Type {
 	case "response.completed", "response.done", "response.incomplete", "response.failed":
-		if s.active == nil || id == "" {
+		if turn == nil || id == "" {
 			return false
 		}
-		s.active.log.RequestCompleted = delivered
-		s.finish(s.active, original, "completed")
-		s.completed[id] = s.active.log.TokenUsage.PromptTokens + s.active.log.TokenUsage.CompletionTokens
-		if s.pending != nil {
+		turn.log.RequestCompleted = delivered
+		s.finish(turn, original, "completed")
+		s.completed[id] = turn.log.TokenUsage.PromptTokens + turn.log.TokenUsage.CompletionTokens
+		if s.pending != nil && turn == s.active {
 			var output []struct {
 				Type  string `json:"type"`
 				Async bool   `json:"async"`
@@ -522,11 +553,17 @@ func (s *nativeWSSession) upstreamEvent(body []byte) bool {
 				}
 			}
 		}
-		s.active = nil
-	case "error", "response.error":
-		if s.active != nil {
-			s.finish(s.active, original, "stream_error")
+		if turn == s.active {
 			s.active = nil
+		}
+		delete(s.retiring, id)
+	case "error", "response.error":
+		if turn != nil {
+			s.finish(turn, original, "stream_error")
+			if turn == s.active {
+				s.active = nil
+			}
+			delete(s.retiring, id)
 		}
 		return false
 	}
@@ -546,7 +583,7 @@ func (s *nativeWSSession) finish(turn *nativeWSTurn, event []byte, outcome strin
 	if outcome == "stream_error" {
 		status = http.StatusBadGateway
 	}
-	chunk := append(append([]byte("data: "), event...), '\n', '\n')
+	chunk := sseDataFrame(event)
 	s.proxy.finalizeStreamingLog(turn.log, turn.accumulator.TokenCount(), chunk, "openai", status, false)
 	if turn.log.Credential != nil && turn.log.TokenUsage != nil {
 		tokens := turn.log.TokenUsage.PromptTokens + turn.log.TokenUsage.CompletionTokens
@@ -559,4 +596,28 @@ func (s *nativeWSSession) finish(turn *nativeWSTurn, event []byte, outcome strin
 func (s *nativeWSSession) hasCompleted(id string) bool {
 	_, ok := s.completed[id]
 	return ok
+}
+
+func sseDataFrame(body []byte) []byte {
+	return append(append([]byte("data: "), body...), '\n', '\n')
+}
+
+func addNativeWSHistoryTokens(ctx context.Context, tokens int) int {
+	if routing := nativeWSRoutingFromContext(ctx); routing != nil {
+		tokens += routing.historyTokens
+	}
+	return tokens
+}
+
+func (s *nativeWSSession) prepareWireBody(logCtx *RequestLogContext, wireBody []byte) (map[string]json.RawMessage, bool) {
+	var wire map[string]json.RawMessage
+	if json.Unmarshal(wireBody, &wire) != nil || wire == nil {
+		s.proxy.reconcileBudgetAndRateLimits(logCtx, 0)
+		s.sendError("internal_error", "Failed to prepare upstream request")
+		return nil, false
+	}
+	delete(wire, "stream")
+	delete(wire, "background")
+	wire["store"] = json.RawMessage(`false`)
+	return wire, true
 }

--- a/internal/proxy/websocket_native_test.go
+++ b/internal/proxy/websocket_native_test.go
@@ -1,0 +1,470 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/litellmdb"
+	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type nativeWSTestDB struct {
+	*clientAuthTestDB
+	entries chan *dbmodels.SpendLogEntry
+}
+
+func (d *nativeWSTestDB) SpendLoggingEnabled() bool { return true }
+func (d *nativeWSTestDB) LogSpend(entry *dbmodels.SpendLogEntry) error {
+	d.entries <- entry
+	return nil
+}
+
+type nativeWSFixture struct {
+	proxy    *Proxy
+	db       *nativeWSTestDB
+	client   *websocket.Conn
+	accepted chan *websocket.Conn
+}
+
+func newNativeWSFixture(t *testing.T, provider config.ProviderType, basePath string, options ...func(*Proxy)) *nativeWSFixture {
+	t.Helper()
+	accepted := make(chan *websocket.Conn, 1)
+	done := make(chan struct{})
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, basePath+"/v1/responses", r.URL.Path)
+		assert.Equal(t, "configured=yes", r.URL.RawQuery)
+		assert.Equal(t, "Bearer upstream-key", r.Header.Get("Authorization"))
+		assert.Empty(t, r.Header.Get("Cookie"))
+		assert.Empty(t, r.Header.Get("X-Api-Key"))
+		assert.Equal(t, "responses_websockets=2026-02-06", r.Header.Get("OpenAI-Beta"))
+		if provider.IsProxyLike() {
+			assert.Equal(t, "1", r.Header.Get(HeaderAIRProxyClient))
+		}
+		conn, err := wsUpgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		accepted <- conn
+		<-done
+	}))
+	t.Cleanup(upstream.Close)
+	t.Cleanup(func() { close(done) })
+	cred := config.CredentialConfig{Name: "upstream", Type: provider, BaseURL: upstream.URL + basePath + "?configured=yes", APIKey: "upstream-key", RPM: 1000, TPM: 1000000}
+	prx := NewTestProxyBuilder().WithCredentials(cred).WithMasterKey("master-key").Build()
+	prx.modelManager = models.New(prx.logger, 1000, []config.ModelRPMConfig{{Name: "astra", Model: "gpt-6-astra", Credential: "upstream", WebSocketResponses: true}})
+	prx.modelManager.LoadModelsFromConfig([]config.CredentialConfig{cred})
+	db := &nativeWSTestDB{clientAuthTestDB: &clientAuthTestDB{tokens: map[string]*dbmodels.TokenInfo{"client-key": {Token: "client-hash", Models: []string{"astra"}}}, errors: make(map[string]error)}, entries: make(chan *dbmodels.SpendLogEntry, 32)}
+	prx.LiteLLMDB = db
+	prx.strictAllTeamModelsACL = true
+	for _, option := range options {
+		option(prx)
+	}
+	prx.priceRegistry = models.NewModelPriceRegistry()
+	prx.priceRegistry.Update(map[string]*models.ModelPrice{"astra": {InputCostPerToken: 1, OutputCostPerToken: 2, CacheReadInputTokenCost: 0.1, CacheCreationInputTokenCost: 1.25}})
+	server := httptest.NewServer(http.HandlerFunc(prx.HandleWebSocketResponses))
+	t.Cleanup(server.Close)
+	client, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses?api-key=do-not-forward", http.Header{
+		"Authorization": {"Bearer client-key"}, "Cookie": {"session=private"}, "Openai-Beta": {"responses_websockets=2026-02-06"},
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusSwitchingProtocols, response.StatusCode)
+	t.Cleanup(func() { _ = client.Close() })
+	return &nativeWSFixture{prx, db, client, accepted}
+}
+
+func wsWrite(t *testing.T, conn *websocket.Conn, body string) {
+	t.Helper()
+	require.NoError(t, writeNativeWS(conn, []byte(body)))
+}
+func wsRead(t *testing.T, conn *websocket.Conn) map[string]json.RawMessage {
+	t.Helper()
+	require.NoError(t, conn.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, body, err := conn.ReadMessage()
+	require.NoError(t, err)
+	var event map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(body, &event))
+	return event
+}
+func wsEvent(t *testing.T, conn *websocket.Conn, typ string) map[string]json.RawMessage {
+	t.Helper()
+	event := wsRead(t, conn)
+	assert.JSONEq(t, fmt.Sprintf("%q", typ), string(event["type"]))
+	return event
+}
+func (f *nativeWSFixture) upstream(t *testing.T) *websocket.Conn {
+	t.Helper()
+	select {
+	case conn := <-f.accepted:
+		return conn
+	case <-time.After(5 * time.Second):
+		t.Fatal("no upstream handshake")
+		return nil
+	}
+}
+func (f *nativeWSFixture) entry(t *testing.T) *dbmodels.SpendLogEntry {
+	t.Helper()
+	select {
+	case entry := <-f.db.entries:
+		return entry
+	case <-time.After(5 * time.Second):
+		t.Fatal("no spend entry")
+		return nil
+	}
+}
+func wsCreated(id string) string {
+	return fmt.Sprintf(`{"type":"response.created","response":{"id":%q,"model":"gpt-6-astra","status":"in_progress"}}`, id)
+}
+func wsCompleted(id string) string {
+	return fmt.Sprintf(`{"type":"response.completed","response":{"id":%q,"model":"gpt-6-astra","status":"completed","output":[],"usage":{"input_tokens":100,"output_tokens":20,"input_tokens_details":{"cached_tokens":40,"cache_write_tokens":10},"output_tokens_details":{"reasoning_tokens":5}}}}`, id)
+}
+
+func TestNativeWebSocketSteeringAndBilling(t *testing.T) {
+	for _, provider := range []config.ProviderType{config.ProviderTypeOpenAI, config.ProviderTypeProxy} {
+		t.Run(string(provider), func(t *testing.T) {
+			f := newNativeWSFixture(t, provider, "/openai")
+			wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"plan","reasoning":{"effort":"max"},"temperature":0.4,"max_output_tokens":256,"prompt_cache_options":{"ttl":"30m","mode":"explicit"},"additional_tools":[{"type":"function","name":"lookup","async":true}],"tool_choice":"required"}`)
+			upstream := f.upstream(t)
+			request := wsEvent(t, upstream, "response.create")
+			expectedModel := `"gpt-6-astra"`
+			if provider.IsProxyLike() {
+				expectedModel = `"astra"`
+			}
+			assert.JSONEq(t, expectedModel, string(request["model"]))
+			assert.NotContains(t, request, "stream")
+			if !provider.IsProxyLike() {
+				assert.NotContains(t, request, "temperature")
+			}
+			assert.Equal(t, "false", string(request["store"]))
+			assert.JSONEq(t, `{"effort":"max"}`, string(request["reasoning"]))
+			assert.JSONEq(t, `{"ttl":"30m","mode":"explicit"}`, string(request["prompt_cache_options"]))
+			assert.JSONEq(t, `[{"type":"function","name":"lookup","async":true}]`, string(request["additional_tools"]))
+			wsWrite(t, upstream, wsCreated("resp_1"))
+			created := wsEvent(t, f.client, "response.created")
+			assert.Contains(t, string(created["response"]), `"model":"astra"`)
+			wsWrite(t, upstream, `{"type":"response.output_text.delta","response_id":"resp_1","delta":"Draft"}`)
+			wsEvent(t, f.client, "response.output_text.delta")
+			steer := `{"type":"response.steer","previous_response_id":"resp_1","input":"Keep it short"}`
+			wsWrite(t, f.client, steer)
+			got := wsEvent(t, upstream, "response.steer")
+			assert.JSONEq(t, `"resp_1"`, string(got["previous_response_id"]))
+			wsWrite(t, upstream, `{"type":"response.steer.accepted","steer":{"id":"steer_1","previous_response_id":"resp_1"}}`)
+			wsEvent(t, f.client, "response.steer.accepted")
+			wsWrite(t, upstream, `{"type":"response.incomplete","response":{"id":"resp_1","status":"incomplete","incomplete_details":{"reason":"steered"},"usage":{"input_tokens":10,"output_tokens":3}}}`)
+			wsEvent(t, f.client, "response.incomplete")
+			first := f.entry(t)
+			assert.Equal(t, 10, first.PromptTokens)
+			assert.InDelta(t, 16, first.Spend, 1e-9)
+			wsWrite(t, upstream, wsCreated("resp_2"))
+			wsEvent(t, f.client, "response.created")
+			wsWrite(t, upstream, wsCompleted("resp_2"))
+			wsEvent(t, f.client, "response.completed")
+			second := f.entry(t)
+			assert.Equal(t, 100, second.PromptTokens)
+			assert.Equal(t, 20, second.CompletionTokens)
+			assert.InDelta(t, 106.5, second.Spend, 1e-9)
+			assert.NotEqual(t, first.RequestID, second.RequestID)
+			wsWrite(t, upstream, wsCompleted("resp_2"))
+			wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_2","input":[{"type":"function_call_output","call_id":"call_1","output":"done"},{"type":"configuration_update","reasoning":{"effort":"high"}}]}`)
+			next := wsEvent(t, upstream, "response.create")
+			assert.JSONEq(t, `"resp_2"`, string(next["previous_response_id"]))
+			assert.JSONEq(t, `[{"type":"function_call_output","call_id":"call_1","output":"done"},{"type":"configuration_update","reasoning":{"effort":"high"}}]`, string(next["input"]))
+			wsWrite(t, upstream, wsCreated("resp_3"))
+			wsEvent(t, f.client, "response.created")
+			wsWrite(t, upstream, wsCompleted("resp_3"))
+			wsEvent(t, f.client, "response.completed")
+			third := f.entry(t)
+			assert.NotEqual(t, second.RequestID, third.RequestID)
+			select {
+			case extra := <-f.db.entries:
+				t.Fatalf("duplicate charge: %+v", extra)
+			default:
+			}
+		})
+	}
+}
+
+func TestNativeWebSocketPendingToolSteer(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"lookup"}`)
+	upstream := f.upstream(t)
+	wsEvent(t, upstream, "response.create")
+	wsWrite(t, upstream, wsCreated("resp_1"))
+	wsEvent(t, f.client, "response.created")
+	wsWrite(t, f.client, `{"type":"response.steer","previous_response_id":"resp_1","input":"summarize"}`)
+	wsEvent(t, upstream, "response.steer")
+	wsWrite(t, upstream, `{"type":"response.completed","response":{"id":"resp_1","output":[{"type":"function_call","name":"lookup","call_id":"call_1","arguments":"{}"}],"usage":{"input_tokens":4,"output_tokens":2}}}`)
+	wsEvent(t, f.client, "response.completed")
+	f.entry(t)
+	wsWrite(t, upstream, `{"type":"response.steer.pending","steer":{"previous_response_id":"resp_1"},"required_input":[{"type":"function_call_output","call_id":"call_1"}]}`)
+	wsEvent(t, f.client, "response.steer.pending")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"42"}]}`)
+	resumed := wsEvent(t, upstream, "response.create")
+	assert.JSONEq(t, `[{"type":"function_call_output","call_id":"call_1","output":"42"}]`, string(resumed["input"]))
+	wsWrite(t, upstream, wsCreated("resp_2"))
+	wsEvent(t, f.client, "response.created")
+	wsWrite(t, upstream, wsCompleted("resp_2"))
+	wsEvent(t, f.client, "response.completed")
+	f.entry(t)
+}
+
+func TestNativeWebSocketRechecksAccess(t *testing.T) {
+	for _, steering := range []bool{false, true} {
+		t.Run(fmt.Sprint(steering), func(t *testing.T) {
+			f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+			wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"hi"}`)
+			upstream := f.upstream(t)
+			wsEvent(t, upstream, "response.create")
+			wsWrite(t, upstream, wsCreated("resp_1"))
+			wsEvent(t, f.client, "response.created")
+			if !steering {
+				wsWrite(t, upstream, wsCompleted("resp_1"))
+				wsEvent(t, f.client, "response.completed")
+				f.entry(t)
+			}
+			f.db.mu.Lock()
+			f.db.errors["client-key"] = litellmdb.ErrTokenNotFound
+			f.db.mu.Unlock()
+			request := `{"type":"response.create","model":"astra","previous_response_id":"resp_1","input":"hi"}`
+			if steering {
+				request = `{"type":"response.steer","previous_response_id":"resp_1","input":"hi"}`
+			}
+			wsWrite(t, f.client, request)
+			event := wsEvent(t, f.client, "error")
+			assert.Contains(t, string(event["error"]), "Invalid")
+		})
+	}
+}
+
+func TestNativeWebSocketRejectsInvalidContinuation(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"hi"}`)
+	upstream := f.upstream(t)
+	wsEvent(t, upstream, "response.create")
+	wsWrite(t, upstream, wsCreated("resp_1"))
+	wsEvent(t, f.client, "response.created")
+	for _, request := range []string{
+		`{"type":"response.create","model":"astra","input":"overlap"}`,
+		`{"type":"response.steer","previous_response_id":"foreign","input":"hi"}`,
+		`{"type":"response.steer","previous_response_id":"resp_1","model":"other","input":"hi"}`,
+		`{"type":"unsupported"}`,
+	} {
+		wsWrite(t, f.client, request)
+		wsEvent(t, f.client, "error")
+	}
+	wsWrite(t, upstream, wsCompleted("resp_1"))
+	wsEvent(t, f.client, "response.completed")
+	f.entry(t)
+	for _, request := range []string{
+		`{"type":"response.create","model":"other","input":"hi"}`,
+		`{"type":"response.create","model":"astra","previous_response_id":"foreign","input":"hi"}`,
+	} {
+		wsWrite(t, f.client, request)
+		wsEvent(t, f.client, "error")
+	}
+	f.proxy.balancer.BanUntil("upstream", "astra", 429, time.Now().Add(time.Hour), "test")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_1","input":"hi"}`)
+	rejected := wsEvent(t, f.client, "error")
+	assert.Contains(t, string(rejected["error"]), "credential unavailable")
+}
+
+func TestNativeWebSocketURL(t *testing.T) {
+	for _, tt := range []struct{ base, want string }{
+		{"https://api.openai.com/v1", "wss://api.openai.com/v1/responses"},
+		{"https://resource.openai.azure.com/openai/v1", "wss://resource.openai.azure.com/openai/v1/responses"},
+		{"https://resource.openai.azure.com/openai", "wss://resource.openai.azure.com/openai/v1/responses"},
+		{"http://localhost:8080?api-version=preview", "ws://localhost:8080/v1/responses?api-version=preview"},
+	} {
+		got, err := nativeWebSocketURL(tt.base)
+		require.NoError(t, err)
+		assert.Equal(t, tt.want, got)
+	}
+	for _, base := range []string{"wss://example.com", "/relative", "https://user:password@example.com"} {
+		_, err := nativeWebSocketURL(base)
+		require.Error(t, err)
+	}
+}
+
+func TestNativeWebSocketHistoryBudgetEstimate(t *testing.T) {
+	prx := NewTestProxyBuilder().Build()
+	setTestModelPrice(prx, "gpt-6-astra", &models.ModelPrice{InputCostPerToken: 1, OutputCostPerToken: 2})
+	body := []byte(`{"input":"new input","max_output_tokens":10}`)
+	plain := &RequestLogContext{}
+	base, ok := prx.estimateRequestCost(plain, "gpt-6-astra", "gpt-6-astra", "gpt-6-astra", body)
+	require.True(t, ok)
+	ctx := context.WithValue(context.Background(), nativeWSRoutingKey{}, &nativeWSRouting{historyTokens: 1000})
+	logCtx := &RequestLogContext{Request: httptest.NewRequest(http.MethodPost, "/v1/responses", nil).WithContext(ctx)}
+	got, ok := prx.estimateRequestCost(logCtx, "gpt-6-astra", "gpt-6-astra", "gpt-6-astra", body)
+	require.True(t, ok)
+	assert.Equal(t, base+1000, got)
+	prx.setPromptTokensEstimate(logCtx, body, "gpt-6-astra")
+	assert.Equal(t, 1000+estimatePromptTokensForModel(body, "gpt-6-astra"), logCtx.promptTokensEstimate())
+}
+
+func TestNativeWebSocketSteerFailureAllowsRetry(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"hi"}`)
+	upstream := f.upstream(t)
+	wsEvent(t, upstream, "response.create")
+	wsWrite(t, upstream, wsCreated("resp_1"))
+	wsEvent(t, f.client, "response.created")
+	steer := `{"type":"response.steer","previous_response_id":"resp_1","input":"shorter"}`
+	wsWrite(t, f.client, steer)
+	wsEvent(t, upstream, "response.steer")
+	wsWrite(t, upstream, `{"type":"response.steer.failed","steer":{"previous_response_id":"resp_1"},"error":{"code":"invalid_input","message":"upstream private details"}}`)
+	event := wsEvent(t, f.client, "response.steer.failed")
+	assert.NotContains(t, string(event["error"]), "upstream private details")
+	wsWrite(t, f.client, steer)
+	wsEvent(t, upstream, "response.steer")
+	wsWrite(t, upstream, wsCompleted("resp_1"))
+	wsEvent(t, f.client, "response.completed")
+	f.entry(t)
+	wsWrite(t, upstream, wsCreated("resp_2"))
+	wsEvent(t, f.client, "response.created")
+	wsWrite(t, upstream, wsCompleted("resp_2"))
+	wsEvent(t, f.client, "response.completed")
+	f.entry(t)
+	select {
+	case extra := <-f.db.entries:
+		t.Fatalf("unused steer charged: %+v", extra)
+	default:
+	}
+}
+
+func TestNativeWebSocketHandshakeFailureDoesNotCharge(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "private provider error", http.StatusBadGateway)
+	}))
+	defer upstream.Close()
+	cred := config.CredentialConfig{Name: "upstream", Type: config.ProviderTypeOpenAI, BaseURL: upstream.URL, APIKey: "upstream-key", RPM: 100, TPM: 10000}
+	prx := NewTestProxyBuilder().WithCredentials(cred).Build()
+	prx.modelManager = models.New(prx.logger, 100, []config.ModelRPMConfig{{Name: "gpt-6-astra", Credential: "upstream", WebSocketResponses: true}})
+	prx.modelManager.LoadModelsFromConfig([]config.CredentialConfig{cred})
+	db := &nativeWSTestDB{clientAuthTestDB: &clientAuthTestDB{}, entries: make(chan *dbmodels.SpendLogEntry, 1)}
+	prx.LiteLLMDB = db
+	setTestModelPrice(prx, "gpt-6-astra", &models.ModelPrice{InputCostPerToken: 1, OutputCostPerToken: 2})
+	server := httptest.NewServer(http.HandlerFunc(prx.HandleWebSocketResponses))
+	defer server.Close()
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses", http.Header{"Authorization": {"Bearer master-key"}})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	wsWrite(t, conn, `{"type":"response.create","model":"gpt-6-astra","input":"should not be billed"}`)
+	event := wsEvent(t, conn, "error")
+	assert.NotContains(t, string(event["error"]), "private provider error")
+	select {
+	case entry := <-db.entries:
+		assert.Zero(t, entry.Spend)
+		assert.Zero(t, entry.PromptTokens)
+	case <-time.After(5 * time.Second):
+		t.Fatal("missing failure log")
+	}
+}
+
+func TestNativeWebSocketOptOutUsesHTTP(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodPost, r.Method)
+		assert.False(t, websocket.IsWebSocketUpgrade(r))
+		w.Header().Set("Content-Type", "text/event-stream")
+		_, _ = fmt.Fprintf(w, "data: %s\n\ndata: [DONE]\n\n", wsCompleted("resp_http"))
+	}))
+	defer upstream.Close()
+	prx := NewTestProxyBuilder().WithSingleCredential("upstream", config.ProviderTypeOpenAI, upstream.URL, "upstream-key").Build()
+	server := httptest.NewServer(http.HandlerFunc(prx.HandleWebSocketResponses))
+	defer server.Close()
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http")+"/v1/responses", http.Header{"Authorization": {"Bearer master-key"}})
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+	wsWrite(t, conn, `{"type":"response.create","model":"gpt-6-astra","input":"hi"}`)
+	wsEvent(t, conn, "response.completed")
+}
+
+func TestNativeWebSocketDrainsUsageAfterDisconnect(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "", func(p *Proxy) { p.drainUpstreamOnAbort = true })
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"hi"}`)
+	upstream := f.upstream(t)
+	wsEvent(t, upstream, "response.create")
+	wsWrite(t, upstream, wsCreated("resp_1"))
+	wsEvent(t, f.client, "response.created")
+	require.NoError(t, f.client.Close())
+	wsWrite(t, upstream, wsCompleted("resp_1"))
+	entry := f.entry(t)
+	assert.Equal(t, 100, entry.PromptTokens)
+	assert.Equal(t, 20, entry.CompletionTokens)
+	assert.InDelta(t, 106.5, entry.Spend, 1e-9)
+	require.NoError(t, upstream.SetReadDeadline(time.Now().Add(5*time.Second)))
+	_, _, err := upstream.ReadMessage()
+	require.Error(t, err)
+}
+
+func TestNativeWebSocketRechecksModelAndBudget(t *testing.T) {
+	for _, blockedBy := range []string{"model", "budget"} {
+		t.Run(blockedBy, func(t *testing.T) {
+			f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+			wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"hi"}`)
+			upstream := f.upstream(t)
+			wsEvent(t, upstream, "response.create")
+			wsWrite(t, upstream, wsCreated("resp_1"))
+			wsEvent(t, f.client, "response.created")
+			wsWrite(t, upstream, wsCompleted("resp_1"))
+			wsEvent(t, f.client, "response.completed")
+			f.entry(t)
+			f.db.mu.Lock()
+			info := *f.db.tokens["client-key"]
+			if blockedBy == "model" {
+				info.Models = []string{"different-model"}
+			} else {
+				info.Spend = 10
+				info.MaxBudget = pointerTo(1.0)
+			}
+			f.db.tokens["client-key"] = &info
+			f.db.mu.Unlock()
+			wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_1","input":"hi"}`)
+			wsEvent(t, f.client, "error")
+		})
+	}
+}
+
+func TestNativeWebSocketCannotResumeAnotherConnection(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_other_connection","input":"hi"}`)
+	event := wsEvent(t, f.client, "error")
+	assert.Contains(t, string(event["error"]), "previous_response_not_found")
+	select {
+	case <-f.accepted:
+		t.Fatal("foreign response reached upstream")
+	default:
+	}
+}
+
+func TestNativeWebSocketDisconnectUsesUsageEstimate(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"estimate these input tokens"}`)
+	upstream := f.upstream(t)
+	wsEvent(t, upstream, "response.create")
+	wsWrite(t, upstream, wsCreated("resp_1"))
+	wsEvent(t, f.client, "response.created")
+	wsWrite(t, upstream, `{"type":"response.output_text.delta","response_id":"resp_1","delta":"partial response"}`)
+	wsEvent(t, f.client, "response.output_text.delta")
+	require.NoError(t, upstream.Close())
+	wsEvent(t, f.client, "error")
+	entry := f.entry(t)
+	assert.Positive(t, entry.PromptTokens)
+	assert.Positive(t, entry.CompletionTokens)
+	select {
+	case <-f.accepted:
+		t.Fatal("unexpected automatic reconnect")
+	default:
+	}
+}

--- a/internal/proxy/websocket_native_test.go
+++ b/internal/proxy/websocket_native_test.go
@@ -210,6 +210,23 @@ func TestNativeWebSocketPendingToolSteer(t *testing.T) {
 	f.entry(t)
 	wsWrite(t, upstream, `{"type":"response.steer.pending","steer":{"previous_response_id":"resp_1"},"required_input":[{"type":"function_call_output","call_id":"call_1"}]}`)
 	wsEvent(t, f.client, "response.steer.pending")
+	f.db.mu.Lock()
+	info := *f.db.tokens["client-key"]
+	info.Spend = 10
+	info.MaxBudget = pointerTo(1.0)
+	f.db.tokens["client-key"] = &info
+	f.db.mu.Unlock()
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"42"}]}`)
+	wsEvent(t, f.client, "error")
+	f.db.mu.Lock()
+	restored := info
+	restored.Spend = 0
+	restored.MaxBudget = nil
+	f.db.tokens["client-key"] = &restored
+	f.db.mu.Unlock()
+	wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"wrong continuation"}`)
+	invalid := wsEvent(t, f.client, "error")
+	assert.Contains(t, string(invalid["error"]), "Return tool results")
 	wsWrite(t, f.client, `{"type":"response.create","model":"astra","previous_response_id":"resp_1","input":[{"type":"function_call_output","call_id":"call_1","output":"42"}]}`)
 	resumed := wsEvent(t, upstream, "response.create")
 	assert.JSONEq(t, `[{"type":"function_call_output","call_id":"call_1","output":"42"}]`, string(resumed["input"]))
@@ -321,11 +338,13 @@ func TestNativeWebSocketSteerFailureAllowsRetry(t *testing.T) {
 	wsWrite(t, upstream, wsCreated("resp_1"))
 	wsEvent(t, f.client, "response.created")
 	steer := `{"type":"response.steer","previous_response_id":"resp_1","input":"shorter"}`
-	wsWrite(t, f.client, steer)
-	wsEvent(t, upstream, "response.steer")
-	wsWrite(t, upstream, `{"type":"response.steer.failed","steer":{"previous_response_id":"resp_1"},"error":{"code":"invalid_input","message":"upstream private details"}}`)
-	event := wsEvent(t, f.client, "response.steer.failed")
-	assert.NotContains(t, string(event["error"]), "upstream private details")
+	for range nativeWSMaxResponses + 1 {
+		wsWrite(t, f.client, steer)
+		wsEvent(t, upstream, "response.steer")
+		wsWrite(t, upstream, `{"type":"response.steer.failed","steer":{"previous_response_id":"resp_1"},"error":{"code":"invalid_input","message":"upstream private details"}}`)
+		event := wsEvent(t, f.client, "response.steer.failed")
+		assert.NotContains(t, string(event["error"]), "upstream private details")
+	}
 	wsWrite(t, f.client, steer)
 	wsEvent(t, upstream, "response.steer")
 	wsWrite(t, upstream, wsCompleted("resp_1"))
@@ -466,5 +485,101 @@ func TestNativeWebSocketDisconnectUsesUsageEstimate(t *testing.T) {
 	case <-f.accepted:
 		t.Fatal("unexpected automatic reconnect")
 	default:
+	}
+}
+
+func TestNativeWebSocketOverlappingSteer(t *testing.T) {
+	for _, newerFinishesFirst := range []bool{false, true} {
+		t.Run(fmt.Sprint(newerFinishesFirst), func(t *testing.T) {
+			f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+			wsWrite(t, f.client, `{"type":"response.create","model":"astra","input":"hi"}`)
+			upstream := f.upstream(t)
+			wsEvent(t, upstream, "response.create")
+			wsWrite(t, upstream, wsCreated("resp_1"))
+			wsEvent(t, f.client, "response.created")
+			wsWrite(t, f.client, `{"type":"response.steer","previous_response_id":"resp_1","input":"shorter"}`)
+			wsEvent(t, upstream, "response.steer")
+			wsWrite(t, upstream, wsCreated("resp_2"))
+			wsEvent(t, f.client, "response.created")
+			for _, id := range []string{"resp_1", "resp_2"} {
+				wsWrite(t, upstream, fmt.Sprintf(`{"type":"response.output_text.delta","response_id":%q,"delta":"Hello"}`, id))
+				wsEvent(t, f.client, "response.output_text.delta")
+			}
+			ids := []string{"resp_1", "resp_2"}
+			if newerFinishesFirst {
+				ids = []string{"resp_2", "resp_1"}
+			}
+			for _, id := range ids {
+				wsWrite(t, upstream, wsCompleted(id))
+				wsEvent(t, f.client, "response.completed")
+				entry := f.entry(t)
+				assert.Equal(t, 100, entry.PromptTokens)
+				assert.Equal(t, 20, entry.CompletionTokens)
+			}
+			wsWrite(t, f.client, `{"type":"response.create","previous_response_id":"resp_2","input":"continue"}`)
+			wsEvent(t, upstream, "response.create")
+			wsWrite(t, upstream, wsCreated("resp_3"))
+			wsEvent(t, f.client, "response.created")
+			wsWrite(t, upstream, wsCompleted("resp_3"))
+			wsEvent(t, f.client, "response.completed")
+			f.entry(t)
+		})
+	}
+}
+
+func TestNativeWebSocketPrepareStripsHandshakeHeaders(t *testing.T) {
+	f := newNativeWSFixture(t, config.ProviderTypeOpenAI, "")
+	req := httptest.NewRequest(http.MethodGet, "/v1/responses", nil)
+	req.Header = http.Header{
+		"Authorization":            {"Bearer client-key"},
+		"Connection":               {"Upgrade, X-Hop"},
+		"Upgrade":                  {"websocket"},
+		"X-Hop":                    {"private"},
+		"Sec-Websocket-Key":        {"key"},
+		"Sec-Websocket-Version":    {"13"},
+		"Sec-Websocket-Protocol":   {"test"},
+		"Sec-Websocket-Extensions": {"permessage-deflate"},
+	}
+	s := &nativeWSSession{proxy: f.proxy, request: req, client: f.client}
+	turn, _, ok := s.prepare(map[string]json.RawMessage{"model": json.RawMessage(`"astra"`), "input": json.RawMessage(`"hi"`)}, 0)
+	require.True(t, ok)
+	t.Cleanup(func() { f.proxy.reconcileBudgetAndRateLimits(turn.log, 0) })
+	assert.False(t, websocket.IsWebSocketUpgrade(turn.log.Request))
+	for _, key := range []string{"Connection", "Upgrade", "X-Hop", "Sec-WebSocket-Key", "Sec-WebSocket-Version", "Sec-WebSocket-Protocol", "Sec-WebSocket-Extensions"} {
+		assert.Empty(t, turn.log.Request.Header.Get(key), key)
+	}
+	assert.Equal(t, "Bearer client-key", turn.log.Request.Header.Get("Authorization"))
+	assert.Equal(t, "websocket", req.Header.Get("Upgrade"))
+}
+
+func TestNativeWebSocketInvalidPreparedBodyReportsError(t *testing.T) {
+	for _, body := range []string{"invalid JSON", "[]", "null"} {
+		t.Run(body, func(t *testing.T) {
+			prx := NewTestProxyBuilder().Build()
+			reconciled := make(chan bool, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				conn, err := wsUpgrader.Upgrade(w, r, nil)
+				if err != nil {
+					t.Error(err)
+					return
+				}
+				defer func() { _ = conn.Close() }()
+				s := &nativeWSSession{proxy: prx, client: conn}
+				logCtx := &RequestLogContext{}
+				wire, ok := s.prepareWireBody(logCtx, []byte(body))
+				assert.False(t, ok)
+				assert.Nil(t, wire)
+				reconciled <- logCtx.budgetReconciled
+			}))
+			defer server.Close()
+			conn, response, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(server.URL, "http"), nil)
+			require.NoError(t, err)
+			defer func() { _ = conn.Close() }()
+			defer func() { _ = response.Body.Close() }()
+			event := wsEvent(t, conn, "error")
+			assert.Contains(t, string(event["error"]), "internal_error")
+			assert.Contains(t, string(event["error"]), "Failed to prepare upstream request")
+			assert.True(t, <-reconciled)
+		})
 	}
 }


### PR DESCRIPTION
Add GPT-6 request compatibility and opt-in native Responses WebSockets (`websocket_responses: true`), including steering, tool continuations, Azure URL routing, access checks, and per-response billing. HTTP/SSE remains the default.

Validated: `go test ./...`, focused `-race` tests, `go build ./...`, and `make lint` (0 issues). WebSocket integration tests use local upstream servers; live Azure steering is not verified.
