### PR TITLE
Separate retry history from credential exclusions

### DIFF
--- a/internal/balancer/retry_history_test.go
+++ b/internal/balancer/retry_history_test.go
@@ -1,0 +1,72 @@
+package balancer
+
+import (
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	"github.com/mixaill76/auto_ai_router/internal/fail2ban"
+	"github.com/mixaill76/auto_ai_router/internal/ratelimit"
+	"github.com/mixaill76/auto_ai_router/internal/scope"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryHistoryExcludedPriorityDoesNotCountAsAttempt(t *testing.T) {
+	for _, excludedHasModel := range []bool{false, true} {
+		for _, scoped := range []bool{false, true} {
+			name := "excluded priority"
+			if excludedHasModel {
+				name += "/excluded credential has model"
+			} else {
+				name += "/excluded credential lacks model"
+			}
+			if scoped {
+				name += "/scoped"
+			} else {
+				name += "/unscoped"
+			}
+			t.Run(name, func(t *testing.T) {
+				credentials := []config.CredentialConfig{
+					{Name: "cheap", Type: config.ProviderTypeOpenAI, APIKey: "test", BaseURL: "http://cheap.test", RPM: 100},
+					{Name: "excluded", Type: config.ProviderTypeOpenAI, APIKey: "test", BaseURL: "http://excluded.test", RPM: 100, FallbackPriority: 150},
+					{Name: "healthy", Type: config.ProviderTypeOpenAI, APIKey: "test", BaseURL: "http://healthy.test", RPM: 100, FallbackPriority: 1},
+				}
+				bal := New(credentials, fail2ban.New(3, 0, []int{401, 403, 500}), ratelimit.New())
+				checker := NewMockModelChecker(true)
+				checker.AddModel("cheap", "model")
+				checker.AddModel("healthy", "model")
+				if excludedHasModel {
+					checker.AddModel("excluded", "model")
+				}
+				bal.SetModelChecker(checker)
+				exclude := map[string]bool{"cheap": true, "excluded": true}
+				attempted := map[string]bool{"cheap": true}
+				var selected *config.CredentialConfig
+				var err error
+				if scoped {
+					selected, err = bal.NextRetryForModelExcludingScoped("model", &credentials[0], exclude, attempted, scope.PublicContext())
+				} else {
+					selected, err = bal.NextRetryForModelExcluding("model", &credentials[0], exclude, attempted)
+				}
+				require.NoError(t, err)
+				require.Equal(t, "healthy", selected.Name)
+				require.Equal(t, map[string]bool{"cheap": true, "excluded": true}, exclude)
+				require.Equal(t, map[string]bool{"cheap": true}, attempted)
+			})
+		}
+	}
+}
+
+func TestRetryHistoryActuallyTriedPriorityKeepsUnprioritizedTail(t *testing.T) {
+	credentials := []config.CredentialConfig{
+		{Name: "priority-start", Type: config.ProviderTypeAnthropic, APIKey: "test", BaseURL: "http://priority.test", RPM: 100, FallbackPriority: 10},
+		{Name: "cheap", Type: config.ProviderTypeOpenAI, APIKey: "test", BaseURL: "http://cheap.test", RPM: 100},
+		{Name: "unused-priority", Type: config.ProviderTypeOpenAI, APIKey: "test", BaseURL: "http://unused.test", RPM: 100, FallbackPriority: 20},
+		{Name: "tail", Type: config.ProviderTypeAnthropic, APIKey: "test", BaseURL: "http://tail.test", RPM: 100},
+	}
+	bal := New(credentials, fail2ban.New(3, 0, []int{401, 403, 500}), ratelimit.New())
+	exclude := map[string]bool{"priority-start": true, "cheap": true}
+	attempted := map[string]bool{"priority-start": true, "cheap": true}
+	selected, err := bal.NextRetryForModelExcluding("", &credentials[1], exclude, attempted)
+	require.NoError(t, err)
+	require.Equal(t, "tail", selected.Name)
+}

--- a/internal/balancer/roundrobin.go
+++ b/internal/balancer/roundrobin.go
@@ -736,11 +736,12 @@ func (r *RoundRobin) NextSameTypeForModelExcludingScoped(modelID string, credTyp
 	return r.nextExcludingScoped(modelID, false, false, credType, exclude, visibility)
 }
 
-func (r *RoundRobin) NextRetryForModelExcluding(modelID string, current *config.CredentialConfig, exclude map[string]bool) (*config.CredentialConfig, error) {
-	return r.NextRetryForModelExcludingScoped(modelID, current, exclude, scope.AdminContext())
+func (r *RoundRobin) NextRetryForModelExcluding(modelID string, current *config.CredentialConfig, exclude, attempted map[string]bool) (*config.CredentialConfig, error) {
+	return r.NextRetryForModelExcludingScoped(modelID, current, exclude, attempted, scope.AdminContext())
 }
 
-func (r *RoundRobin) NextRetryForModelExcludingScoped(modelID string, current *config.CredentialConfig, exclude map[string]bool, visibility scope.Context) (*config.CredentialConfig, error) {
+// Exclusions restrict selection. Only dispatched attempts advance retry history.
+func (r *RoundRobin) NextRetryForModelExcludingScoped(modelID string, current *config.CredentialConfig, exclude, attempted map[string]bool, visibility scope.Context) (*config.CredentialConfig, error) {
 	if current == nil {
 		return nil, ErrNoCredentialsAvailable
 	}
@@ -748,7 +749,7 @@ func (r *RoundRobin) NextRetryForModelExcludingScoped(modelID string, current *c
 		return r.NextSameTypeForModelExcludingScoped(modelID, current.Type, exclude, visibility)
 	}
 	if current.EffectivePriority() <= 0 {
-		if r.hasTriedPriorityCredential(exclude) {
+		if r.hasTriedPriorityCredential(attempted) {
 			return r.nextUnprioritizedRetry(modelID, exclude, visibility)
 		}
 		return r.NextSameTypeForModelExcludingScoped(modelID, current.Type, exclude, visibility)
@@ -930,14 +931,14 @@ func (r *RoundRobin) selectUnprioritizedRetryCandidateLocked(modelID string, can
 	return r.selectWeightedLiveCandidate(modelID, live, key, rateLimitHit)
 }
 
-func (r *RoundRobin) hasTriedPriorityCredential(exclude map[string]bool) bool {
-	if len(exclude) == 0 {
+func (r *RoundRobin) hasTriedPriorityCredential(attempted map[string]bool) bool {
+	if len(attempted) == 0 {
 		return false
 	}
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	for name, tried := range exclude {
+	for name, tried := range attempted {
 		if !tried {
 			continue
 		}

--- a/internal/balancer/roundrobin_test.go
+++ b/internal/balancer/roundrobin_test.go
@@ -1033,12 +1033,12 @@ func TestNextRetryForModelExcluding_FallbackPriorityOrder(t *testing.T) {
 	bal.SetModelChecker(mc)
 
 	tried := map[string]bool{"cheapgpt": true}
-	cred, err := bal.NextRetryForModelExcluding("claude", &credentials[0], tried)
+	cred, err := bal.NextRetryForModelExcluding("claude", &credentials[0], tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "cometapi", cred.Name)
 
 	tried["cometapi"] = true
-	cred, err = bal.NextRetryForModelExcluding("claude", cred, tried)
+	cred, err = bal.NextRetryForModelExcluding("claude", cred, tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "grant", cred.Name)
 }
@@ -1056,12 +1056,12 @@ func TestNextRetryForModelExcluding_FallbackPriorityFallsBackToUnprioritized(t *
 	bal := New(credentials, f2b, rl)
 
 	tried := map[string]bool{"cheapgpt": true}
-	cred, err := bal.NextRetryForModelExcluding("", &credentials[0], tried)
+	cred, err := bal.NextRetryForModelExcluding("", &credentials[0], tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "cometapi", cred.Name)
 
 	tried["cometapi"] = true
-	cred, err = bal.NextRetryForModelExcluding("", cred, tried)
+	cred, err = bal.NextRetryForModelExcluding("", cred, tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "cloudru", cred.Name)
 }
@@ -1080,12 +1080,12 @@ func TestNextRetryForModelExcluding_UnprioritizedTailContinuesAcrossTypes(t *tes
 	bal := New(credentials, f2b, rl)
 
 	tried := map[string]bool{"cheapgpt": true, "cometapi": true}
-	cred, err := bal.NextRetryForModelExcluding("", &credentials[1], tried)
+	cred, err := bal.NextRetryForModelExcluding("", &credentials[1], tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "cloudru", cred.Name)
 
 	tried["cloudru"] = true
-	cred, err = bal.NextRetryForModelExcluding("", cred, tried)
+	cred, err = bal.NextRetryForModelExcluding("", cred, tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "yandex", cred.Name)
 }
@@ -1102,7 +1102,8 @@ func TestNextRetryForModelExcluding_DefaultsToSameType(t *testing.T) {
 
 	bal := New(credentials, f2b, rl)
 
-	cred, err := bal.NextRetryForModelExcluding("", &credentials[0], map[string]bool{"openai-a": true})
+	tried := map[string]bool{"openai-a": true}
+	cred, err := bal.NextRetryForModelExcluding("", &credentials[0], tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "openai-b", cred.Name)
 }
@@ -1119,7 +1120,8 @@ func TestNextRetryForModelExcluding_FallbackPrioritySkipsFallbackCredentials(t *
 
 	bal := New(credentials, f2b, rl)
 
-	cred, err := bal.NextRetryForModelExcluding("", &credentials[0], map[string]bool{"primary-a": true})
+	tried := map[string]bool{"primary-a": true}
+	cred, err := bal.NextRetryForModelExcluding("", &credentials[0], tried, tried)
 	require.NoError(t, err)
 	assert.Equal(t, "primary-b", cred.Name)
 }
@@ -1138,13 +1140,12 @@ func TestNextRetryForModelExcluding_UsesSeparateSWRRStatePerPriority(t *testing.
 
 	bal := New(credentials, f2b, rl)
 
-	_, err := bal.NextRetryForModelExcluding("", &credentials[0], map[string]bool{"primary-a": true})
+	tried := map[string]bool{"primary-a": true}
+	_, err := bal.NextRetryForModelExcluding("", &credentials[0], tried, tried)
 	require.NoError(t, err)
-	_, err = bal.NextRetryForModelExcluding("", &credentials[0], map[string]bool{
-		"primary-a": true,
-		"tier-20-a": true,
-		"tier-20-b": true,
-	})
+	tried["tier-20-a"] = true
+	tried["tier-20-b"] = true
+	_, err = bal.NextRetryForModelExcluding("", &credentials[0], tried, tried)
 	require.NoError(t, err)
 
 	priorities := make(map[int]bool)
@@ -1309,10 +1310,12 @@ func TestNextRetryForModelExcluding_ProxyLikeRetriesStayExactType(t *testing.T) 
 
 	bal := New(credentials, f2b, rl)
 
-	_, err := bal.NextRetryForModelExcluding("gpt-cache", &credentials[0], map[string]bool{"air1": true})
+	tried := map[string]bool{"air1": true}
+	_, err := bal.NextRetryForModelExcluding("gpt-cache", &credentials[0], tried, tried)
 	require.ErrorIs(t, err, ErrNoCredentialsAvailable)
 
-	_, err = bal.NextRetryForModelExcluding("gpt-cache", &credentials[1], map[string]bool{"proxy1": true})
+	tried = map[string]bool{"proxy1": true}
+	_, err = bal.NextRetryForModelExcluding("gpt-cache", &credentials[1], tried, tried)
 	require.ErrorIs(t, err, ErrNoCredentialsAvailable)
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -1419,6 +1419,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Retry loop: try same-type credentials by default, or fallback_priority tiers when configured.
 	triedCreds := GetTried(r.Context())
+	attemptedCreds := make(map[string]bool)
 	var (
 		resp            *http.Response
 		responseBody    []byte
@@ -1441,7 +1442,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			var nextReq credentialPreparedRequest
 			retryReady := false
 			for {
-				candidate, err := p.balancer.NextRetryForModelExcludingScoped(modelID, cred, triedCreds, logCtx.Scope)
+				candidate, err := p.balancer.NextRetryForModelExcludingScoped(modelID, cred, triedCreds, attemptedCreds, logCtx.Scope)
 				if err != nil {
 					p.logger.DebugContext(r.Context(), "No more retry credentials available",
 						"model", modelID, "attempt", attempt, "error", err)
@@ -1760,6 +1761,7 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 
 		// Execute HTTP request
 		var doErr error
+		attemptedCreds[cred.Name] = true
 		resp, doErr = p.client.Do(proxyReq) //nolint:gosec // G704: same targetURL as the request built above, host isn't attacker-controlled
 		if doErr != nil {
 			// Transport failure on one credential — retried with the next one;

--- a/internal/proxy/retry_attempt_history_test.go
+++ b/internal/proxy/retry_attempt_history_test.go
@@ -1,0 +1,81 @@
+package proxy
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/mixaill76/auto_ai_router/internal/config"
+	dbmodels "github.com/mixaill76/auto_ai_router/internal/litellmdb/models"
+	routermodels "github.com/mixaill76/auto_ai_router/internal/models"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRetryIgnoresDeniedPriorityHistory(t *testing.T) {
+	for _, deniedHasModel := range []bool{false, true} {
+		name := "unrelated model"
+		if deniedHasModel {
+			name = "same model"
+		}
+		t.Run(name, func(t *testing.T) {
+			var primaryCalls, secondaryCalls, deniedCalls atomic.Int32
+			primary := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				primaryCalls.Add(1)
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("Retry-After", "30")
+				w.WriteHeader(http.StatusTooManyRequests)
+				_, _ = w.Write([]byte(`{"error":{"message":"rate limit exceeded","type":"rate_limit_error","code":"rate_limited"}}`))
+			}))
+			defer primary.Close()
+			secondary := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				secondaryCalls.Add(1)
+				w.Header().Set("Content-Type", "text/event-stream")
+				_, _ = w.Write([]byte("data: {\"id\":\"response-1\",\"model\":\"model\",\"choices\":[{\"index\":0,\"delta\":{\"content\":\"OK\"},\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n"))
+			}))
+			defer secondary.Close()
+			denied := newIPv4Server(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				deniedCalls.Add(1)
+				w.WriteHeader(http.StatusInternalServerError)
+			}))
+			defer denied.Close()
+			credentials := []config.CredentialConfig{
+				{Name: "primary", Type: config.ProviderTypeOpenAI, BaseURL: primary.URL, APIKey: "key", RPM: 100, TPM: 10000},
+				{Name: "secondary", Type: config.ProviderTypeOpenAI, BaseURL: secondary.URL, APIKey: "key", Priority: 1, RPM: 100, TPM: 10000},
+				{Name: "denied", Type: config.ProviderTypeOpenAI, BaseURL: denied.URL, APIKey: "key", Priority: 150, RPM: 100, TPM: 10000},
+			}
+			builder := NewTestProxyBuilder().WithCredentials(credentials...).WithMaxProviderRetries(6)
+			routes := []config.ModelRPMConfig{{Name: "model", Credential: "primary"}, {Name: "model", Credential: "secondary"}}
+			if deniedHasModel {
+				routes = append(routes, config.ModelRPMConfig{Name: "model", Credential: "denied"})
+			}
+			manager := routermodels.New(builder.config.Logger, 100, routes)
+			manager.SetModelAliases(map[string]string{"public/model": "model"})
+			manager.LoadModelsFromConfig(credentials)
+			manager.SetCredentials(credentials)
+			policies, err := routermodels.LoadOrganizationPolicies([]config.OrganizationPolicyConfig{{
+				OrganizationID: "org-1", PriceProfileID: "profile-1",
+				ModelPricesLink: writeProxyPolicyPrices(t, `{"public/model":{"input_cost_per_token":0.001,"output_cost_per_token":0.002}}`),
+				ModelAllowlist:  []string{"public/model"}, CredentialDenylist: []string{"denied"},
+			}}, manager, routermodels.OrganizationPolicyLoadOptions{LiteLLMDBEnabled: true, LiteLLMDBRequired: true})
+			require.NoError(t, err)
+			builder.config.ModelManager = manager
+			builder.config.OrganizationPolicies = policies
+			prx := builder.Build()
+			prx.LiteLLMDB = &organizationPolicyTestDB{tokens: map[string]*dbmodels.TokenInfo{
+				"token": {Token: "token-hash", UserID: "user-1", DirectOrganizationID: "org-1", OrganizationID: "org-1"},
+			}}
+			req := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(`{"model":"public/model","messages":[{"role":"user","content":"OK"}],"stream":true}`))
+			req.Header.Set("Authorization", "Bearer token")
+			req.Header.Set("Content-Type", "application/json")
+			response := httptest.NewRecorder()
+			prx.ProxyRequest(response, req)
+			require.Equal(t, int32(1), primaryCalls.Load())
+			require.Zero(t, deniedCalls.Load())
+			require.Equal(t, int32(1), secondaryCalls.Load())
+			require.Equal(t, http.StatusOK, response.Code)
+			require.Contains(t, response.Body.String(), "[DONE]")
+		})
+	}
+}


### PR DESCRIPTION
Track dispatched provider requests separately from credential exclusions. Denylists and skipped candidates no longer count as attempted priority credentials.

Preserve credential filters, same-type retries and priority progression after actual attempts.

Add balancer and proxy regression tests for excluded priority credentials, including credentials without the requested model. Verify that denied credentials remain unused and valid alternatives receive retries.
