### PR TITLE
Preserve image compatibility and client validation errors

### DIFF
--- a/internal/converter/converter.go
+++ b/internal/converter/converter.go
@@ -169,6 +169,10 @@ func (c *ProviderConverter) RequestFrom(body []byte) ([]byte, error) {
 			body = openaiconv.ConvertWebSearchTools(body)
 		}
 
+		if c.mode.IsImageGeneration || c.mode.IsImageEdit {
+			body = openaiconv.RewriteImageMiniJSON(body, c.mode.ModelID, c.mode.IsImageEdit)
+		}
+
 		// gpt-image-1 family does not support the response_format parameter in
 		// /v1/images/generations — strip it before forwarding to avoid a 400.
 		if c.mode.IsImageGeneration && openaiconv.IsGptImage1Model(c.mode.ModelID) {

--- a/internal/converter/converterutil/errors.go
+++ b/internal/converter/converterutil/errors.go
@@ -13,6 +13,7 @@ import (
 // which 4xx applies, regardless of which proxy call site catches it.
 type RequestValidationError struct {
 	Param      string
+	Code       string
 	Message    string
 	StatusCode int
 }

--- a/internal/converter/openai/image_compat.go
+++ b/internal/converter/openai/image_compat.go
@@ -1,0 +1,48 @@
+package openai
+
+import "encoding/json"
+
+func IsGptImage1MiniModel(modelID string) bool {
+	return matchModelFamily(modelID, "gpt-image-1-mini")
+}
+
+func normalizeImageMiniQuality(quality string) string {
+	switch quality {
+	case "standard":
+		return "medium"
+	case "hd":
+		return "high"
+	default:
+		return quality
+	}
+}
+
+func RewriteImageMiniJSON(body []byte, modelID string, edit bool) []byte {
+	if !IsGptImage1MiniModel(modelID) {
+		return body
+	}
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(body, &fields) != nil || fields == nil {
+		return body
+	}
+	changed := false
+	var quality string
+	if json.Unmarshal(fields["quality"], &quality) == nil {
+		if normalized := normalizeImageMiniQuality(quality); normalized != quality {
+			fields["quality"], _ = json.Marshal(normalized)
+			changed = true
+		}
+	}
+	if _, exists := fields["input_fidelity"]; edit && exists {
+		delete(fields, "input_fidelity")
+		changed = true
+	}
+	if !changed {
+		return body
+	}
+	result, err := json.Marshal(fields)
+	if err != nil {
+		return body
+	}
+	return result
+}

--- a/internal/converter/openai/image_compat_test.go
+++ b/internal/converter/openai/image_compat_test.go
@@ -1,0 +1,30 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageMiniJSONPreservesInvalidInput(t *testing.T) {
+	for _, body := range []string{`{"quality":`, `null`, `{"quality":123}`, `{"quality":"custom"}`} {
+		require.Equal(t, body, string(RewriteImageMiniJSON([]byte(body), "gpt-image-1-mini", false)))
+	}
+}
+
+func TestImageMiniJSONModelScope(t *testing.T) {
+	for _, model := range []string{"gpt-image-1-mini", "openai/gpt-image-1-mini", "gpt-image-1", "gpt-image-2", "gemini-3.1-flash-image"} {
+		body := RewriteImageMiniJSON([]byte(`{"quality":"hd","input_fidelity":"high","extra":{"id":9007199254740993}}`), model, true)
+		var fields map[string]json.RawMessage
+		require.NoError(t, json.Unmarshal(body, &fields))
+		require.JSONEq(t, `{"id":9007199254740993}`, string(fields["extra"]))
+		if model == "gpt-image-1-mini" || model == "openai/gpt-image-1-mini" {
+			require.Equal(t, `"high"`, string(fields["quality"]))
+			require.NotContains(t, fields, "input_fidelity")
+		} else {
+			require.Equal(t, `"hd"`, string(fields["quality"]))
+			require.Contains(t, fields, "input_fidelity")
+		}
+	}
+}

--- a/internal/converter/openai/multipart_rewrite.go
+++ b/internal/converter/openai/multipart_rewrite.go
@@ -132,6 +132,15 @@ func RewriteImageEditMultipart(body []byte, contentType, modelID string, stripRe
 			partData = []byte(modelID)
 		}
 
+		if IsGptImage1MiniModel(modelID) && filename == "" {
+			if fieldName == "input_fidelity" {
+				continue
+			}
+			if fieldName == "quality" {
+				partData = []byte(normalizeImageMiniQuality(string(partData)))
+			}
+		}
+
 		// Skip response_format field when requested.
 		if stripResponseFormat && fieldName == "response_format" {
 			continue

--- a/internal/converter/vertex/image_edit_json.go
+++ b/internal/converter/vertex/image_edit_json.go
@@ -1,0 +1,95 @@
+package vertex
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+
+	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
+)
+
+func imageEditJSONToOpenAIChatRequest(body []byte, model string) ([]byte, error) {
+	chatBody, err := imageRequestToOpenAIChatRequest(body, model)
+	if err != nil {
+		return nil, err
+	}
+	var fields struct {
+		Image  json.RawMessage `json:"image"`
+		Images json.RawMessage `json:"images"`
+		Mask   json.RawMessage `json:"mask"`
+	}
+	if err := json.Unmarshal(body, &fields); err != nil {
+		return nil, imageJSONValidationError(err)
+	}
+	if len(fields.Image) > 0 && len(fields.Images) > 0 {
+		return nil, imageValidationError("image", "Invalid parameter value", "invalid_value")
+	}
+	rawImages := fields.Image
+	if len(fields.Images) > 0 {
+		rawImages = fields.Images
+	}
+	var images []json.RawMessage
+	if len(rawImages) > 0 && rawImages[0] == '[' {
+		if err := json.Unmarshal(rawImages, &images); err != nil {
+			return nil, imageJSONValidationError(err)
+		}
+	} else if len(rawImages) > 0 && string(rawImages) != "null" {
+		images = append(images, rawImages)
+	}
+	if len(images) == 0 {
+		return nil, imageValidationError("image", "Missing required parameter", "missing_required_parameter")
+	}
+	var chat openai.OpenAIRequest
+	if err := json.Unmarshal(chatBody, &chat); err != nil {
+		return nil, err
+	}
+	blocks := []openai.ContentBlock{{Type: "text", Text: chat.Messages[0].Content.(string)}}
+	for _, raw := range images {
+		imageURL, err := imageEditJSONURL(raw, "image")
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, openai.ContentBlock{Type: "image_url", ImageURL: imageURL})
+	}
+	if len(fields.Mask) > 0 && string(fields.Mask) != "null" {
+		mask, err := imageEditJSONURL(fields.Mask, "mask")
+		if err != nil {
+			return nil, err
+		}
+		blocks = append(blocks, openai.ContentBlock{Type: "text", Text: "Use the provided mask image to constrain the edit."}, openai.ContentBlock{Type: "image_url", ImageURL: mask})
+	}
+	chat.Messages[0].Content = blocks
+	return json.Marshal(chat)
+}
+
+func imageEditJSONURL(raw json.RawMessage, param string) (*openai.ImageURL, error) {
+	var value string
+	if json.Unmarshal(raw, &value) != nil {
+		var object struct {
+			URL      string `json:"url"`
+			ImageURL string `json:"image_url"`
+		}
+		if json.Unmarshal(raw, &object) != nil {
+			return nil, imageValidationError(param, "Invalid parameter type", "invalid_type")
+		}
+		value = object.ImageURL
+		if value == "" {
+			value = object.URL
+		}
+	}
+	if strings.HasPrefix(value, "data:") {
+		part, err := parseDataURLToPart(value)
+		if err != nil {
+			return nil, err
+		}
+		if part == nil || part.InlineData == nil || !strings.HasPrefix(part.InlineData.MIMEType, "image/") || len(part.InlineData.Data) == 0 {
+			return nil, imageValidationError(param, "Invalid image data", "invalid_image")
+		}
+	} else {
+		parsed, err := url.Parse(value)
+		if err != nil || parsed.Host == "" || parsed.Scheme != "https" && parsed.Scheme != "http" && parsed.Scheme != "gs" || parseURLToPart(value, nil) == nil {
+			return nil, imageValidationError(param, "Invalid image data", "invalid_image")
+		}
+	}
+	return &openai.ImageURL{URL: value}, nil
+}

--- a/internal/converter/vertex/image_edit_json_test.go
+++ b/internal/converter/vertex/image_edit_json_test.go
@@ -1,0 +1,52 @@
+package vertex
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
+	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageEditJSONValidation(t *testing.T) {
+	for _, tt := range []struct {
+		name, body, contentType string
+		status                  int
+	}{
+		{"malformed JSON", `{"prompt":`, "application/json", 400},
+		{"missing image", `{"prompt":"test"}`, "application/json", 400},
+		{"invalid image type", `{"prompt":"test","image":12}`, "application/json", 400},
+		{"empty image array", `{"prompt":"test","images":[]}`, "application/json", 400},
+		{"invalid data URL", `{"prompt":"test","image":"data:image/png;base64,broken!"}`, "application/json", 400},
+		{"unsupported file ID", `{"prompt":"test","images":[{"file_id":"file-test"}]}`, "application/json", 400},
+		{"invalid mask", `{"prompt":"test","image":"data:image/png;base64,aW1n","mask":false}`, "application/json", 400},
+		{"unsupported content type", `test`, "text/plain", 415},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := imageEditRequestToOpenAIChatRequest([]byte(tt.body), tt.contentType, "gemini-3.1-flash-image")
+			var validation *converterutil.RequestValidationError
+			require.ErrorAs(t, err, &validation)
+			status := validation.StatusCode
+			if status == 0 {
+				status = 400
+			}
+			require.Equal(t, tt.status, status)
+		})
+	}
+}
+
+func TestImageEditJSONReusesGenerationOptions(t *testing.T) {
+	body, err := imageEditRequestToOpenAIChatRequest([]byte(`{"model":"alias","prompt":"test","image":"https://example.com/image.png","size":"1792x2400","n":2,"seed":7,"temperature":0.5,"top_p":0.9}`), "application/json", "gemini-3.1-flash-image")
+	require.NoError(t, err)
+	var request openai.OpenAIRequest
+	require.NoError(t, json.Unmarshal(body, &request))
+	require.Equal(t, 2, *request.N)
+	require.EqualValues(t, 7, *request.Seed)
+	require.Equal(t, 0.5, *request.Temperature)
+	require.Equal(t, 0.9, *request.TopP)
+	generation := request.ExtraBody["generation_config"].(map[string]any)
+	image := generation["image_config"].(map[string]any)
+	require.Equal(t, "3:4", image["aspectRatio"])
+	require.Equal(t, "2K", image["imageSize"])
+}

--- a/internal/converter/vertex/image_size.go
+++ b/internal/converter/vertex/image_size.go
@@ -1,7 +1,6 @@
 package vertex
 
 import (
-	"fmt"
 	"math"
 	"strconv"
 	"strings"
@@ -183,12 +182,12 @@ func parseGeminiImageSize(size string) (int, int, bool, error) {
 
 	left, right, ok := strings.Cut(normalized, separator)
 	if !ok || strings.Contains(right, separator) {
-		return 0, 0, false, fmt.Errorf("invalid image size %q: expected WxH or W:H", size)
+		return 0, 0, false, imageValidationError("size", "Invalid image size", "invalid_image_size")
 	}
 	width, widthErr := strconv.Atoi(strings.TrimSpace(left))
 	height, heightErr := strconv.Atoi(strings.TrimSpace(right))
 	if widthErr != nil || heightErr != nil || width <= 0 || height <= 0 {
-		return 0, 0, false, fmt.Errorf("invalid image size %q: dimensions must be positive integers", size)
+		return 0, 0, false, imageValidationError("size", "Invalid image size", "invalid_image_size")
 	}
 	if separator == "x" && width <= 32 && height <= 32 {
 		ratioOnly = true

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -69,7 +70,7 @@ func BuildVertexImageURL(cred *config.CredentialConfig, modelID string) string {
 func OpenAIImageToVertex(openAIBody []byte) ([]byte, error) {
 	var openAIReq openai.OpenAIImageRequest
 	if err := json.Unmarshal(openAIBody, &openAIReq); err != nil {
-		return nil, fmt.Errorf("failed to parse OpenAI image request: %w", err)
+		return nil, imageJSONValidationError(err)
 	}
 
 	// Convert size to aspect ratio
@@ -146,7 +147,14 @@ func ImageRequestToOpenAIChatRequest(openAIBody []byte) ([]byte, error) {
 func imageRequestToOpenAIChatRequest(openAIBody []byte, providerModel string) ([]byte, error) {
 	var imageReq openai.OpenAIImageRequest
 	if err := json.Unmarshal(openAIBody, &imageReq); err != nil {
-		return nil, fmt.Errorf("failed to parse OpenAI image request: %w", err)
+		return nil, imageJSONValidationError(err)
+	}
+
+	if strings.TrimSpace(imageReq.Prompt) == "" {
+		return nil, imageValidationError("prompt", "Missing required parameter", "missing_required_parameter")
+	}
+	if imageReq.N != nil && *imageReq.N <= 0 {
+		return nil, imageValidationError("n", "Invalid parameter value", "invalid_value")
 	}
 
 	genConfig := map[string]interface{}{
@@ -176,7 +184,7 @@ func imageRequestToOpenAIChatRequest(openAIBody []byte, providerModel string) ([
 	}
 	if imageReq.Seed != nil {
 		if *imageReq.Seed < math.MinInt32 || *imageReq.Seed > math.MaxInt32 {
-			return nil, fmt.Errorf("invalid image generation seed %d", *imageReq.Seed)
+			return nil, imageValidationError("seed", "Invalid parameter value", "invalid_value")
 		}
 		chatReq.Seed = imageReq.Seed
 	}
@@ -197,15 +205,15 @@ func ImageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType string) 
 func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, providerModel string) ([]byte, error) {
 	mediaType, params, err := mime.ParseMediaType(contentType)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse image edit content type: %w", err)
+		return nil, imageValidationError("content_type", "Invalid parameter value", "invalid_value")
 	}
 	if !strings.HasPrefix(mediaType, "multipart/form-data") {
-		return nil, fmt.Errorf("image edits require multipart/form-data content type")
+		return nil, imageValidationError("content_type", "Invalid parameter value", "invalid_value")
 	}
 
 	boundary := params["boundary"]
 	if boundary == "" {
-		return nil, fmt.Errorf("missing multipart boundary in content type")
+		return nil, imageValidationError("content_type", "Invalid parameter value", "invalid_value")
 	}
 
 	reader := multipart.NewReader(bytes.NewReader(openAIBody), boundary)
@@ -219,7 +227,7 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 			break
 		}
 		if err != nil {
-			return nil, fmt.Errorf("failed to read multipart image edit payload: %w", err)
+			return nil, imageValidationError("image", "Invalid multipart form data", "invalid_multipart")
 		}
 
 		formName := part.FormName()
@@ -239,7 +247,7 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 
 		mimeType, mimeErr := detectImageMIMEType(part.Header.Get("Content-Type"), data)
 		if mimeErr != nil {
-			return nil, fmt.Errorf("invalid multipart part %q: %w", formName, mimeErr)
+			return nil, imageValidationError(formName, "Invalid image data", "invalid_image")
 		}
 
 		block := map[string]interface{}{
@@ -259,11 +267,15 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 
 	model := strings.TrimSpace(fields["model"])
 	if model == "" {
-		return nil, fmt.Errorf("image edit request missing model field")
+		return nil, imageValidationError("model", "Missing required parameter", "missing_required_parameter")
 	}
 	prompt := strings.TrimSpace(fields["prompt"])
 	if prompt == "" {
-		return nil, fmt.Errorf("image edit request missing prompt field")
+		return nil, imageValidationError("prompt", "Missing required parameter", "missing_required_parameter")
+	}
+
+	if len(contentBlocks) == 0 {
+		return nil, imageValidationError("image", "Missing required parameter", "missing_required_parameter")
 	}
 
 	messageBlocks := make([]map[string]interface{}, 0, 1+len(contentBlocks)+len(maskBlocks))
@@ -308,7 +320,7 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 	if rawSeed := strings.TrimSpace(fields["seed"]); rawSeed != "" {
 		seed, err := strconv.ParseInt(rawSeed, 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("invalid image edit seed %q", rawSeed)
+			return nil, imageValidationError("seed", "Invalid parameter value", "invalid_value")
 		}
 		chatReq.Seed = &seed
 	}
@@ -326,7 +338,14 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 		}
 		chatReq.TopP = &topP
 	}
-	if n := parsePositiveInt(fields["n"]); n > 0 {
+	if rawN := strings.TrimSpace(fields["n"]); rawN != "" {
+		n, err := strconv.Atoi(rawN)
+		if err != nil {
+			return nil, imageValidationError("n", "Invalid parameter type", "invalid_type")
+		}
+		if n <= 0 {
+			return nil, imageValidationError("n", "Invalid parameter value", "invalid_value")
+		}
 		n = clampImageCount(n)
 		chatReq.N = &n
 	}
@@ -434,21 +453,10 @@ func convertVertexUsageToImageUsage(meta *genai.GenerateContentResponseUsageMeta
 	}
 }
 
-func parsePositiveInt(raw string) int {
-	if raw == "" {
-		return 0
-	}
-	n, err := strconv.Atoi(strings.TrimSpace(raw))
-	if err != nil || n <= 0 {
-		return 0
-	}
-	return n
-}
-
 func parseImageEditFloat(raw, name string) (float64, error) {
 	value, err := strconv.ParseFloat(raw, 64)
 	if err != nil || math.IsNaN(value) || math.IsInf(value, 0) {
-		return 0, fmt.Errorf("invalid image edit %s %q", name, raw)
+		return 0, imageValidationError(name, "Invalid parameter value", "invalid_value")
 	}
 	return value, nil
 }
@@ -468,7 +476,7 @@ func applyGeminiImageConfigFields(genConfig map[string]interface{}, fields map[s
 		}
 		var parsed map[string]interface{}
 		if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
-			return fmt.Errorf("invalid image edit %s %q", name, raw)
+			return imageValidationError(name, "Invalid JSON", "invalid_json")
 		}
 		for key, value := range parsed {
 			imageConfig[key] = value
@@ -511,10 +519,10 @@ func firstNonEmptyField(fields map[string]string, names ...string) string {
 func readMultipartPartLimit(part *multipart.Part, maxBytes int64) ([]byte, error) {
 	data, err := io.ReadAll(io.LimitReader(part, maxBytes+1))
 	if err != nil {
-		return nil, fmt.Errorf("failed to read multipart part %q: %w", part.FormName(), err)
+		return nil, imageValidationError(part.FormName(), "Invalid multipart form data", "invalid_multipart")
 	}
 	if int64(len(data)) > maxBytes {
-		return nil, fmt.Errorf("multipart part %q exceeds %d bytes", part.FormName(), maxBytes)
+		return nil, converterutil.NewRequestEntityTooLargeError(part.FormName(), "Image exceeds the multipart size limit")
 	}
 	return data, nil
 }
@@ -538,4 +546,16 @@ func clampImageCount(n int) int {
 		return 10
 	}
 	return n
+}
+
+func imageValidationError(param, message, code string) error {
+	return &converterutil.RequestValidationError{Param: param, Message: message, Code: code}
+}
+
+func imageJSONValidationError(err error) error {
+	var typeErr *json.UnmarshalTypeError
+	if errors.As(err, &typeErr) {
+		return imageValidationError(typeErr.Field, "Invalid parameter type", "invalid_type")
+	}
+	return imageValidationError("", "Invalid JSON", "invalid_json")
 }

--- a/internal/converter/vertex/images.go
+++ b/internal/converter/vertex/images.go
@@ -196,7 +196,7 @@ func imageRequestToOpenAIChatRequest(openAIBody []byte, providerModel string) ([
 	return json.Marshal(chatReq)
 }
 
-// ImageEditRequestToOpenAIChatRequest converts OpenAI multipart images.edit payload
+// ImageEditRequestToOpenAIChatRequest converts JSON or multipart image edit requests
 // to an OpenAI chat request for Gemini image-capable models.
 func ImageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType string) ([]byte, error) {
 	return imageEditRequestToOpenAIChatRequest(openAIBody, contentType, "")
@@ -207,8 +207,11 @@ func imageEditRequestToOpenAIChatRequest(openAIBody []byte, contentType, provide
 	if err != nil {
 		return nil, imageValidationError("content_type", "Invalid parameter value", "invalid_value")
 	}
-	if !strings.HasPrefix(mediaType, "multipart/form-data") {
-		return nil, imageValidationError("content_type", "Invalid parameter value", "invalid_value")
+	if mediaType == "application/json" {
+		return imageEditJSONToOpenAIChatRequest(openAIBody, providerModel)
+	}
+	if mediaType != "multipart/form-data" {
+		return nil, &converterutil.RequestValidationError{Param: "content_type", Message: "Image edits require JSON or multipart form data", StatusCode: http.StatusUnsupportedMediaType}
 	}
 
 	boundary := params["boundary"]

--- a/internal/converter/vertex/images_test.go
+++ b/internal/converter/vertex/images_test.go
@@ -8,6 +8,7 @@ import (
 	"net/textproto"
 	"testing"
 
+	"github.com/mixaill76/auto_ai_router/internal/converter/converterutil"
 	"github.com/mixaill76/auto_ai_router/internal/converter/openai"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -137,7 +138,7 @@ func TestMapGeminiImageSizeRejectsInvalidValue(t *testing.T) {
 	config, err := mapGeminiImageSize("gemini-3.1-flash-image", "not-a-size")
 	assert.Error(t, err)
 	assert.Nil(t, config)
-	assert.Contains(t, err.Error(), "expected WxH or W:H")
+	assertImageValidationError(t, err, "size", "invalid_image_size")
 }
 
 func TestImageRequestToOpenAIChatRequest(t *testing.T) {
@@ -203,7 +204,7 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 			result, err := ImageRequestToOpenAIChatRequest([]byte(input))
 			assert.Error(t, err)
 			assert.Nil(t, result)
-			assert.Contains(t, err.Error(), "invalid image generation seed")
+			assertImageValidationError(t, err, "seed", "invalid_value")
 		})
 	}
 
@@ -252,7 +253,7 @@ func TestImageRequestToOpenAIChatRequest(t *testing.T) {
 		result, err := ImageRequestToOpenAIChatRequest([]byte("not json"))
 		assert.Error(t, err)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "failed to parse OpenAI image request")
+		assertImageValidationError(t, err, "", "invalid_json")
 	})
 }
 
@@ -280,6 +281,18 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 
 		require.NoError(t, writer.Close())
 		return buf.Bytes(), writer.FormDataContentType()
+	}
+
+	for _, count := range []string{"invalid-count", "0", "-1"} {
+		t.Run("invalid image count "+count, func(t *testing.T) {
+			body, contentType := buildMultipart(t, "gemini-3.1-flash-image", "1024x1024", map[string]string{"n": count})
+			_, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
+			code := "invalid_value"
+			if count == "invalid-count" {
+				code = "invalid_type"
+			}
+			assertImageValidationError(t, err, "n", code)
+		})
 	}
 
 	t.Run("multipart edit request converts to multimodal chat request", func(t *testing.T) {
@@ -385,7 +398,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		})
 		_, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "invalid image edit image_config")
+		assertImageValidationError(t, err, "image_config", "invalid_json")
 	})
 
 	t.Run("omitted sampling parameters remain unset", func(t *testing.T) {
@@ -406,7 +419,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 		assert.Error(t, err)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "invalid image edit seed")
+		assertImageValidationError(t, err, "seed", "invalid_value")
 	})
 
 	for _, test := range []struct {
@@ -428,7 +441,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 			result, err := ImageEditRequestToOpenAIChatRequest(body, contentType)
 			assert.Error(t, err)
 			assert.Nil(t, result)
-			assert.Contains(t, err.Error(), "invalid image edit "+test.field)
+			assertImageValidationError(t, err, test.field, "invalid_value")
 		})
 	}
 
@@ -441,7 +454,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		result, err := ImageEditRequestToOpenAIChatRequest(buf.Bytes(), writer.FormDataContentType())
 		assert.Error(t, err)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "missing model")
+		assertImageValidationError(t, err, "model", "missing_required_parameter")
 	})
 
 	t.Run("mask image is included in content blocks", func(t *testing.T) {
@@ -505,7 +518,7 @@ func TestImageEditRequestToOpenAIChatRequest(t *testing.T) {
 		result, err := ImageEditRequestToOpenAIChatRequest(buf.Bytes(), writer.FormDataContentType())
 		assert.Error(t, err)
 		assert.Nil(t, result)
-		assert.Contains(t, err.Error(), "unsupported MIME type")
+		assertImageValidationError(t, err, "image", "invalid_image")
 	})
 }
 
@@ -715,4 +728,29 @@ func TestVertexChatResponseToOpenAIImage_UsageFormat(t *testing.T) {
 		require.NoError(t, json.Unmarshal(result, &resp))
 		assert.Empty(t, resp.Data)
 	})
+}
+
+func assertImageValidationError(t *testing.T, err error, param, code string) {
+	t.Helper()
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, param, validationErr.Param)
+	assert.Equal(t, code, validationErr.Code)
+}
+
+func TestImageMultipartSizeLimit(t *testing.T) {
+	var body bytes.Buffer
+	form := multipart.NewWriter(&body)
+	file, err := form.CreateFormFile("image", "test.png")
+	require.NoError(t, err)
+	_, err = file.Write([]byte("oversized"))
+	require.NoError(t, err)
+	require.NoError(t, form.Close())
+	part, err := multipart.NewReader(&body, form.Boundary()).NextPart()
+	require.NoError(t, err)
+	_, err = readMultipartPartLimit(part, 4)
+	var validationErr *converterutil.RequestValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.Equal(t, "image", validationErr.Param)
+	assert.Equal(t, 413, validationErr.StatusCode)
 }

--- a/internal/proxy/client_error_messages_test.go
+++ b/internal/proxy/client_error_messages_test.go
@@ -1,0 +1,85 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	compatlitellm "github.com/mixaill76/auto_ai_router/internal/responsecompat/litellm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type clientErrorTransport struct {
+	status int
+	body   string
+}
+
+func (tr clientErrorTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	if tr.status == 0 {
+		return nil, context.Canceled
+	}
+	return &http.Response{
+		StatusCode: tr.status,
+		Header:     http.Header{"Content-Type": {"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(tr.body)),
+		Request:    r,
+	}, nil
+}
+
+func TestProxyRequestClientErrorMessages(t *testing.T) {
+	for _, mode := range []string{"native", "litellm"} {
+		for _, tt := range []struct {
+			name   string
+			status int
+			body   string
+		}{
+			{"prompt length", http.StatusBadRequest, `{"error":{"message":"prompt is too long: 1685418 tokens \u003e 1000000 maximum","type":"invalid_request_error"},"request_id":"req_provider","type":"error"}`},
+			{"internal server error", http.StatusInternalServerError, `{"error":{"message":"Post http://air-ru01/v1/responses failed"}}`},
+			{"bad gateway", http.StatusBadGateway, `{"error":{"message":"Proxy forward error: Post http://air-ru01/v1/responses: context canceled"}}`},
+			{"transport error", 0, ""},
+		} {
+			t.Run(mode+"/"+tt.name, func(t *testing.T) {
+				prx := NewTestProxyBuilder().
+					WithSingleCredential("gateway", config.ProviderTypeProxy, "http://air-ru01", "upstream-key").
+					Build()
+				prx.client.Transport = clientErrorTransport{status: tt.status, body: tt.body}
+				if mode == "litellm" {
+					prx.responseCompat = compatlitellm.New()
+				}
+
+				req := httptest.NewRequest(http.MethodPost, "/v1/responses", strings.NewReader(`{"model":"gpt-4","input":"hello"}`))
+				req.Header.Set("Authorization", "Bearer master-key")
+				req.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				prx.ProxyRequest(w, req)
+
+				wantStatus := tt.status
+				if wantStatus == 0 {
+					wantStatus = http.StatusBadGateway
+				}
+				require.Equal(t, wantStatus, w.Code)
+				var response APIErrorResponse
+				require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+				for _, detail := range []string{"air-ru01", "http://", "context canceled", "upstream-key", "req_provider"} {
+					assert.NotContains(t, w.Body.String(), detail)
+				}
+				if tt.status == http.StatusBadRequest {
+					assert.Equal(t, "Context length exceeded", response.Error.Message)
+					assert.Equal(t, "invalid_request_error", response.Error.Type)
+					require.NotNil(t, response.Error.Code)
+					assert.Equal(t, "context_length_exceeded", *response.Error.Code)
+					require.NotNil(t, response.Error.Param)
+					assert.Equal(t, "prompt", *response.Error.Param)
+				} else {
+					assert.Contains(t, []string{"Request failed", "Bad Gateway"}, response.Error.Message)
+				}
+			})
+		}
+	}
+}

--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -175,7 +175,15 @@ func statusForValidationError(e *converterutil.RequestValidationError) int {
 // it was logged under, not silently collapse to 400.
 func writeValidationError(w http.ResponseWriter, e *converterutil.RequestValidationError, message string) {
 	status := statusForValidationError(e)
-	WriteJSONError(w, status, message, errorTypeForStatus(status), nil, nil)
+	var param, code *string
+	if e.Param != "" {
+		param = &e.Param
+	}
+	if e.Code != "" {
+		code = &e.Code
+		message = e.Message
+	}
+	WriteJSONError(w, status, message, errorTypeForStatus(status), param, code)
 }
 
 // WriteErrorRateLimit writes a 429 Too Many Requests JSON error.

--- a/internal/proxy/image_compatibility_test.go
+++ b/internal/proxy/image_compatibility_test.go
@@ -1,0 +1,169 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageMiniForwardedCompatibility(t *testing.T) {
+	for _, model := range []string{"gpt-image-1-mini", "gpt-image-1", "gpt-image-2"} {
+		for _, format := range []string{"generation", "JSON edit", "multipart edit"} {
+			for _, quality := range []string{"standard", "hd", "low", "unknown"} {
+				t.Run(model+"/"+format+"/"+quality, func(t *testing.T) {
+					wantQuality := quality
+					if model == "gpt-image-1-mini" {
+						if quality == "standard" {
+							wantQuality = "medium"
+						}
+						if quality == "hd" {
+							wantQuality = "high"
+						}
+					}
+					called := false
+					upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+						called = true
+						var fields map[string]any
+						if format == "multipart edit" {
+							require.NoError(t, r.ParseMultipartForm(1<<20))
+							defer func() { require.NoError(t, r.MultipartForm.RemoveAll()) }()
+							fields = map[string]any{}
+							for k, v := range r.MultipartForm.Value {
+								fields[k] = v[0]
+							}
+							for _, name := range []string{"image", "mask"} {
+								file, _, err := r.FormFile(name)
+								require.NoError(t, err)
+								data, err := io.ReadAll(file)
+								require.NoError(t, err)
+								require.NoError(t, file.Close())
+								require.Equal(t, name+" bytes", string(data))
+							}
+						} else {
+							require.NoError(t, json.NewDecoder(r.Body).Decode(&fields))
+							require.Equal(t, "image bytes", fields["image"])
+							require.Equal(t, "mask bytes", fields["mask"])
+						}
+						require.Equal(t, model, fields["model"])
+						require.Equal(t, wantQuality, fields["quality"])
+						require.Equal(t, "unchanged", fields["user"])
+						if model == "gpt-image-1-mini" && format != "generation" {
+							require.NotContains(t, fields, "input_fidelity")
+						} else {
+							require.Equal(t, "high", fields["input_fidelity"])
+						}
+						w.Header().Set("Content-Type", "application/json")
+						_, _ = io.WriteString(w, `{"data":[{"b64_json":"aW1n"}]}`)
+					}))
+					defer upstream.Close()
+					prx := NewTestProxyBuilder().WithSingleCredential("provider", config.ProviderTypeOpenAI, upstream.URL, "key").Build()
+					manager := models.New(testhelpers.NewTestLogger(), 50, []config.ModelRPMConfig{{Name: "public-image", Model: model, RPM: 100, TPM: -1}})
+					manager.LoadModelsFromConfig([]config.CredentialConfig{{Name: "provider", Type: config.ProviderTypeOpenAI}})
+					prx.modelManager = manager
+					prx.balancer.SetModelChecker(manager)
+					fields := map[string]string{"model": "public-image", "prompt": "test", "quality": quality, "input_fidelity": "high", "user": "unchanged", "image": "image bytes", "mask": "mask bytes"}
+					var body bytes.Buffer
+					contentType := "application/json"
+					if format == "multipart edit" {
+						form := multipart.NewWriter(&body)
+						for k, v := range fields {
+							if k == "image" || k == "mask" {
+								part, err := form.CreateFormFile(k, k+".png")
+								require.NoError(t, err)
+								_, err = io.WriteString(part, v)
+								require.NoError(t, err)
+							} else {
+								require.NoError(t, form.WriteField(k, v))
+							}
+						}
+						require.NoError(t, form.Close())
+						contentType = form.FormDataContentType()
+					} else {
+						require.NoError(t, json.NewEncoder(&body).Encode(fields))
+					}
+					path := "/v1/images/edits"
+					if format == "generation" {
+						path = "/v1/images/generations"
+					}
+					req := httptest.NewRequest(http.MethodPost, path, &body)
+					req.Header.Set("Content-Type", contentType)
+					req.Header.Set("Authorization", "Bearer master-key")
+					w := httptest.NewRecorder()
+					prx.ProxyRequest(w, req)
+					require.Equal(t, 200, w.Code, w.Body.String())
+					require.True(t, called)
+				})
+			}
+		}
+	}
+}
+
+func TestGeminiJSONEditForwardedPayload(t *testing.T) {
+	for _, provider := range []config.ProviderType{config.ProviderTypeGemini} {
+		t.Run(string(provider), func(t *testing.T) {
+			called := false
+			upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				called = true
+				var payload struct {
+					Contents []struct {
+						Parts []struct {
+							Text       string
+							InlineData *struct {
+								MimeType string
+								Data     string
+							}
+						}
+					}
+					GenerationConfig map[string]any
+				}
+				require.NoError(t, json.NewDecoder(r.Body).Decode(&payload))
+				require.Len(t, payload.Contents, 1)
+				parts := payload.Contents[0].Parts
+				require.Len(t, parts, 5)
+				require.Equal(t, "test", parts[0].Text)
+				for _, i := range []int{1, 2, 4} {
+					require.NotNil(t, parts[i].InlineData)
+					require.Equal(t, "image/png", parts[i].InlineData.MimeType)
+					require.Equal(t, "aW1n", parts[i].InlineData.Data)
+				}
+				require.Equal(t, "Use the provided mask image to constrain the edit.", parts[3].Text)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"candidates":[{"content":{"parts":[{"inlineData":{"mimeType":"image/png","data":"aW1n"}}]}}]}`)
+			}))
+			defer upstream.Close()
+			prx := NewTestProxyBuilder().WithSingleCredential("provider", provider, upstream.URL, "key").Build()
+			manager := models.New(testhelpers.NewTestLogger(), 50, []config.ModelRPMConfig{{Name: "public-image", Model: "gemini-3.1-flash-image", RPM: 100, TPM: -1}})
+			manager.LoadModelsFromConfig([]config.CredentialConfig{{Name: "provider", Type: provider}})
+			prx.modelManager = manager
+			prx.balancer.SetModelChecker(manager)
+			req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader(`{"model":"public-image","prompt":"test","images":[{"image_url":"data:image/png;base64,aW1n"},"data:image/png;base64,aW1n"],"mask":{"url":"data:image/png;base64,aW1n"},"size":"1024x1024"}`))
+			req.Header.Set("Authorization", "Bearer master-key")
+			req.Header.Set("Content-Type", "application/json; charset=utf-8")
+			w := httptest.NewRecorder()
+			prx.ProxyRequest(w, req)
+			require.Equal(t, 200, w.Code, w.Body.String())
+			require.True(t, called)
+		})
+	}
+}
+
+func TestGeminiJSONEditPreservesProviderFailure(t *testing.T) {
+	prx := NewTestProxyBuilder().WithSingleCredential("provider", config.ProviderTypeGemini, "http://provider.internal", "key").Build()
+	prx.client.Transport = clientErrorTransport{status: http.StatusInternalServerError, body: `{"error":{"message":"Provider failure"}}`}
+	req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", strings.NewReader(`{"model":"gemini-3.1-flash-image","prompt":"test","image":"data:image/png;base64,aW1n"}`))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	prx.ProxyRequest(w, req)
+	require.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/internal/proxy/image_validation_test.go
+++ b/internal/proxy/image_validation_test.go
@@ -1,0 +1,124 @@
+package proxy
+
+import (
+	"bytes"
+	"encoding/json"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	compatlitellm "github.com/mixaill76/auto_ai_router/internal/responsecompat/litellm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type unexpectedImageTransport struct{ t *testing.T }
+
+func (tr unexpectedImageTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	tr.t.Error("Invalid image request reached the provider")
+	return nil, http.ErrNotSupported
+}
+
+func TestImageValidationBeforeForwarding(t *testing.T) {
+	for _, provider := range []config.ProviderType{config.ProviderTypeGemini, config.ProviderTypeVertexAI} {
+		for _, mode := range []string{"native", "litellm"} {
+			for _, tt := range []struct {
+				name, fields, param, code string
+			}{
+				{"missing prompt", ``, "prompt", "missing_required_parameter"},
+				{"empty prompt", `,"prompt":" "`, "prompt", "missing_required_parameter"},
+				{"prompt type", `,"prompt":123`, "prompt", "invalid_type"},
+				{"size", `,"prompt":"test","size":"invalid-size"`, "size", "invalid_image_size"},
+				{"count type", `,"prompt":"test","n":"invalid-count"`, "n", "invalid_type"},
+				{"count value", `,"prompt":"test","n":0`, "n", "invalid_value"},
+				{"seed", `,"prompt":"test","seed":2147483648`, "seed", "invalid_value"},
+			} {
+				t.Run(string(provider)+"/"+mode+"/"+tt.name, func(t *testing.T) {
+					prx := NewTestProxyBuilder().WithSingleCredential("provider", provider, "http://provider.internal", "key").Build()
+					prx.client.Transport = unexpectedImageTransport{t}
+					if mode == "litellm" {
+						prx.responseCompat = compatlitellm.New()
+					}
+					req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"gemini-3.1-flash-image"`+tt.fields+`}`))
+					req.Header.Set("Authorization", "Bearer master-key")
+					req.Header.Set("Content-Type", "application/json")
+					w := httptest.NewRecorder()
+					prx.ProxyRequest(w, req)
+					assertImageClientError(t, w, tt.param, tt.code)
+				})
+			}
+			for _, missing := range []string{"prompt", "image"} {
+				t.Run(string(provider)+"/"+mode+"/edit missing "+missing, func(t *testing.T) {
+					var body bytes.Buffer
+					form := multipart.NewWriter(&body)
+					require.NoError(t, form.WriteField("model", "gemini-3.1-flash-image"))
+					if missing != "prompt" {
+						require.NoError(t, form.WriteField("prompt", "test"))
+					}
+					if missing != "image" {
+						part, err := form.CreateFormFile("image", "test.png")
+						require.NoError(t, err)
+						_, err = part.Write([]byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'})
+						require.NoError(t, err)
+					}
+					require.NoError(t, form.Close())
+					prx := NewTestProxyBuilder().WithSingleCredential("provider", provider, "http://provider.internal", "key").Build()
+					prx.client.Transport = unexpectedImageTransport{t}
+					if mode == "litellm" {
+						prx.responseCompat = compatlitellm.New()
+					}
+					req := httptest.NewRequest(http.MethodPost, "/v1/images/edits", &body)
+					req.Header.Set("Authorization", "Bearer master-key")
+					req.Header.Set("Content-Type", form.FormDataContentType())
+					w := httptest.NewRecorder()
+					prx.ProxyRequest(w, req)
+					assertImageClientError(t, w, missing, "missing_required_parameter")
+				})
+			}
+		}
+	}
+}
+
+func assertImageClientError(t *testing.T, w *httptest.ResponseRecorder, param, code string) {
+	t.Helper()
+	require.Equal(t, http.StatusBadRequest, w.Code, w.Body.String())
+	var response APIErrorResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &response))
+	assert.Equal(t, "invalid_request_error", response.Error.Type)
+	require.NotNil(t, response.Error.Param)
+	assert.Equal(t, param, *response.Error.Param)
+	require.NotNil(t, response.Error.Code)
+	assert.Equal(t, code, *response.Error.Code)
+	assert.NotEqual(t, "Invalid request", response.Error.Message)
+	assert.NotContains(t, w.Body.String(), "provider.internal")
+}
+
+func TestImageUpstreamErrors(t *testing.T) {
+	for _, mode := range []string{"native", "litellm"} {
+		for _, tt := range []struct {
+			body, param, code string
+		}{
+			{`{"error":{"message":"Invalid type for prompt","param":"prompt","code":"invalid_type"}}`, "prompt", "invalid_type"},
+			{`{"error":{"message":"Invalid value for size","param":"size","code":"invalid_value"}}`, "size", "invalid_value"},
+			{`{"error":{"message":"Unable to process input image. Request sent to http://air-ru01","status":"INVALID_ARGUMENT"}}`, "image", "invalid_image"},
+		} {
+			t.Run(mode+"/"+tt.code, func(t *testing.T) {
+				prx := NewTestProxyBuilder().WithSingleCredential("gateway", config.ProviderTypeProxy, "http://air-ru01", "key").Build()
+				prx.client.Transport = clientErrorTransport{status: http.StatusBadRequest, body: tt.body}
+				if mode == "litellm" {
+					prx.responseCompat = compatlitellm.New()
+				}
+				req := httptest.NewRequest(http.MethodPost, "/v1/images/generations", strings.NewReader(`{"model":"openai/gpt-image-2","prompt":"test"}`))
+				req.Header.Set("Authorization", "Bearer master-key")
+				req.Header.Set("Content-Type", "application/json")
+				w := httptest.NewRecorder()
+				prx.ProxyRequest(w, req)
+				assertImageClientError(t, w, tt.param, tt.code)
+				assert.NotContains(t, w.Body.String(), "air-ru01")
+			})
+		}
+	}
+}

--- a/internal/upstreamerror/classify.go
+++ b/internal/upstreamerror/classify.go
@@ -11,6 +11,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"unicode"
 )
 
 // BadRequest is the result of classifying a raw 400 body: always one of a
@@ -33,6 +34,9 @@ func ClassifyBadRequest(rawBody []byte) BadRequest {
 
 	signals, providerParam := providerErrorSignalsFromBody(rawBody)
 	joined := strings.ToLower(strings.Join(signals, " "))
+	if classified, ok := classifyValidationError(joined, providerParam, signals); ok {
+		return classified
+	}
 
 	switch {
 	case hasSignal(joined, "tool_choice", "tool choice", "toolchoice"):
@@ -282,4 +286,54 @@ func inferMaxTokensParam(joined string) string {
 	default:
 		return "max_tokens"
 	}
+}
+
+func classifyValidationError(joined string, param *string, signals []string) (BadRequest, bool) {
+	result := BadRequest{Param: param}
+	switch {
+	case hasSignal(joined, "invalid_image_size", "invalid image size"):
+		result.Message, result.Code = "Invalid image size", "invalid_image_size"
+		if result.Param == nil {
+			field := "size"
+			result.Param = &field
+		}
+	case hasSignal(joined, "invalid_image", "invalid image", "could not decode image", "unable to decode image", "failed to decode image", "image is not valid", "image is invalid", "image_parse_error", "image file could not be processed", "unable to process input image", "unable to process the input image"):
+		result.Message, result.Code = "Invalid image data", "invalid_image"
+		if result.Param == nil {
+			field := "image"
+			result.Param = &field
+		}
+	case hasSignal(joined, "missing_required_parameter", "missing required parameter", "missing required argument"):
+		result.Message, result.Code = "Missing required parameter", "missing_required_parameter"
+	case hasSignal(joined, "invalid_type", "invalid type", "invalid parameter type"):
+		result.Message, result.Code = "Invalid parameter type", "invalid_type"
+	case hasSignal(joined, "invalid_json", "invalid json"):
+		result.Message, result.Code = "Invalid JSON", "invalid_json"
+	case hasSignal(joined, "invalid_multipart", "invalid multipart"):
+		result.Message, result.Code = "Invalid multipart form data", "invalid_multipart"
+	case hasSignal(joined, "invalid_value", "invalid value", "invalid parameter value"):
+		result.Message, result.Code = "Invalid parameter value", "invalid_value"
+	default:
+		return BadRequest{}, false
+	}
+	if result.Param == nil {
+		if field := extractQuotedInvalidField(signals); field != nil {
+			if cleaned := cleanProviderErrorParam(*field); cleaned != "" {
+				result.Param = &cleaned
+			}
+		}
+	}
+	if result.Param == nil {
+		for _, word := range strings.FieldsFunc(joined, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '_'
+		}) {
+			switch word {
+			case "prompt", "size", "n", "image", "mask", "seed", "quality", "output_format", "output_compression", "background", "moderation", "response_format", "image_config", "aspect_ratio", "image_size":
+				field := word
+				result.Param = &field
+				return result, true
+			}
+		}
+	}
+	return result, true
 }

--- a/internal/upstreamerror/classify.go
+++ b/internal/upstreamerror/classify.go
@@ -49,7 +49,7 @@ func ClassifyBadRequest(rawBody []byte) BadRequest {
 		result.Message = "Invalid " + *param
 		result.Code = "invalid_max_tokens"
 		result.Param = param
-	case hasSignal(joined, "context length", "context window", "context limit", "too many tokens", "input too long", "prompt too long", "token limit"):
+	case hasSignal(joined, "context length", "context window", "context limit", "too many tokens", "input too long", "prompt too long", "prompt is too long", "token limit"):
 		result.Message = "Context length exceeded"
 		result.Code = "context_length_exceeded"
 		result.Param = inferBadRequestParam(joined, providerParam)

--- a/internal/upstreamerror/image_errors_test.go
+++ b/internal/upstreamerror/image_errors_test.go
@@ -1,0 +1,46 @@
+package upstreamerror
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageErrorClassification(t *testing.T) {
+	for _, tt := range []struct {
+		name, body, message, code, param string
+	}{
+		{"missing prompt", `{"error":{"message":"Missing required parameter 'prompt'.","param":"prompt"}}`, "Missing required parameter", "missing_required_parameter", "prompt"},
+		{"prompt type", `{"error":{"message":"Invalid type for 'prompt'. Expected a string.","code":"invalid_type","param":"prompt"}}`, "Invalid parameter type", "invalid_type", "prompt"},
+		{"size value", `{"error":{"message":"Invalid value for 'size'. See http://provider.internal","code":"invalid_value","param":"size"}}`, "Invalid parameter value", "invalid_value", "size"},
+		{"image data", `{"error":{"message":"Invalid image data from credential private-key","code":"invalid_image"}}`, "Invalid image data", "invalid_image", "image"},
+		{"Gemini image data", `{"error":{"code":400,"message":"Unable to process input image. Please retry.","status":"INVALID_ARGUMENT"}}`, "Invalid image data", "invalid_image", "image"},
+		{"mask data", `{"error":{"message":"Could not decode image","param":"mask"}}`, "Invalid image data", "invalid_image", "mask"},
+		{"image size", `{"error":{"message":"Invalid image size","param":"size","code":"invalid_image_size"}}`, "Invalid image size", "invalid_image_size", "size"},
+		{"JSON", `{"error":{"message":"Invalid JSON","param":"image_config","code":"invalid_json"}}`, "Invalid JSON", "invalid_json", "image_config"},
+		{"multipart", `{"error":{"message":"Invalid multipart form data","param":"image","code":"invalid_multipart"}}`, "Invalid multipart form data", "invalid_multipart", "image"},
+		{"unknown detail", `{"error":{"message":"Unrecognized provider failure at http://provider.internal"}}`, "Invalid request", "invalid_request", ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(tt.body)
+			for range 3 {
+				got := ClassifyBadRequest(body)
+				assert.Equal(t, tt.message, got.Message)
+				assert.Equal(t, tt.code, got.Code)
+				if tt.param == "" {
+					assert.Nil(t, got.Param)
+				} else {
+					require.NotNil(t, got.Param)
+					assert.Equal(t, tt.param, *got.Param)
+				}
+				var err error
+				body, err = json.Marshal(map[string]any{"error": map[string]any{"message": got.Message, "code": got.Code, "param": got.Param}})
+				require.NoError(t, err)
+				assert.NotContains(t, string(body), "provider.internal")
+				assert.NotContains(t, string(body), "private-key")
+			}
+		})
+	}
+}


### PR DESCRIPTION
Preserve image request compatibility and return specific client validation errors while keeping internal routes and provider diagnostics out of responses.

Gemini image requests with invalid prompt types, sizes, or counts currently return HTTP 500. Missing generation prompts and edits without an image can reach the provider. Reject these requests before forwarding with HTTP 400 and a specific error code and parameter. Return HTTP 413 when a multipart input exceeds the existing size limit.

Classify missing parameters, invalid types and values, malformed JSON and multipart data, and invalid image data. Preserve these classifications through proxy forwarding and LiteLLM normalization. Recognize Anthropic's prompt length error as `context_length_exceeded`.

Current main already masks internal routes in server and transport errors. Retain regression coverage for HTTP 500, HTTP 502, and canceled proxy requests.

Validation includes the full test suite with the race detector, converter and HTTP regression tests, repeated error normalization, and lint with no findings.

Support JSON edits for Gemini image models through the existing image conversion path. Accept URL and data URL inputs, including multiple images and masks. Preserve multipart behavior. Reject unsupported input with HTTP 400 or HTTP 415. File IDs are not supported.

For the resolved gpt-image-1-mini model, normalize quality from standard to medium and from hd to high. Remove input_fidelity from edits only. Preserve other models, values, files, masks, and unrelated fields.

The compatibility commit passes the affected suites with the race detector and lint with no findings. HTTP tests verify forwarded JSON and multipart payloads, model aliases, unaffected models, and provider failure status. Converter tests cover malformed JSON and unsupported inputs.
