### PR TITLE
fix: normalize Responses API tool_choice object-form to Chat Completions string

### DIFF
--- a/internal/converter/responses/request.go
+++ b/internal/converter/responses/request.go
@@ -1236,6 +1236,15 @@ func convertToolChoice(raw map[string]interface{}) error {
 		return nil
 	}
 
+	// Responses API "required" and "any" mean "force any tool call" with no
+	// specific function preference.  Chat Completions expresses the same intent
+	// with the plain string "required".  DeepSeek (and possibly other
+	// OpenAI-compatible backends) reject the object form outright.
+	if tcType == "required" || tcType == "any" {
+		raw["tool_choice"] = "required"
+		return nil
+	}
+
 	// Non-function tool_choice types (e.g. web_search_preview, file_search) reference
 	// Responses-API built-in tools.  Pass them through: provider-specific converters
 	// downstream (Vertex, Anthropic, OpenAI) handle what they support and ignore

--- a/internal/converter/responses/request_test.go
+++ b/internal/converter/responses/request_test.go
@@ -342,6 +342,34 @@ func TestRequestToChat_ToolChoiceNonFunctionPassthrough(t *testing.T) {
 	assert.Equal(t, "file_search", tc["type"])
 }
 
+func TestRequestToChat_ToolChoiceRequiredObject(t *testing.T) {
+	// Responses API accepts {"type":"required"} as an object-form equivalent of
+	// the string "required".  DeepSeek (and other OpenAI-compatible backends)
+	// reject the object form, so the converter must normalize it to the plain
+	// string "required" that Chat Completions providers accept.
+	body := `{"model":"gpt-4o","input":"hi","tool_choice":{"type":"required"}}`
+	result, err := RequestToChat([]byte(body))
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Equal(t, "required", parsed["tool_choice"])
+}
+
+func TestRequestToChat_ToolChoiceAnyObject(t *testing.T) {
+	// Responses API accepts {"type":"any"} as an object-form equivalent of
+	// "required" (force any tool call).  Same normalization as "required".
+	body := `{"model":"gpt-4o","input":"hi","tool_choice":{"type":"any"}}`
+	result, err := RequestToChat([]byte(body))
+	require.NoError(t, err)
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal(result, &parsed))
+
+	assert.Equal(t, "required", parsed["tool_choice"])
+}
+
 func TestRequestToChat_FunctionCallOutput(t *testing.T) {
 	body := `{
 		"model": "gpt-4o",


### PR DESCRIPTION
## Summary

Responses API accepts `tool_choice` as both a plain string (`"auto"`, `"none"`, `"required"`) and an object (`{"type": "required"}`, `{"type": "any"}`). Chat Completions providers — notably DeepSeek — reject the object form outright with `400 Invalid tool_choice`.

## Fix

Add a conversion step in `convertToolChoice` that maps `{"type":"required"\}` and `{"type":"any"\}` to the plain string `"required"`, matching the Chat Completions wire format.

The existing function-type mapping (`{"type":"function", "name": "..."}`) and non-function passthrough (e.g. `web_search_preview`) are unchanged.

## Test plan

- `go test ./internal/converter/responses/ -run TestRequestToChat_ToolChoice` — all pass
- `go test ./...` — full suite clean
- `go vet ./...` — clean

New tests:
- `TestRequestToChat_ToolChoiceRequiredObject` — verifies `{"type":"required"}` → `"required"`
- `TestRequestToChat_ToolChoiceAnyObject` — verifies `{"type":"any"}` → `"required"`

## Reproduction

Before fix: `tool_choice: {"type": "required"}` with reasoning → 400 from DeepSeek
After fix: `tool_choice: {"type": "required"}` → converted to `"required"` → 200 OK