### PR TITLE
Preserve streaming image deltas and token usage

### DIFF
--- a/internal/proxy/response_writer.go
+++ b/internal/proxy/response_writer.go
@@ -508,9 +508,8 @@ func (p *Proxy) writeProxyStreamingResponseWithTokens(
 	var lastUsage *converter.TokenUsage
 	completion := p.newCompletionTokenAccumulator(tokenizerModelID)
 	var payloadBuf [][]byte
-	onChunk := func(chunk []byte) {
-		// One split per chunk (plan item C), reused for both usage
-		// extraction and the completion accumulator.
+	onLine := func(chunk []byte) {
+		// Image-bearing usage events can span several HTTP reads.
 		payloadBuf = splitSSEPayloads(chunk, payloadBuf)
 		if chunkMayCarryTokenUsage(chunk) {
 			if usage := extractTokenUsageFromPayloads(payloadBuf, tokenUsageOptions); usage != nil {
@@ -529,6 +528,10 @@ func (p *Proxy) writeProxyStreamingResponseWithTokens(
 		}
 		completion.AddPayloads(payloadBuf)
 	}
+	var usageLines streamUsageLines
+	onChunk := func(chunk []byte) {
+		usageLines.Observe(chunk, onLine)
+	}
 
 	buildFallbackUsage := func() *converter.TokenUsage {
 		if lastUsage != nil {
@@ -543,6 +546,7 @@ func (p *Proxy) writeProxyStreamingResponseWithTokens(
 		return nil
 	}
 	finalize := func(streamErr error) (*converter.TokenUsage, error) {
+		usageLines.Finalize(onLine)
 		if detectProviderStreamError {
 			streamErr = resolveCapturedProviderStreamError(logCtx, resp.StatusCode, streamErr, providerStreamError)
 		}

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -891,13 +891,9 @@ func (p *Proxy) handleStreamingWithTokens(w http.ResponseWriter, resp *http.Resp
 	}
 
 	var payloadBuf [][]byte
-	onChunk := func(chunk []byte) {
-		chunkCount++
-
-		// One split per chunk (plan item C), reused below for both usage and
-		// total-tokens extraction; the completion accumulator keeps its own
-		// reused buffer (see completionTokenAccumulator.payloadBuf) since it
-		// also has to run on hasUsage==false chunks.
+	onLine := func(chunk []byte) {
+		// Parse complete SSE lines, not individual HTTP reads: a large image
+		// event may carry its usage after several stream buffer boundaries.
 		payloadBuf = splitSSEPayloads(chunk, payloadBuf)
 		if hasUsage := chunkMayCarryTokenUsage(chunk); hasUsage {
 			if logCtx != nil {
@@ -922,6 +918,11 @@ func (p *Proxy) handleStreamingWithTokens(w http.ResponseWriter, resp *http.Resp
 		// Don't let a bare [DONE] sentinel or empty chunks overwrite a lastChunk that carries usage data.
 		rememberLastStreamDataChunk(&lastChunk, chunk)
 	}
+	var usageLines streamUsageLines
+	onChunk := func(chunk []byte) {
+		chunkCount++
+		usageLines.Observe(chunk, onLine)
+	}
 
 	clientReader := normalizeSuccessfulResponseModelStream(
 		promanutils.NewSanitizingSSEReader(providerReader, clientVisibleResponseModel(logCtx, modelID)),
@@ -939,6 +940,7 @@ func (p *Proxy) handleStreamingWithTokens(w http.ResponseWriter, resp *http.Resp
 			defer cancel()
 			p.drainUpstream(drainCtx, clientReader, onChunk, credName)
 		}
+		usageLines.Finalize(onLine)
 		estimated := totalTokens
 		if estimated == 0 {
 			estimated = completion.TokenCount()
@@ -951,6 +953,7 @@ func (p *Proxy) handleStreamingWithTokens(w http.ResponseWriter, resp *http.Resp
 		return err
 	}
 
+	usageLines.Finalize(onLine)
 	var streamErr error
 	if detectProviderStreamError {
 		streamErr = resolveCapturedProviderStreamError(logCtx, resp.StatusCode, nil, providerStreamError)

--- a/internal/proxy/stream_usage_frames_test.go
+++ b/internal/proxy/stream_usage_frames_test.go
@@ -1,0 +1,74 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreamingUsageInLargeImageFrame(t *testing.T) {
+	prx := NewTestProxyBuilder().WithSingleCredential("test", config.ProviderTypeProxy, "http://unused", "unused").Build()
+	image := "data:image/png;base64," + strings.Repeat("A", 2*1024*1024)
+	body := `data: {"choices":[{"delta":{"images":[{"image_url":{"url":"` + image + `"}}]}}],"usage":{"prompt_tokens":14,"completion_tokens":1301,"total_tokens":1315,"completion_tokens_details":{"image_tokens":1290}}}` + "\n\ndata: [DONE]\n\n"
+	resp := &http.Response{StatusCode: 200, Header: http.Header{"Content-Type": []string{"text/event-stream"}}, Body: io.NopCloser(strings.NewReader(body))}
+	logCtx := &RequestLogContext{RequestID: "image-usage", Credential: &config.CredentialConfig{Name: "test", Type: config.ProviderTypeProxy}}
+	recorder := httptest.NewRecorder()
+	require.NoError(t, prx.handleStreamingWithTokens(recorder, resp, "test", "google/gemini-2.5-flash-image", logCtx))
+	require.Contains(t, recorder.Body.String(), image)
+	require.NotNil(t, logCtx.TokenUsage)
+	require.Equal(t, 14, logCtx.TokenUsage.PromptTokens)
+	require.Equal(t, 1301, logCtx.TokenUsage.CompletionTokens)
+	require.Equal(t, 1290, logCtx.TokenUsage.OutputImageTokens)
+	require.Equal(t, "provider", logCtx.UsageSource)
+	cost := models.CalculateTokenCosts(logCtx.TokenUsage, &models.ModelPrice{
+		InputCostPerToken: 0.0000005124, OutputCostPerToken: 0.00000427,
+		OutputCostPerImageToken: 0.00005124, CacheReadInputTokensFree: true,
+	})
+	require.InDelta(t, 0.0661537436, cost.TotalCost, 1e-12)
+}
+
+func TestStreamUsageLinesSplitAtEveryBoundary(t *testing.T) {
+	line := []byte(`data: {"usage":{"prompt_tokens":14,"completion_tokens":1301,"total_tokens":1315,"completion_tokens_details":{"image_tokens":1290}}}` + "\r\n")
+	for split := 1; split < len(line); split++ {
+		var capture streamUsageLines
+		var usage *StreamUsageInfo
+		consume := func(frame []byte) {
+			usage = (&openAIStreamUsageExtractor{}).ExtractUsage(frame)
+		}
+		capture.Observe(line[:split], consume)
+		require.Nil(t, usage)
+		capture.Observe(line[split:], consume)
+		require.NotNil(t, usage, "split %d", split)
+		require.Equal(t, 1290, usage.OutputImageTokens)
+	}
+}
+
+func TestStreamUsageLinesFinalize(t *testing.T) {
+	var capture streamUsageLines
+	var lines []string
+	consume := func(line []byte) { lines = append(lines, string(line)) }
+	capture.Observe([]byte("data: first\n\ndata: last"), consume)
+	capture.Finalize(consume)
+	require.Equal(t, []string{"data: first\n", "\n", "data: last"}, lines)
+}
+
+func TestStreamUsageLinesBoundAndRecovery(t *testing.T) {
+	var capture streamUsageLines
+	var lines []string
+	consume := func(line []byte) { lines = append(lines, string(line)) }
+	chunk := []byte(strings.Repeat("A", 8192))
+	for size := 0; size <= maxSSEModelRewriteLineBytes; size += len(chunk) {
+		capture.Observe(chunk, consume)
+	}
+	require.True(t, capture.discard)
+	require.Nil(t, capture.pending)
+	capture.Observe([]byte("tail\ndata: next\n"), consume)
+	require.Equal(t, []string{"data: next\n"}, lines)
+	require.False(t, capture.discard)
+}

--- a/internal/proxy/stream_usage_frames_test.go
+++ b/internal/proxy/stream_usage_frames_test.go
@@ -49,6 +49,43 @@ func TestStreamUsageLinesSplitAtEveryBoundary(t *testing.T) {
 	}
 }
 
+func TestProxyHopStreamingUsageInLargeImageFrame(t *testing.T) {
+	for _, mode := range []string{"complete", "drain after disconnect", "EOF without newline"} {
+		t.Run(mode, func(t *testing.T) {
+			prx := NewTestProxyBuilder().WithDrainUpstreamOnAbort(true).Build()
+			image := "data:image/png;base64," + strings.Repeat("A", 2*1024*1024)
+			body := `data: {"choices":[{"delta":{"images":[{"image_url":{"url":"` + image + `"}}]}}],"usage":{"prompt_tokens":14,"completion_tokens":1301,"total_tokens":1315,"completion_tokens_details":{"image_tokens":1290}}}` + "\n\ndata: [DONE]\n\n"
+			if mode == "EOF without newline" {
+				body = strings.TrimSuffix(body, "\n\ndata: [DONE]\n\n")
+			}
+			resp := &ProxyResponse{StatusCode: 200, Headers: http.Header{"Content-Type": []string{"text/event-stream"}}, StreamBody: io.NopCloser(strings.NewReader(body))}
+			logCtx := &RequestLogContext{RequestID: "image-usage", Credential: &config.CredentialConfig{Name: "test", Type: config.ProviderTypeAIR}}
+			recorder := httptest.NewRecorder()
+			var writer http.ResponseWriter = recorder
+			if mode == "drain after disconnect" {
+				writer = newFailAfterNBytesWriter(10)
+			}
+			usage, err := prx.writeProxyStreamingResponseWithTokens(writer, resp, httptest.NewRequest("POST", "/v1/chat/completions", nil), logCtx.Credential, "google/gemini-2.5-flash-image", "google/gemini-2.5-flash-image", logCtx)
+			if mode == "drain after disconnect" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Contains(t, recorder.Body.String(), image)
+			}
+			require.NotNil(t, usage)
+			require.Equal(t, 14, usage.PromptTokens)
+			require.Equal(t, 1301, usage.CompletionTokens)
+			require.Equal(t, 1290, usage.OutputImageTokens)
+			require.Equal(t, "provider", logCtx.UsageSource)
+			cost := models.CalculateTokenCosts(usage, &models.ModelPrice{
+				InputCostPerToken: 0.0000005124, OutputCostPerToken: 0.00000427,
+				OutputCostPerImageToken: 0.00005124, CacheReadInputTokensFree: true,
+			})
+			require.InDelta(t, 0.0661537436, cost.TotalCost, 1e-12)
+		})
+	}
+}
+
 func TestStreamUsageLinesFinalize(t *testing.T) {
 	var capture streamUsageLines
 	var lines []string
@@ -59,11 +96,11 @@ func TestStreamUsageLinesFinalize(t *testing.T) {
 }
 
 func TestStreamUsageLinesBoundAndRecovery(t *testing.T) {
-	var capture streamUsageLines
+	capture := streamUsageLines{maxLineBytes: 64}
 	var lines []string
 	consume := func(line []byte) { lines = append(lines, string(line)) }
-	chunk := []byte(strings.Repeat("A", 8192))
-	for size := 0; size <= maxSSEModelRewriteLineBytes; size += len(chunk) {
+	chunk := []byte(strings.Repeat("A", 8))
+	for size := 0; size <= capture.maxLineBytes; size += len(chunk) {
 		capture.Observe(chunk, consume)
 	}
 	require.True(t, capture.discard)

--- a/internal/proxy/stream_usage_lines.go
+++ b/internal/proxy/stream_usage_lines.go
@@ -1,0 +1,48 @@
+package proxy
+
+import "bytes"
+
+// streamUsageLines reassembles SSE data lines before usage extraction. Reads
+// from an HTTP body may split JSON anywhere, including inside an image-bearing
+// event that also carries usage. The bound matches image stream model rewriting.
+type streamUsageLines struct {
+	pending []byte
+	discard bool
+}
+
+func (s *streamUsageLines) Observe(chunk []byte, consume func([]byte)) {
+	for len(chunk) > 0 {
+		end := bytes.IndexByte(chunk, '\n')
+		length := len(chunk)
+		if end >= 0 {
+			length = end + 1
+		}
+		part := chunk[:length]
+		chunk = chunk[length:]
+		if !s.discard {
+			if len(s.pending)+len(part) > maxSSEModelRewriteLineBytes {
+				s.pending = nil
+				s.discard = true
+			} else if len(s.pending) == 0 && end >= 0 {
+				consume(part)
+			} else {
+				s.pending = append(s.pending, part...)
+				if end >= 0 {
+					consume(s.pending)
+					s.pending = nil
+				}
+			}
+		}
+		if end >= 0 {
+			s.discard = false
+		}
+	}
+}
+
+func (s *streamUsageLines) Finalize(consume func([]byte)) {
+	if !s.discard && len(s.pending) > 0 {
+		consume(s.pending)
+	}
+	s.pending = nil
+	s.discard = false
+}

--- a/internal/proxy/stream_usage_lines.go
+++ b/internal/proxy/stream_usage_lines.go
@@ -6,11 +6,16 @@ import "bytes"
 // from an HTTP body may split JSON anywhere, including inside an image-bearing
 // event that also carries usage. The bound matches image stream model rewriting.
 type streamUsageLines struct {
-	pending []byte
-	discard bool
+	pending      []byte
+	discard      bool
+	maxLineBytes int
 }
 
 func (s *streamUsageLines) Observe(chunk []byte, consume func([]byte)) {
+	limit := s.maxLineBytes
+	if limit <= 0 {
+		limit = maxSSEModelRewriteLineBytes
+	}
 	for len(chunk) > 0 {
 		end := bytes.IndexByte(chunk, '\n')
 		length := len(chunk)
@@ -20,7 +25,7 @@ func (s *streamUsageLines) Observe(chunk []byte, consume func([]byte)) {
 		part := chunk[:length]
 		chunk = chunk[length:]
 		if !s.discard {
-			if len(s.pending)+len(part) > maxSSEModelRewriteLineBytes {
+			if len(s.pending)+len(part) > limit {
 				s.pending = nil
 				s.discard = true
 			} else if len(s.pending) == 0 && end >= 0 {

--- a/internal/responsecompat/litellm/stream.go
+++ b/internal/responsecompat/litellm/stream.go
@@ -437,7 +437,7 @@ func mustMarshal(value any) []byte {
 }
 
 func hasStreamDelta(delta map[string]any) bool {
-	for _, field := range []string{"content", "tool_calls", "function_call", "reasoning_content", "audio"} {
+	for _, field := range []string{"content", "tool_calls", "function_call", "reasoning_content", "audio", "images"} {
 		if value, ok := delta[field]; ok && value != nil {
 			return true
 		}

--- a/internal/responsecompat/litellm/stream_images_test.go
+++ b/internal/responsecompat/litellm/stream_images_test.go
@@ -1,0 +1,65 @@
+package litellm
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChatStreamPreservesImageOnlyDelta(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		size   int
+		finish string
+	}{
+		{name: "image after text", size: 32, finish: "null"},
+		{name: "image with finish", size: 32, finish: `"stop"`},
+		{name: "image larger than one MiB", size: 2 * 1024 * 1024, finish: "null"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			imageURL := "data:image/png;base64," + strings.Repeat("A", tc.size)
+			source := `data: {"id":"image-stream","model":"provider-model","choices":[{"index":0,"delta":{"role":"assistant","content":"Here is the image"},"finish_reason":null}]}` + "\n\n" +
+				`data: {"id":"image-stream","model":"provider-model","choices":[{"index":0,"delta":{"images":[{"type":"image_url","image_url":{"url":"` + imageURL + `"}}]},"finish_reason":` + tc.finish + `}]}` + "\n\n"
+			if tc.finish == "null" {
+				source += `data: {"id":"image-stream","model":"provider-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}` + "\n\n"
+			}
+			source += `data: {"id":"image-stream","model":"provider-model","choices":[],"usage":{"prompt_tokens":14,"completion_tokens":1290,"total_tokens":1304,"completion_tokens_details":{"image_tokens":1290}}}` + "\n\ndata: [DONE]\n\n"
+			output, err := io.ReadAll(New().Stream(Context{
+				Endpoint: "/v1/chat/completions", RequestedModel: "public-model", IncludeUsage: true,
+			}, strings.NewReader(source)))
+			require.NoError(t, err)
+			frames := splitDataFrames(string(output))
+			require.NotEmpty(t, frames)
+			require.Equal(t, "[DONE]", frames[len(frames)-1])
+			images, finishes, usages := 0, 0, 0
+			for _, frame := range frames[:len(frames)-1] {
+				var body map[string]any
+				require.NoError(t, json.Unmarshal([]byte(frame), &body))
+				require.Equal(t, "public-model", body["model"])
+				if usage, ok := body["usage"].(map[string]any); ok {
+					usages++
+					require.Equal(t, float64(1304), usage["total_tokens"])
+					require.Equal(t, float64(1290), usage["completion_tokens_details"].(map[string]any)["image_tokens"])
+				}
+				for _, raw := range body["choices"].([]any) {
+					choice := raw.(map[string]any)
+					delta := choice["delta"].(map[string]any)
+					if values, ok := delta["images"].([]any); ok {
+						images += len(values)
+						require.Equal(t, imageURL, values[0].(map[string]any)["image_url"].(map[string]any)["url"])
+						require.Nil(t, choice["finish_reason"])
+					}
+					if choice["finish_reason"] == "stop" {
+						finishes++
+					}
+				}
+			}
+			require.Equal(t, 1, images)
+			require.Equal(t, 1, finishes)
+			require.Equal(t, 1, usages)
+		})
+	}
+}


### PR DESCRIPTION
Preserve image-only Chat Completion deltas after text output and retain separate finish events.

Reassemble SSE lines before extracting token usage in direct and AIR proxy streaming paths. Preserve image token counts when events span HTTP reads. Bound line accumulation to 64 MiB and finalize pending input after EOF or upstream drain.

Regression tests cover large image events, arbitrary read boundaries, image deltas after text, finish events, EOF without a newline, client disconnect with upstream drain and oversized line recovery.
