### PR TITLE
fix: extract usage from response.incomplete in passthrough Responses API

### DIFF
--- a/internal/proxy/responses_incomplete_usage_e2e_test.go
+++ b/internal/proxy/responses_incomplete_usage_e2e_test.go
@@ -1,0 +1,110 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	pricing "github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestProxyRequest_ResponsesIncompleteEventStillBillsRealUsage reproduces a
+// real production bug: DashScope (and potentially other providers) sends full
+// usage in the terminal "response.incomplete" event when the model stops
+// early (e.g. max_output_tokens reached), not only in "response.completed".
+// handlePassthroughResponsesStreaming used to only capture usage on
+// "response.completed", so an incomplete response fell through to
+// finalizeStreamingLog's local-tiktoken-estimate fallback for PromptTokens
+// instead of the real, much larger provider-reported value — silently
+// undercounting both the rate limiter and the billed spend.
+//
+// The mock "response.incomplete" payload is deliberately padded past 8 KB
+// (streamBufPool's fixed read-buffer size in streamToClient), so the SSE
+// line genuinely arrives across multiple onChunk calls, each holding only a
+// raw byte-level fragment. This matters: without the fix,
+// completedEventPayload is never captured, and finalizeStreamingLog's
+// type-agnostic fallback extractor runs on lastRawChunk — the last such
+// fragment, which is NOT valid/parseable JSON on its own. Only the properly
+// reassembled (partialSSELine-stitched) full line, captured into
+// completedEventPayload by the "response.completed" || "response.incomplete"
+// check, parses successfully. A small (<8 KB) mock payload would accidentally
+// mask the bug: sanitizingSSEReader's internal bufio.Reader buffers a whole
+// short line before streamToClient's Read() loop ever sees it, so
+// lastRawChunk would already hold the complete, valid line regardless of the
+// fix — this was confirmed by first writing this test without padding and
+// watching it pass even with the fix reverted.
+//
+// The request body is also deliberately a short, few-token prompt while the
+// upstream reports a huge real input_tokens count: if usage extraction ever
+// falls back to estimating tokens from the request body again, PromptTokens
+// comes back tiny instead of matching the upstream value — failing
+// unambiguously either way.
+func TestProxyRequest_ResponsesIncompleteEventStillBillsRealUsage(t *testing.T) {
+	const (
+		realInputTokens  = 150000
+		realOutputTokens = 30
+		realTotalTokens  = realInputTokens + realOutputTokens
+	)
+
+	// Padding lives in a field the decoder doesn't map (silently ignored by
+	// json.Unmarshal), placed BEFORE "usage" so the fragment(s) preceding the
+	// real usage object are pushed past the 8 KB read-buffer boundary.
+	padding := strings.Repeat("x", 16*1024)
+
+	upstream := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		data := "event: response.incomplete\ndata: " +
+			`{"type":"response.incomplete","response":{"id":"resp_incomplete","object":"response",` +
+			`"status":"incomplete","model":"gpt-incomplete-usage",` +
+			`"incomplete_details":{"reason":"max_output_tokens"},` +
+			`"_padding":"` + padding + `",` +
+			`"output":[{"type":"message","id":"msg_1","status":"incomplete","role":"assistant","content":[]}],` +
+			`"usage":{"input_tokens":150000,"output_tokens":30,"total_tokens":150030}}}` +
+			"\n\ndata: [DONE]\n\n"
+		_, _ = w.Write([]byte(data))
+	}))
+	defer upstream.Close()
+
+	dbStub := &stubLiteLLMManager{}
+	prx := NewTestProxyBuilder().
+		WithCredentials(config.CredentialConfig{
+			Name:    "openai-incomplete-usage",
+			Type:    config.ProviderTypeOpenAI,
+			BaseURL: upstream.URL,
+			APIKey:  "upstream-key",
+			RPM:     100,
+			TPM:     10000,
+		}).
+		WithMasterKey("master-key").
+		Build()
+	prx.LiteLLMDB = dbStub
+	setTestModelPrice(prx, "gpt-incomplete-usage", &pricing.ModelPrice{
+		InputCostPerToken:  1,
+		OutputCostPerToken: 2,
+	})
+
+	req := httptest.NewRequest("POST", "/v1/responses", strings.NewReader(`{
+		"model": "gpt-incomplete-usage",
+		"input": "hi",
+		"stream": true
+	}`))
+	req.Header.Set("Authorization", "Bearer master-key")
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	prx.ProxyRequest(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Len(t, dbStub.loggedEntries, 1)
+
+	entry := dbStub.loggedEntries[0]
+	assert.Equal(t, realInputTokens, entry.PromptTokens,
+		"PromptTokens must come from the provider's response.incomplete usage, not a tiktoken estimate of the short request body")
+	assert.Equal(t, realOutputTokens, entry.CompletionTokens)
+	assert.Equal(t, realTotalTokens, entry.TotalTokens)
+	assert.Equal(t, float64(realInputTokens)*1+float64(realOutputTokens)*2, entry.Spend)
+}

--- a/internal/proxy/stream.go
+++ b/internal/proxy/stream.go
@@ -1787,7 +1787,7 @@ func (p *Proxy) handlePassthroughResponsesStreaming(
 				Type     string             `json:"type"`
 				Response responses.Response `json:"response"`
 			}
-			if json.Unmarshal([]byte(jsonData), &event) == nil && event.Type == "response.completed" {
+			if json.Unmarshal([]byte(jsonData), &event) == nil && (event.Type == "response.completed" || event.Type == "response.incomplete") {
 				if event.Response.Usage != nil {
 					totalTokens = event.Response.Usage.TotalTokens
 					if logCtx != nil {

--- a/internal/proxy/stream_test.go
+++ b/internal/proxy/stream_test.go
@@ -581,6 +581,14 @@ func TestOpenAIStreamUsageExtractor(t *testing.T) {
 			},
 		},
 		{
+			name:      "responses API - response.incomplete event carries usage",
+			chunk:     []byte(`{"type":"response.incomplete","response":{"id":"resp_456","status":"incomplete","incomplete_details":{"reason":"max_output_tokens"},"usage":{"input_tokens":5000,"output_tokens":30,"total_tokens":5030,"output_tokens_details":{"reasoning_tokens":30}}}}`),
+			expectNil: false,
+			expectUsage: func(u *StreamUsageInfo) bool {
+				return u.PromptTokens == 5000 && u.CompletionTokens == 30 && u.ReasoningTokens == 30
+			},
+		},
+		{
 			name:      "responses API - completed output items provide web search count",
 			chunk:     []byte(`{"type":"response.completed","response":{"output":[{"type":"web_search_call","status":"completed"},{"type":"web_search_call","status":"completed"}],"usage":{"input_tokens":20,"output_tokens":5,"total_tokens":25}}}`),
 			expectNil: false,


### PR DESCRIPTION
## Problem

DashScope (and potentially other providers) send full usage data in `response.incomplete` events, not just in `response.completed`. Previously AIR only extracted usage from `response.completed`, causing `totalTokens` to remain 0 when the response was incomplete (e.g. `max_output_tokens` reached).

This resulted in only output tokens being counted for rate limiting and billing, while **input tokens were silently lost**.

## Impact

For long-context requests (input 90k-160k tokens, output ~600 tokens), this caused significant undercounting:
- Rate limiter only consumed output tokens → other requests could overdraw the same credential
- Billing/LiteLLM DB logged only output tokens → spend reports showed ~1/100th of actual usage

## Root Cause

In `handlePassthroughResponsesStreaming` (`internal/proxy/stream.go`), usage extraction was gated on:

```go
event.Type == "response.completed"
```

When a response ends with `response.incomplete` (model hit `max_output_tokens`), the provider sends usage in that event too, but AIR ignored it.

## Fix

Extended the condition to also handle `response.incomplete`:

```go
event.Type == "response.completed" || event.Type == "response.incomplete"
```

The usage extraction logic is identical for both events — the provider sends the same `usage` object structure.

## Verification

- **Direct provider test**: Confirmed DashScope sends full `usage` (input_tokens, output_tokens, reasoning_tokens) in `response.incomplete`
- **All unit tests pass** (`go test ./...`)
- **Added test case** for `response.incomplete` with usage extraction

## Risk

Low. Only affects the passthrough-responses path (OpenAI/Proxy/AIR provider types). Converter-based providers (Anthropic, Vertex) are not affected. If a provider sends `response.incomplete` without `usage`, the `event.Response.Usage != nil` guard prevents any change in behavior.