### PR TITLE
fix: classify spend-log error message instead of hardcoded "Request failed"

### DIFF
--- a/internal/proxy/errors.go
+++ b/internal/proxy/errors.go
@@ -107,6 +107,25 @@ func maskedUpstreamErrorBody(statusCode int, requestID string, rawBodies ...[]by
 	return append(body, '\n')
 }
 
+// classifiedErrorMessage returns the same "message" maskedUpstreamErrorBody
+// would put in the client-facing body for statusCode — used to keep
+// logCtx.ErrorMsg (and, downstream, the spend-log/analytics
+// metadata.error_information.error_message column) in sync with what the
+// client actually saw, instead of the historical hardcoded "Request failed"
+// placeholder (see internal/proxy/proxy.go's two logCtx.ErrorMsg call sites).
+func classifiedErrorMessage(statusCode int, rawBody []byte) string {
+	switch statusCode {
+	case http.StatusBadRequest:
+		return classifiedBadRequestError(rawBody).Message
+	case http.StatusTooManyRequests:
+		return "Rate limit exceeded"
+	case http.StatusRequestTimeout, http.StatusGatewayTimeout:
+		return "Request timed out"
+	default:
+		return "Request failed"
+	}
+}
+
 // classifiedBadRequestError delegates to the shared upstreamerror classifier
 // (also used by litellm compatibility mode's normalizeError) so both modes
 // surface the same classification instead of one discarding it.

--- a/internal/proxy/errors_test.go
+++ b/internal/proxy/errors_test.go
@@ -267,6 +267,69 @@ func TestWriteValidationError_TooLarge(t *testing.T) {
 	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
 }
 
+// TestClassifiedErrorMessage_MatchesClientBody guards against
+// logCtx.ErrorMsg (and, downstream, the spend-log/analytics
+// metadata.error_information.error_message column) silently drifting back to
+// a generic placeholder while the client-facing body stays classified — the
+// exact regression this function was introduced to fix (see proxy.go's two
+// logCtx.ErrorMsg call sites, which used to hardcode "Request failed").
+func TestClassifiedErrorMessage_MatchesClientBody(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		rawBody    []byte
+		want       string
+	}{
+		{
+			name:       "400 with recognizable signal is classified, not generic",
+			statusCode: http.StatusBadRequest,
+			rawBody:    []byte(`{"error":{"message":"missing required parameter: 'messages'"}}`),
+			want:       "Missing required parameter",
+		},
+		{
+			name:       "400 with no recognizable signal falls to the classifier's own default",
+			statusCode: http.StatusBadRequest,
+			rawBody:    []byte(`{"error":{"message":"something went sideways"}}`),
+			want:       "Invalid request",
+		},
+		{"429 rate limit", http.StatusTooManyRequests, nil, "Rate limit exceeded"},
+		{"408 request timeout", http.StatusRequestTimeout, nil, "Request timed out"},
+		{"504 gateway timeout", http.StatusGatewayTimeout, nil, "Request timed out"},
+		{"401 unauthorized stays generic (never classified, by design)", http.StatusUnauthorized, nil, "Request failed"},
+		{"403 forbidden stays generic (never classified, by design)", http.StatusForbidden, nil, "Request failed"},
+		{"404 not found stays generic (never classified, by design)", http.StatusNotFound, nil, "Request failed"},
+		{"500 server error stays generic (never classified, by design)", http.StatusInternalServerError, nil, "Request failed"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, classifiedErrorMessage(tt.statusCode, tt.rawBody))
+		})
+	}
+}
+
+// TestClassifiedErrorMessage_ConsistentWithMaskedUpstreamErrorBody asserts
+// classifiedErrorMessage always returns exactly the "message" field that
+// maskedUpstreamErrorBody puts in the body the client actually receives —
+// the property the spend-log fix depends on.
+func TestClassifiedErrorMessage_ConsistentWithMaskedUpstreamErrorBody(t *testing.T) {
+	statuses := []int{
+		http.StatusBadRequest, http.StatusTooManyRequests,
+		http.StatusRequestTimeout, http.StatusGatewayTimeout,
+		http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound,
+	}
+	rawBody := []byte(`{"error":{"message":"max_tokens must be a positive integer"}}`)
+
+	for _, status := range statuses {
+		clientBody := maskedUpstreamErrorBody(status, "req-1", rawBody)
+		var decoded APIErrorResponse
+		require.NoError(t, json.Unmarshal(clientBody, &decoded))
+
+		assert.Equal(t, decoded.Error.Message, classifiedErrorMessage(status, rawBody),
+			"status %d: logCtx.ErrorMsg would drift from what the client saw", status)
+	}
+}
+
 func stringPtr(s string) *string {
 	return &s
 }

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -2199,7 +2199,11 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 
 		if resp.StatusCode >= 400 {
 			logCtx.Status = "failure"
-			logCtx.ErrorMsg = "Request failed"
+			// Same classification the client's own response body already went
+			// through (clientResponseBodyForCredential -> maskedUpstreamErrorBody)
+			// — keeps the spend-log/analytics record in sync with what the client
+			// actually saw instead of a generic placeholder.
+			logCtx.ErrorMsg = classifiedErrorMessage(resp.StatusCode, rawErrorBody)
 			// Final error returned to the client — single unified ERROR record
 			// with everything needed for debugging.
 			p.logUpstreamError(r.Context(), "Upstream request completed with error status", resp.StatusCode, cred, modelID, rawErrorBody,
@@ -2264,7 +2268,10 @@ func (p *Proxy) proxyRequest(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write(body)
 			logCtx.Status = "failure"
 			logCtx.HTTPStatus = resp.StatusCode
-			logCtx.ErrorMsg = "Request failed"
+			// No raw body captured here (streamed, not buffered) — same limitation
+			// maskedUpstreamErrorBody above already has, so this stays consistent
+			// with what the client just received.
+			logCtx.ErrorMsg = classifiedErrorMessage(resp.StatusCode, nil)
 			logCtx.TargetURL = targetURL
 			return
 		}


### PR DESCRIPTION
## Summary
- `logCtx.ErrorMsg` (persisted into `LiteLLM_SpendLogs.metadata.error_information.error_message`) was unconditionally hardcoded to `"Request failed"` for any status >= 400, even though the client-facing response body was already correctly classified via `ClassifyBadRequest` since `cca841f`.
- This left every spend-log/analytics record generic ("Request failed") while the actual API response returned to the caller was specific (e.g. "Missing required parameter" / param `messages`), making the DB useless for diagnosing which validation error actually occurred.
- Extracts the message computation shared with `maskedUpstreamErrorBody` into a new `classifiedErrorMessage(status, rawBody)` helper and reuses it for `logCtx.ErrorMsg` in both the non-streaming and streaming error paths, so the DB record always matches what the client actually saw.
- Non-classified statuses (401/403/404/5xx) intentionally keep returning `"Request failed"` — that's unchanged, by design, matching the client-facing behavior for those statuses.

## Test plan
- [x] `go test ./internal/proxy/...` — full package passes
- [x] Added `TestClassifiedErrorMessage_MatchesClientBody` — table test covering 400 (classified + generic fallback), 429, 408/504, and 401/403/404/500 (unchanged generic)
- [x] Added `TestClassifiedErrorMessage_ConsistentWithMaskedUpstreamErrorBody` — asserts `classifiedErrorMessage` always equals the `message` field `maskedUpstreamErrorBody` puts in the client-facing body, across all relevant statuses

🤖 Generated with [Claude Code](https://claude.com/claude-code)