### PR TITLE
Preserve token usage in compatible streams

### DIFF
--- a/internal/responsecompat/litellm/stream.go
+++ b/internal/responsecompat/litellm/stream.go
@@ -24,7 +24,6 @@ type streamReader struct {
 	pendingPrelude  bool
 	sentChatPrelude bool
 	sentDone        bool
-	openAIStream    bool
 }
 
 type choiceStreamState struct {
@@ -199,12 +198,6 @@ func (r *streamReader) normalizeTextChunk(body map[string]any) bool {
 
 func (r *streamReader) normalizeChatChunk(body map[string]any) (bool, bool) {
 	r.pendingUsage = nil
-	if _, exists := body["obfuscation"]; exists {
-		r.openAIStream = true
-	}
-	if _, exists := body["service_tier"]; exists {
-		r.openAIStream = true
-	}
 	hadSystemFingerprint := body["system_fingerprint"] != nil
 	usage, hasUsage := body["usage"].(map[string]any)
 	hasUsage = hasUsage && usage != nil
@@ -253,8 +246,7 @@ func (r *streamReader) normalizeChatChunk(body map[string]any) (bool, bool) {
 			delete(body, "usage")
 			finalUsage = false
 		} else {
-			forceZero := r.openAIStream && hadSystemFingerprint
-			usage = liteLLMStreamUsage(usage, forceZero)
+			usage = liteLLMStreamUsage(usage)
 		}
 	}
 
@@ -368,10 +360,7 @@ func (r *streamReader) usageChoices() []any {
 	return choices
 }
 
-func liteLLMStreamUsage(usage map[string]any, forceZero bool) map[string]any {
-	if forceZero {
-		return emptyLiteLLMStreamUsage()
-	}
+func liteLLMStreamUsage(usage map[string]any) map[string]any {
 	normalizeUsage(usage)
 	delete(usage, "cost")
 	delete(usage, "cost_details")
@@ -419,15 +408,6 @@ func (r *streamReader) usageChunk(usage map[string]any) map[string]any {
 		"object":  "chat.completion.chunk",
 		"choices": r.usageChoices(),
 		"usage":   usage,
-	}
-}
-
-func emptyLiteLLMStreamUsage() map[string]any {
-	return map[string]any{
-		"completion_tokens":         0,
-		"completion_tokens_details": map[string]any{"reasoning_tokens": 0},
-		"prompt_tokens":             0,
-		"total_tokens":              0,
 	}
 }
 

--- a/internal/responsecompat/litellm/stream_test.go
+++ b/internal/responsecompat/litellm/stream_test.go
@@ -128,11 +128,11 @@ func TestChatStreamPreservesUsageWithoutSystemFingerprint(t *testing.T) {
 	assert.NotContains(t, string(output), "service_tier")
 }
 
-func TestChatStreamKeepsOpenAIMetadataAndZeroUsage(t *testing.T) {
+func TestChatStreamKeepsOpenAIMetadataAndUsage(t *testing.T) {
 	source := strings.NewReader(
 		`data: {"id":"gpt-id","created":10,"choices":[{"index":0,"delta":{"role":"assistant","content":"ok"}}],"obfuscation":"abc","service_tier":"default","system_fingerprint":"fp-1"}` + "\n\n" +
 			`data: {"id":"gpt-id","created":10,"choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"obfuscation":"abc","service_tier":"default","system_fingerprint":"fp-1"}` + "\n\n" +
-			`data: {"id":"gpt-id","created":10,"choices":[],"latency_checkpoint":{"engine_ttft_ms":10},"obfuscation":"abc","service_tier":"default","system_fingerprint":"fp-1","usage":{"prompt_tokens":13,"completion_tokens":3,"total_tokens":16}}` + "\n\n" +
+			`data: {"id":"gpt-id","created":10,"choices":[],"latency_checkpoint":{"engine_ttft_ms":10},"obfuscation":"abc","service_tier":"default","system_fingerprint":"fp-1","usage":{"prompt_tokens":13,"completion_tokens":3,"total_tokens":16,"prompt_tokens_details":{"cached_tokens":4},"completion_tokens_details":{"reasoning_tokens":1}}}` + "\n\n" +
 			"data: [DONE]\n\n",
 	)
 
@@ -151,8 +151,30 @@ func TestChatStreamKeepsOpenAIMetadataAndZeroUsage(t *testing.T) {
 	var usageChunk map[string]any
 	require.NoError(t, json.Unmarshal([]byte(frames[2]), &usageChunk))
 	usage := usageChunk["usage"].(map[string]any)
-	assert.Equal(t, float64(0), usage["total_tokens"])
+	assert.Equal(t, map[string]any{
+		"prompt_tokens":             float64(13),
+		"completion_tokens":         float64(3),
+		"total_tokens":              float64(16),
+		"prompt_tokens_details":     map[string]any{"cached_tokens": float64(4)},
+		"completion_tokens_details": map[string]any{"reasoning_tokens": float64(1)},
+	}, usage)
 	assert.NotContains(t, frames[2], "service_tier")
+	assert.Contains(t, frames[1], `"finish_reason":"stop"`)
+	assert.Equal(t, "[DONE]", frames[3])
+
+	_, err = source.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	output, err = io.ReadAll(New().Stream(Context{
+		Endpoint:       "/v1/chat/completions",
+		RequestedModel: "openai/gpt-4.1-mini",
+		IncludeUsage:   false,
+	}, source))
+	require.NoError(t, err)
+	frames = splitDataFrames(string(output))
+	require.Len(t, frames, 3)
+	assert.NotContains(t, string(output), `"usage"`)
+	assert.Contains(t, frames[1], `"finish_reason":"stop"`)
+	assert.Equal(t, "[DONE]", frames[2])
 }
 
 func TestChatStreamMovesFinishReasonToTerminalChunk(t *testing.T) {

--- a/internal/responsecompat/litellm/stream_test.go
+++ b/internal/responsecompat/litellm/stream_test.go
@@ -346,10 +346,10 @@ func TestChatStreamMatchesLiteLLMFraming(t *testing.T) {
 	var usage map[string]any
 	require.NoError(t, json.Unmarshal([]byte(frames[4]), &usage))
 	assert.Equal(t, map[string]any{
-		"completion_tokens":         float64(0),
+		"completion_tokens":         float64(3),
 		"completion_tokens_details": map[string]any{"reasoning_tokens": float64(0)},
-		"prompt_tokens":             float64(0),
-		"total_tokens":              float64(0),
+		"prompt_tokens":             float64(13),
+		"total_tokens":              float64(16),
 	}, usage["usage"])
 	usageChoices := usage["choices"].([]any)
 	require.Len(t, usageChoices, 1)


### PR DESCRIPTION
Preserve provider token counts in LiteLLM-compatible Chat Completion streams with OpenAI metadata. Remove forced zeroing and its unused stream state and helper.

Update regression coverage for prompt, completion, total, cached and reasoning token counts. Verify that disabling `include_usage` still omits usage and preserves finish and DONE events.

Billing logic and other response formatting remain unchanged.
