### PR TITLE
Add per-credential proxy support

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -65,6 +65,7 @@ credentials:
     type: "openai"
     api_key: "sk-proj-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     base_url: "https://api.openai.com"
+    # proxy_url: "os.environ/OPENAI_PROXY_URL"  # Optional: http(s):// or socks5(h)://[user:password@]host:port
     rpm: 100
     tpm: 50000
     weight: 100  # Optional: weighted round-robin share (default 1). See docs/advanced/balancing.md

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -161,6 +161,7 @@ Common fields for all credentials:
 | ------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------- |
 | `name`             | string | Unique credential identifier                                                                                                     |
 | `type`             | string | Provider type: `openai`, `anthropic`, `cometapi`, `vertex-ai`, `gemini`, `bedrock`, `proxy`                                      |
+| `proxy_url`        | string | Optional outbound proxy URL for this credential (HTTP, HTTPS, SOCKS5)                       |
 | `rpm`              | int    | Requests per minute limit (-1 = unlimited)                                                                                       |
 | `tpm`              | int    | Tokens per minute limit (-1 = unlimited)                                                                                         |
 | `is_fallback`      | bool   | Use as fallback when primary credentials are exhausted                                                                           |
@@ -170,6 +171,33 @@ Common fields for all credentials:
 | `forbidden_scopes` | list   | Alias for `denied_scopes`                                                                                                        |
 | `openai_proto`     | bool   | `cometapi` only: use CometAPI's OpenAI-compatible wire protocol ([details](../providers/cometapi.md#openai-protocol-mode))       |
 | `google_proto`     | bool   | `cometapi` only: use CometAPI's Google GenAI-compatible wire protocol ([details](../providers/cometapi.md#google-protocol-mode)) |
+
+### Outbound proxy per credential
+
+Set one `proxy_url` on a credential to route its upstream requests through a fixed proxy:
+
+```yaml
+credentials:
+  - name: openai_main
+    type: openai
+    api_key: os.environ/OPENAI_API_KEY
+    base_url: https://api.openai.com
+    proxy_url: os.environ/OPENAI_PROXY_URL
+```
+
+For example, set `OPENAI_PROXY_URL=http://user:password@proxy.example.com:3128`.
+Supported schemes: `http`, `https`, `socks5`, and `socks5h`. Percent-encode special
+characters in usernames and passwords. Both SOCKS5 schemes resolve destination
+hostnames through the proxy.
+
+The setting applies to ordinary and streaming provider requests, Vertex AI OAuth
+token acquisition and refresh, and `/health` and `/v1/models` discovery for `air`
+and `proxy` credentials. An explicit URL overrides `HTTP_PROXY`, `HTTPS_PROXY`,
+and `NO_PROXY`. When omitted or empty, the existing environment-based behavior
+is preserved. Invalid URLs are rejected during config loading without exposing
+proxy credentials in the error. If the proxy fails, the request fails through
+the usual credential retry/fallback flow; it does not retry the same credential
+directly. Proxy lists and rotation are not supported.
 
 ### Scoped credential visibility
 

--- a/internal/auth/vertex.go
+++ b/internal/auth/vertex.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net/http"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -14,6 +15,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
+	"github.com/mixaill76/auto_ai_router/internal/httputil"
 	"github.com/mixaill76/auto_ai_router/internal/utils"
 )
 
@@ -22,6 +24,7 @@ type tokenRefreshRequest struct {
 	credentialName  string
 	credentialsFile string
 	credentialsJSON string
+	proxyURL        string
 	responseChan    chan tokenRefreshResponse
 }
 
@@ -33,6 +36,7 @@ type tokenRefreshResponse struct {
 
 // VertexTokenManager manages OAuth2 tokens for Vertex AI credentials
 type VertexTokenManager struct {
+	httpClient          *http.Client
 	mu                  sync.RWMutex
 	tokens              map[string]*cachedToken
 	credentials         map[string][]byte // Cache for credentials
@@ -53,11 +57,13 @@ type cachedToken struct {
 	token       *oauth2.Token
 	tokenSource oauth2.TokenSource
 	expiresAt   time.Time
+	proxyURL    string
 }
 
 // NewVertexTokenManager creates a new token manager
 func NewVertexTokenManager(logger *slog.Logger) *VertexTokenManager {
 	tm := &VertexTokenManager{
+		httpClient:          httputil.NewHTTPClient(&httputil.HTTPClientConfig{Timeout: 30 * time.Second}),
 		tokens:              make(map[string]*cachedToken),
 		credentials:         make(map[string][]byte),
 		logger:              logger,
@@ -67,6 +73,7 @@ func NewVertexTokenManager(logger *slog.Logger) *VertexTokenManager {
 		stopChan:            make(chan struct{}),
 		refreshing:          make(map[string][]chan tokenRefreshResponse),
 	}
+	tm.httpClient.Timeout = tm.tokenRefreshTimeout
 	tm.wg.Add(1)
 	go tm.refreshWorker()
 	return tm
@@ -91,14 +98,14 @@ func NewVertexTokenManager(logger *slog.Logger) *VertexTokenManager {
 // Response channel buffering: Each response channel has a buffer size of 1, which allows
 // the worker to send responses non-blocking. If a waiter has already given up due to timeout,
 // the response will still be sent but go unread.
-func (tm *VertexTokenManager) GetToken(credentialName, credentialsFile, credentialsJSON string) (string, error) {
+func (tm *VertexTokenManager) GetToken(credentialName, credentialsFile, credentialsJSON, proxyURL string) (string, error) {
 	if tm.stopped.Load() {
 		return "", fmt.Errorf("token manager is stopped")
 	}
 
 	// Fast path: check if we have a valid cached token (read-only)
 	tm.mu.RLock()
-	if cached, exists := tm.tokens[credentialName]; exists {
+	if cached, exists := tm.tokens[credentialName]; exists && cached.proxyURL == proxyURL {
 		if utils.NowUTC().Before(cached.expiresAt.Add(-tm.tokenRefresh)) {
 			token := cached.token.AccessToken
 			tm.mu.RUnlock()
@@ -115,7 +122,7 @@ func (tm *VertexTokenManager) GetToken(credentialName, credentialsFile, credenti
 
 	// Double-check cache to prevent race condition: cache may have been updated
 	// after our first check and before acquiring this lock
-	if cached, exists := tm.tokens[credentialName]; exists {
+	if cached, exists := tm.tokens[credentialName]; exists && cached.proxyURL == proxyURL {
 		if utils.NowUTC().Before(cached.expiresAt.Add(-tm.tokenRefresh)) {
 			token := cached.token.AccessToken
 			tm.mu.RUnlock()
@@ -141,6 +148,7 @@ func (tm *VertexTokenManager) GetToken(credentialName, credentialsFile, credenti
 			credentialName:  credentialName,
 			credentialsFile: credentialsFile,
 			credentialsJSON: credentialsJSON,
+			proxyURL:        proxyURL,
 			responseChan:    responseChan,
 		}
 		select {
@@ -249,7 +257,7 @@ func (tm *VertexTokenManager) processRefreshRequest(req tokenRefreshRequest) {
 	tm.mu.RLock()
 	cached, exists := tm.tokens[req.credentialName]
 	tm.mu.RUnlock()
-	if exists {
+	if exists && cached.proxyURL == req.proxyURL {
 		// Token exists, refresh it
 		token, err = tm.refreshToken(req.credentialName, cached)
 		// If refresh fails, try to create a new token immediately instead of returning error
@@ -257,11 +265,11 @@ func (tm *VertexTokenManager) processRefreshRequest(req tokenRefreshRequest) {
 			tm.mu.Lock()
 			delete(tm.tokens, req.credentialName)
 			tm.mu.Unlock()
-			token, err = tm.createNewToken(req.credentialName, req.credentialsFile, req.credentialsJSON)
+			token, err = tm.createNewToken(req.credentialName, req.credentialsFile, req.credentialsJSON, req.proxyURL)
 		}
 	} else {
 		// No cached token, create a new one
-		token, err = tm.createNewToken(req.credentialName, req.credentialsFile, req.credentialsJSON)
+		token, err = tm.createNewToken(req.credentialName, req.credentialsFile, req.credentialsJSON, req.proxyURL)
 	}
 
 	// Send response to all waiting goroutines
@@ -316,7 +324,7 @@ func (tm *VertexTokenManager) refreshToken(credentialName string, cached *cached
 	return newToken.AccessToken, nil
 }
 
-func (tm *VertexTokenManager) createNewToken(credentialName, credentialsFile, credentialsJSON string) (string, error) {
+func (tm *VertexTokenManager) createNewToken(credentialName, credentialsFile, credentialsJSON, proxyURL string) (string, error) {
 	tm.logger.Debug("Creating new Vertex AI token", "credential", credentialName)
 
 	credBytes, err := tm.loadCredentials(credentialName, credentialsFile, credentialsJSON)
@@ -336,8 +344,13 @@ func (tm *VertexTokenManager) createNewToken(credentialName, credentialsFile, cr
 	}
 
 	// Create credentials with Vertex AI scope (ServiceAccount type is validated above)
+	ctx := context.Background()
+	if proxyURL != "" {
+		// JWT token exchange uses PostForm without propagating its context.
+		ctx = context.WithValue(ctx, oauth2.HTTPClient, httputil.WithClientProxy(tm.httpClient, proxyURL))
+	}
 	creds, err := google.CredentialsFromJSONWithType(
-		context.Background(),
+		ctx,
 		credBytes,
 		google.ServiceAccount,
 		"https://www.googleapis.com/auth/cloud-platform",
@@ -358,6 +371,7 @@ func (tm *VertexTokenManager) createNewToken(credentialName, credentialsFile, cr
 		token:       token,
 		tokenSource: creds.TokenSource,
 		expiresAt:   token.Expiry,
+		proxyURL:    proxyURL,
 	}
 	tm.mu.Unlock()
 

--- a/internal/auth/vertex_proxy_test.go
+++ b/internal/auth/vertex_proxy_test.go
@@ -1,0 +1,52 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/json"
+	"encoding/pem"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVertexTokenUsesCredentialProxy(t *testing.T) {
+	var requests atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		assert.Equal(t, "http://oauth.invalid/token", r.URL.String())
+		assert.NoError(t, r.ParseForm())
+		assert.NotEmpty(t, r.Form.Get("assertion"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"proxied-token","token_type":"Bearer","expires_in":3600}`)
+	}))
+	defer server.Close()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	data, err := json.Marshal(map[string]string{
+		"type": "service_account", "client_email": "test@example.com", "token_uri": "http://oauth.invalid/token",
+		"private_key": string(pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})),
+	})
+	require.NoError(t, err)
+	tm := NewVertexTokenManager(testhelpers.NewTestLogger())
+	defer tm.Stop()
+	token, err := tm.GetToken("vertex", "", string(data), server.URL)
+	require.NoError(t, err)
+	require.Equal(t, "proxied-token", token)
+	tm.mu.Lock()
+	tm.tokens["vertex"].expiresAt = time.Now()
+	tm.tokens["vertex"].token.Expiry = time.Now()
+	tm.mu.Unlock()
+	token, err = tm.GetToken("vertex", "", string(data), server.URL)
+	require.NoError(t, err)
+	require.Equal(t, "proxied-token", token)
+	require.EqualValues(t, 2, requests.Load())
+}

--- a/internal/auth/vertex_test.go
+++ b/internal/auth/vertex_test.go
@@ -66,7 +66,7 @@ func TestGetToken_InvalidJSON(t *testing.T) {
 	tm := NewVertexTokenManager(logger)
 	defer tm.Stop()
 
-	_, err := tm.GetToken("test", "", "invalid-json")
+	_, err := tm.GetToken("test", "", "invalid-json", "")
 	if err == nil {
 		t.Error("expected error for invalid JSON, got nil")
 	}
@@ -85,7 +85,7 @@ func TestGetToken_InvalidServiceAccountType(t *testing.T) {
 	}
 	b, _ := json.Marshal(invalidSA)
 
-	_, err := tm.GetToken("test", "", string(b))
+	_, err := tm.GetToken("test", "", string(b), "")
 	if err == nil {
 		t.Error("expected error for non-service-account type, got nil")
 	}
@@ -96,7 +96,7 @@ func TestGetToken_NoCredentials(t *testing.T) {
 	tm := NewVertexTokenManager(logger)
 	defer tm.Stop()
 
-	_, err := tm.GetToken("test", "", "")
+	_, err := tm.GetToken("test", "", "", "")
 	if err == nil {
 		t.Error("expected error for missing credentials, got nil")
 	}
@@ -110,7 +110,7 @@ func TestGetToken_FileNotFound(t *testing.T) {
 	tm := NewVertexTokenManager(logger)
 	defer tm.Stop()
 
-	_, err := tm.GetToken("test", "/nonexistent/path.json", "")
+	_, err := tm.GetToken("test", "/nonexistent/path.json", "", "")
 	if err == nil {
 		t.Error("expected error for non-existent file, got nil")
 	}
@@ -236,7 +236,7 @@ func TestGetToken_CachedTokenReuse(t *testing.T) {
 
 	// Get the same token - should reuse cached token (valid for 1 hour)
 	// No credentials needed if cached token is still valid
-	token, err := tm.GetToken("test", "", "")
+	token, err := tm.GetToken("test", "", "", "")
 	if err != nil {
 		t.Errorf("expected no error for cached valid token, got: %v", err)
 	}
@@ -304,7 +304,7 @@ func TestGetToken_TokenRefreshError(t *testing.T) {
 	tm.mu.Unlock()
 
 	// Attempt to get expired token - should trigger refresh and fail
-	_, err := tm.GetToken("test", "", "")
+	_, err := tm.GetToken("test", "", "", "")
 	if err == nil {
 		t.Error("expected error when token refresh fails")
 	}
@@ -341,7 +341,7 @@ func TestGetToken_NearExpiry(t *testing.T) {
 	tm.mu.Unlock()
 
 	// Get token - should trigger refresh since token expires in 3 min (within 5 min buffer)
-	token, err := tm.GetToken("test", "", "")
+	token, err := tm.GetToken("test", "", "", "")
 	if err != nil {
 		t.Errorf("expected no error, got: %v", err)
 	}
@@ -380,7 +380,7 @@ func TestGetToken_ConcurrentRefresh(t *testing.T) {
 	results := make(chan string, numGoroutines)
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			token, err := tm.GetToken("test", "", "")
+			token, err := tm.GetToken("test", "", "", "")
 			if err != nil {
 				t.Errorf("GetToken failed: %v", err)
 			}
@@ -433,7 +433,7 @@ func TestGetToken_RequestCoalescing(t *testing.T) {
 	results := make(chan string, numGoroutines)
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			token, err := tm.GetToken("test", "", "")
+			token, err := tm.GetToken("test", "", "", "")
 			if err != nil {
 				t.Errorf("GetToken failed: %v", err)
 				results <- ""
@@ -497,7 +497,7 @@ func TestGetToken_TimeoutDuringRefresh(t *testing.T) {
 	tm.mu.Unlock()
 
 	// GetToken should timeout
-	_, err := tm.GetToken("slow", "", "")
+	_, err := tm.GetToken("slow", "", "", "")
 	if err == nil {
 		t.Error("expected timeout error, got nil")
 	}
@@ -539,7 +539,7 @@ func TestGetToken_ParallelDifferentCredentials(t *testing.T) {
 
 	for _, cred := range credentials {
 		go func(credName string) {
-			token, err := tm.GetToken(credName, "", "")
+			token, err := tm.GetToken(credName, "", "", "")
 			if err != nil {
 				t.Errorf("GetToken(%s) failed: %v", credName, err)
 				results <- struct{ name, token string }{credName, ""}
@@ -595,7 +595,7 @@ func TestGetToken_CoalescingWithTimeout(t *testing.T) {
 
 	for i := 0; i < numGoroutines; i++ {
 		go func() {
-			_, err := tm.GetToken("test", "", "")
+			_, err := tm.GetToken("test", "", "", "")
 			results <- err
 		}()
 	}
@@ -681,7 +681,7 @@ func TestGetToken_CoalescingCallerTimeout(t *testing.T) {
 			if idx > 0 {
 				time.Sleep(5 * time.Millisecond)
 			}
-			_, err := tm.GetToken("test", "", "")
+			_, err := tm.GetToken("test", "", "", "")
 			results <- struct {
 				idx int
 				err error
@@ -725,7 +725,7 @@ func TestGetToken_CoalescingCallerTimeout(t *testing.T) {
 	tm.mu.Unlock()
 
 	// This should succeed
-	token, err := tm.GetToken("test", "", "")
+	token, err := tm.GetToken("test", "", "", "")
 	if err != nil {
 		t.Errorf("Recovery GetToken failed: %v", err)
 	}
@@ -763,7 +763,7 @@ func TestGetToken_ChannelLeakOnTimeout(t *testing.T) {
 	defer func() { tm.tokenRefreshTimeout = originalTimeout }()
 
 	// Fire a request that will timeout
-	_, err := tm.GetToken("test", "", "")
+	_, err := tm.GetToken("test", "", "", "")
 	if err == nil {
 		t.Error("Expected timeout error")
 	}
@@ -817,7 +817,7 @@ func TestGetToken_FirstCallerTimeoutRemovesFromMap(t *testing.T) {
 	defer func() { tm.tokenRefreshTimeout = originalTimeout }()
 
 	// Get token - will timeout
-	_, err := tm.GetToken("test", "", "")
+	_, err := tm.GetToken("test", "", "", "")
 	if err == nil {
 		t.Error("Expected timeout")
 	}
@@ -863,7 +863,7 @@ func TestGetToken_MultipleTimeoutsSequential(t *testing.T) {
 	}
 	tm.mu.Unlock()
 
-	_, err := tm.GetToken("test", "", "")
+	_, err := tm.GetToken("test", "", "", "")
 	if err == nil {
 		t.Error("Expected first timeout")
 	}
@@ -885,7 +885,7 @@ func TestGetToken_MultipleTimeoutsSequential(t *testing.T) {
 	}
 	tm.mu.Unlock()
 
-	_, err = tm.GetToken("test", "", "")
+	_, err = tm.GetToken("test", "", "", "")
 	if err == nil {
 		t.Error("Expected second timeout")
 	}
@@ -905,7 +905,7 @@ func TestGetToken_MultipleTimeoutsSequential(t *testing.T) {
 	}
 	tm.mu.Unlock()
 
-	token, err := tm.GetToken("test", "", "")
+	token, err := tm.GetToken("test", "", "", "")
 	if err != nil {
 		t.Errorf("Expected success after timeouts, got error: %v", err)
 	}
@@ -945,7 +945,7 @@ func TestGetToken_ProcessRefreshRequestRobustness(t *testing.T) {
 	// Launch 20 concurrent requests
 	for i := 0; i < 20; i++ {
 		go func() {
-			token, err := tm.GetToken("test", "", "")
+			token, err := tm.GetToken("test", "", "", "")
 			results <- struct {
 				token string
 				err   error
@@ -996,7 +996,7 @@ func TestGetToken_RefreshingMapStateAfterCompletion(t *testing.T) {
 	tm.mu.Unlock()
 
 	// Make request
-	token, err := tm.GetToken("test", "", "")
+	token, err := tm.GetToken("test", "", "", "")
 	if err != nil {
 		t.Errorf("Expected success, got error: %v", err)
 	}
@@ -1061,7 +1061,7 @@ func TestGetToken_ConcurrentDifferentCredentialsWithTimeout(t *testing.T) {
 		// Each credential gets 2 concurrent requests
 		for i := 0; i < 2; i++ {
 			go func(name string) {
-				token, err := tm.GetToken(name, "", "")
+				token, err := tm.GetToken(name, "", "", "")
 				results <- struct {
 					cred  string
 					token string

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -742,6 +742,7 @@ type CredentialConfig struct {
 	Type     ProviderType `yaml:"type"`
 	APIKey   string       `yaml:"api_key"`
 	BaseURL  string       `yaml:"base_url"`
+	ProxyURL string       `yaml:"proxy_url,omitempty"`
 	AuthType string       `yaml:"auth_type,omitempty"`
 	// OpenAIProtocol switches a cometapi credential from CometAPI's
 	// Anthropic-compatible wire protocol (/v1/messages) to its
@@ -864,6 +865,7 @@ func (c CredentialConfig) SameProviderIdentity(other CredentialConfig) bool {
 	return c.Name == other.Name &&
 		c.Type == other.Type &&
 		c.BaseURL == other.BaseURL &&
+		c.ProxyURL == other.ProxyURL &&
 		c.APIKey == other.APIKey &&
 		c.AuthType == other.AuthType &&
 		c.OpenAIProtocol == other.OpenAIProtocol &&
@@ -879,6 +881,7 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 		Type             string           `yaml:"type"`
 		APIKey           string           `yaml:"api_key"`
 		BaseURL          string           `yaml:"base_url"`
+		ProxyURL         string           `yaml:"proxy_url,omitempty"`
 		AuthType         string           `yaml:"auth_type,omitempty"`
 		OpenAIProtocol   string           `yaml:"openai_proto,omitempty"`
 		GoogleProtocol   string           `yaml:"google_proto,omitempty"`
@@ -916,6 +919,7 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 	c.Type = normalizeProviderType(resolveEnvString(temp.Type))
 	c.APIKey = resolveEnvString(temp.APIKey)
 	c.BaseURL = resolveEnvString(temp.BaseURL)
+	c.ProxyURL = resolveEnvString(temp.ProxyURL)
 	c.AuthType = strings.ToLower(resolveEnvString(temp.AuthType))
 	c.Scopes = scope.NormalizeList(temp.Scopes)
 	c.DeniedScopes = scope.NormalizeList(append(temp.DeniedScopes, temp.ForbiddenScopes...))
@@ -962,6 +966,10 @@ func (c *CredentialConfig) UnmarshalYAML(value *yaml.Node) error {
 	}
 	// Copy models decoded via YAML anchors / inline definitions
 	c.Models = temp.Models
+
+	if _, err := ParseProxyURL(c.ProxyURL); err != nil {
+		return fmt.Errorf("credential %s: %w", c.Name, err)
+	}
 
 	// Validate base_url for proxy and other provider types that require it
 	if c.BaseURL != "" {
@@ -1841,6 +1849,10 @@ func (c *Config) Validate() error {
 	for i, cred := range c.Credentials {
 		if cred.Name == "" {
 			return fmt.Errorf("credential %d: name is required", i)
+		}
+
+		if _, err := ParseProxyURL(cred.ProxyURL); err != nil {
+			return fmt.Errorf("credential %s: %w", cred.Name, err)
 		}
 
 		// Validate provider type

--- a/internal/config/proxy.go
+++ b/internal/config/proxy.go
@@ -1,0 +1,32 @@
+package config
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+func ParseProxyURL(raw string) (*url.URL, error) {
+	if raw == "" {
+		return nil, nil
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Hostname() == "" || u.Opaque != "" {
+		return nil, fmt.Errorf("proxy_url must be an absolute proxy URL with a host")
+	}
+	switch u.Scheme {
+	case "http", "https", "socks5", "socks5h":
+	default:
+		return nil, fmt.Errorf("proxy_url scheme must be http, https, socks5, or socks5h")
+	}
+	if (u.Path != "" && u.Path != "/") || u.RawQuery != "" || u.ForceQuery || u.Fragment != "" {
+		return nil, fmt.Errorf("proxy_url must not contain a path, query, or fragment")
+	}
+	if port := u.Port(); port != "" {
+		n, err := strconv.Atoi(port)
+		if err != nil || n < 1 || n > 65535 {
+			return nil, fmt.Errorf("proxy_url port must be between 1 and 65535")
+		}
+	}
+	return u, nil
+}

--- a/internal/config/proxy_test.go
+++ b/internal/config/proxy_test.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestCredentialProxyURL(t *testing.T) {
+	t.Setenv("CREDENTIAL_PROXY", "http://user:secret@localhost:3128")
+	var cred CredentialConfig
+	require.NoError(t, yaml.Unmarshal([]byte("name: test\ntype: openai\nproxy_url: os.environ/CREDENTIAL_PROXY"), &cred))
+	require.Equal(t, "http://user:secret@localhost:3128", cred.ProxyURL)
+	data, err := yaml.Marshal(cred)
+	require.NoError(t, err)
+	var restored CredentialConfig
+	require.NoError(t, yaml.Unmarshal(data, &restored))
+	require.Equal(t, cred.ProxyURL, restored.ProxyURL)
+	changed := cred
+	changed.ProxyURL = "http://another:3128"
+	require.False(t, cred.SameProviderIdentity(changed))
+}
+
+func TestParseProxyURL(t *testing.T) {
+	for _, raw := range []string{"", "http://proxy:3128", "https://user:p%40ss@proxy", "socks5://proxy:1080", "socks5h://[::1]:1080", "http://proxy/"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := ParseProxyURL(raw)
+			require.NoError(t, err)
+		})
+	}
+	for _, raw := range []string{"proxy:3128", "ftp://proxy", "http:///", "http://proxy:0", "http://proxy:65536", "http://proxy:nope", "http://proxy/path", "http://proxy?", "http://proxy?q=secret", "http://proxy#secret", "http://user:secret%@proxy"} {
+		t.Run(raw, func(t *testing.T) {
+			_, err := ParseProxyURL(raw)
+			require.Error(t, err)
+			require.NotContains(t, err.Error(), "secret")
+			var cred CredentialConfig
+			err = yaml.Unmarshal([]byte("name: test\nproxy_url: "+raw), &cred)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "credential test:")
+			require.NotContains(t, err.Error(), "secret")
+		})
+	}
+}

--- a/internal/httputil/client.go
+++ b/internal/httputil/client.go
@@ -81,9 +81,9 @@ func NewHTTPClient(cfg *HTTPClientConfig) *http.Client {
 	}
 
 	transport := &http.Transport{
-		Proxy:                 http.ProxyFromEnvironment, // Support HTTP_PROXY, HTTPS_PROXY, NO_PROXY
-		TLSHandshakeTimeout:   timeout,                   // Timeout for TLS handshake phase
-		ResponseHeaderTimeout: timeout,                   // Timeout for connect + response headers only
+		Proxy:                 proxyFromRequest,
+		TLSHandshakeTimeout:   timeout, // Timeout for TLS handshake phase
+		ResponseHeaderTimeout: timeout, // Timeout for connect + response headers only
 		MaxIdleConns:          maxIdleConns,
 		MaxIdleConnsPerHost:   maxIdleConnsPerHost,
 		IdleConnTimeout:       idleConnTimeout,
@@ -181,7 +181,7 @@ func FetchResponseFromProxy(
 	url := baseURL + path
 
 	// Create request
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(WithProxyURL(ctx, cred.ProxyURL), "GET", url, nil)
 	if err != nil {
 		logger.Error("Failed to create request",
 			"credential", cred.Name,

--- a/internal/httputil/proxy.go
+++ b/internal/httputil/proxy.go
@@ -1,0 +1,37 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+)
+
+type proxyURLContextKey struct{}
+
+type proxyTransport struct {
+	base     http.RoundTripper
+	proxyURL string
+}
+
+func (t proxyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return t.base.RoundTrip(req.Clone(WithProxyURL(req.Context(), t.proxyURL)))
+}
+
+func WithClientProxy(client *http.Client, proxyURL string) *http.Client {
+	cloned := *client
+	cloned.Transport = proxyTransport{base: client.Transport, proxyURL: proxyURL}
+	return &cloned
+}
+
+func WithProxyURL(ctx context.Context, proxyURL string) context.Context {
+	return context.WithValue(ctx, proxyURLContextKey{}, proxyURL)
+}
+
+func proxyFromRequest(req *http.Request) (*url.URL, error) {
+	if raw, _ := req.Context().Value(proxyURLContextKey{}).(string); raw != "" {
+		return config.ParseProxyURL(raw)
+	}
+	return http.ProxyFromEnvironment(req)
+}

--- a/internal/httputil/proxy_test.go
+++ b/internal/httputil/proxy_test.go
@@ -1,0 +1,168 @@
+package httputil
+
+import (
+	"bufio"
+	"context"
+	"encoding/base64"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/testhelpers"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCredentialProxyIsolation(t *testing.T) {
+	var directCalls atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		directCalls.Add(1)
+		_, _ = io.WriteString(w, "direct")
+	}))
+	defer origin.Close()
+	newProxy := func(label string) *httptest.Server {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, origin.URL+"/v1/chat/completions", r.URL.String())
+			assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("user:secret")), r.Header.Get("Proxy-Authorization"))
+			assert.Equal(t, "Bearer provider-key", r.Header.Get("Authorization"))
+			_, _ = io.WriteString(w, label)
+		}))
+		t.Cleanup(server.Close)
+		return server
+	}
+	first, second := newProxy("first"), newProxy("second")
+	client := NewHTTPClient(nil)
+	defer client.CloseIdleConnections()
+	for _, tc := range []struct{ proxy, want string }{
+		{strings.Replace(first.URL, "://", "://user:secret@", 1), "first"},
+		{strings.Replace(second.URL, "://", "://user:secret@", 1), "second"},
+		{"", "direct"},
+		{strings.Replace(first.URL, "://", "://user:secret@", 1), "first"},
+	} {
+		req, err := http.NewRequestWithContext(WithProxyURL(context.Background(), tc.proxy), http.MethodPost, origin.URL+"/v1/chat/completions", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer provider-key")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, resp.Body.Close())
+		require.NoError(t, err)
+		require.Equal(t, tc.want, string(body))
+	}
+	require.EqualValues(t, 1, directCalls.Load())
+}
+
+func TestCredentialProxyDoesNotFallBackToDirect(t *testing.T) {
+	var directCalls atomic.Int32
+	origin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { directCalls.Add(1) }))
+	defer origin.Close()
+	unavailable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	unavailable.Close()
+	client := NewHTTPClient(nil)
+	defer client.CloseIdleConnections()
+	for _, proxyURL := range []string{unavailable.URL, "http://user:secret%@invalid"} {
+		req, err := http.NewRequestWithContext(WithProxyURL(context.Background(), proxyURL), http.MethodGet, origin.URL, nil)
+		require.NoError(t, err)
+		_, err = client.Do(req)
+		require.Error(t, err)
+		require.NotContains(t, err.Error(), "secret")
+	}
+	require.Zero(t, directCalls.Load())
+}
+
+func TestDiscoveryUsesCredentialProxy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "unreachable.invalid", r.URL.Host)
+		assert.Equal(t, "Bearer discovery-key", r.Header.Get("Authorization"))
+		_, _ = io.WriteString(w, r.URL.Path)
+	}))
+	defer server.Close()
+	cred := &config.CredentialConfig{Name: t.Name(), BaseURL: "http://unreachable.invalid", APIKey: "discovery-key", ProxyURL: server.URL}
+	for _, path := range []string{"/health", "/v1/models"} {
+		body, err := FetchFromProxy(context.Background(), cred, path, testhelpers.NewTestLogger())
+		require.NoError(t, err)
+		require.Equal(t, path, string(body))
+	}
+}
+
+func TestCredentialProxyHTTPSConnect(t *testing.T) {
+	var connects atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		connects.Add(1)
+		assert.Equal(t, http.MethodConnect, r.Method)
+		assert.Equal(t, "upstream.invalid:443", r.Host)
+		assert.Equal(t, "Basic "+base64.StdEncoding.EncodeToString([]byte("user:secret")), r.Header.Get("Proxy-Authorization"))
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer server.Close()
+	client := NewHTTPClient(nil)
+	proxyURL := strings.Replace(server.URL, "://", "://user:secret@", 1)
+	req, err := http.NewRequestWithContext(WithProxyURL(context.Background(), proxyURL), http.MethodGet, "https://upstream.invalid/v1/models", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Bad Gateway")
+	require.NotContains(t, err.Error(), "secret")
+	require.EqualValues(t, 1, connects.Load())
+}
+
+func TestCredentialProxySOCKS(t *testing.T) {
+	for _, scheme := range []string{"socks5", "socks5h"} {
+		t.Run(scheme, func(t *testing.T) {
+			listener, err := net.Listen("tcp", "127.0.0.1:0")
+			require.NoError(t, err)
+			defer func() { _ = listener.Close() }()
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				conn, err := listener.Accept()
+				if !assert.NoError(t, err) {
+					return
+				}
+				defer func() { _ = conn.Close() }()
+				header := make([]byte, 3)
+				_, err = io.ReadFull(conn, header)
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.Equal(t, []byte{5, 1, 0}, header)
+				_, _ = conn.Write([]byte{5, 0})
+				header = make([]byte, 5)
+				_, err = io.ReadFull(conn, header)
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.Equal(t, []byte{5, 1, 0, 3}, header[:4])
+				address := make([]byte, int(header[4])+2)
+				_, err = io.ReadFull(conn, address)
+				if !assert.NoError(t, err) {
+					return
+				}
+				assert.Equal(t, "upstream.invalid", string(address[:len(address)-2]))
+				_, _ = conn.Write([]byte{5, 0, 0, 1, 127, 0, 0, 1, 0, 80})
+				req, err := http.ReadRequest(bufio.NewReader(conn))
+				if !assert.NoError(t, err) {
+					return
+				}
+				_ = req.Body.Close()
+				assert.Equal(t, "/v1/models", req.URL.Path)
+				_, _ = io.WriteString(conn, "HTTP/1.1 200 OK\r\nContent-Length: 7\r\nConnection: close\r\n\r\nproxied")
+			}()
+			client := NewHTTPClient(nil)
+			req, err := http.NewRequestWithContext(WithProxyURL(context.Background(), scheme+"://"+listener.Addr().String()), http.MethodGet, "http://upstream.invalid/v1/models", nil)
+			require.NoError(t, err)
+			resp, err := client.Do(req)
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			require.NoError(t, resp.Body.Close())
+			require.NoError(t, err)
+			require.Equal(t, "proxied", string(body))
+			<-done
+		})
+	}
+}

--- a/internal/proxy/credential_proxy_test.go
+++ b/internal/proxy/credential_proxy_test.go
@@ -1,0 +1,37 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestProxyRequestUsesCredentialProxy(t *testing.T) {
+	for _, provider := range []config.ProviderType{config.ProviderTypeOpenAI, config.ProviderTypeProxy, config.ProviderTypeAIR} {
+		t.Run(string(provider), func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "http://upstream.invalid/v1/chat/completions", r.URL.String())
+				assert.Equal(t, "Bearer provider-key", r.Header.Get("Authorization"))
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = io.WriteString(w, `{"id":"proxied","choices":[{"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`)
+			}))
+			defer server.Close()
+			prx := NewTestProxyBuilder().WithCredentials(config.CredentialConfig{
+				Name: "test", Type: provider, BaseURL: "http://upstream.invalid", APIKey: "provider-key", ProxyURL: server.URL, RPM: -1, TPM: -1,
+			}).Build()
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"Hello"}]}`))
+			req.Header.Set("Authorization", "Bearer master-key")
+			req.Header.Set("Content-Type", "application/json")
+			recorder := httptest.NewRecorder()
+			prx.ProxyRequest(recorder, req)
+			require.Equal(t, http.StatusOK, recorder.Code, recorder.Body.String())
+			require.Contains(t, recorder.Body.String(), "proxied")
+		})
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -648,7 +648,7 @@ func (p *Proxy) executeProxyRequest(
 	if r.URL.Path == "/v1/messages" {
 		body, anthropicBetas = anthropicconv.ExtractBetaHeader(body)
 	}
-	proxyReq, err := http.NewRequestWithContext(upstreamCtx, r.Method, targetURL, bytes.NewReader(body)) //nolint:gosec // G704: targetURL's host is proxyBaseURL from a configured credential, not attacker-controlled — only the path/query comes from the incoming request
+	proxyReq, err := http.NewRequestWithContext(httputil.WithProxyURL(upstreamCtx, cred.ProxyURL), r.Method, targetURL, bytes.NewReader(body)) //nolint:gosec // G704: targetURL's host is proxyBaseURL from a configured credential, not attacker-controlled — only the path/query comes from the incoming request
 	if err != nil {
 		p.logger.ErrorContext(r.Context(), "Failed to create proxy request", "error", err, "url", targetURL)
 		return nil, err
@@ -1676,7 +1676,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 		var vertexToken string
 		if cred.Type == config.ProviderTypeVertexAI {
 			var tokenErr error
-			vertexToken, tokenErr = p.tokenManager.GetToken(cred.Name, cred.CredentialsFile, cred.CredentialsJSON)
+			vertexToken, tokenErr = p.tokenManager.GetToken(cred.Name, cred.CredentialsFile, cred.CredentialsJSON, cred.ProxyURL)
 			if tokenErr != nil {
 				p.logger.ErrorContext(r.Context(), "Failed to get Vertex AI token",
 					"error_code", http.StatusInternalServerError,
@@ -1695,7 +1695,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 
 		upstreamCtx, cancelUpstream := p.upstreamRequestContext(r)
 		defer cancelUpstream()
-		proxyReq, reqErr := http.NewRequestWithContext(upstreamCtx, r.Method, targetURL, bytes.NewReader(requestBody)) //nolint:gosec // G704: targetURL's host comes from the matched credential's base URL, not the incoming request
+		proxyReq, reqErr := http.NewRequestWithContext(httputil.WithProxyURL(upstreamCtx, cred.ProxyURL), r.Method, targetURL, bytes.NewReader(requestBody)) //nolint:gosec // G704: targetURL's host comes from the matched credential's base URL, not the incoming request
 		if reqErr != nil {
 			// Fatal: request creation error
 			p.logger.ErrorContext(r.Context(), "Failed to create proxy request", "error", reqErr, "url", targetURL)

--- a/internal/proxy/webui/config.html
+++ b/internal/proxy/webui/config.html
@@ -242,6 +242,10 @@
                 <td>base url</td>
                 <td><span class="masked">{{ maskURL .BaseURL }}</span></td>
               </tr>{{ end }}
+              {{ if .ProxyURL }}<tr>
+                <td>proxy url</td>
+                <td><span class="masked">{{ maskURL .ProxyURL }}</span></td>
+              </tr>{{ end }}
               {{ if .ProjectID }}<tr>
                 <td>project id</td>
                 <td>{{ .ProjectID }}</td>


### PR DESCRIPTION
Add optional `proxy_url` per credential for provider requests, discovery and Vertex OAuth. Supports HTTP(S)/SOCKS5, preserves environment defaults and never bypasses an explicitly configured proxy on failure.

Verified: `go test ./...`, race tests for auth/httputil/proxy, and `make lint`.
